### PR TITLE
Improve modulation in qblox.GenericPulsar class

### DIFF
--- a/src/qibolab/instruments/qblox.py
+++ b/src/qibolab/instruments/qblox.py
@@ -75,7 +75,7 @@ class GenericPulsar(ABC):
         # calculate it
         envelope_q  = np.zeros(int(pulse.duration))
         envelopes   = np.array([envelope_i, envelope_q])
-        time        = np.arange(pulse.length) * 1e-9
+        time        = np.arange(pulse.duration) * 1e-9
         cosalpha    = np.cos(2 * np.pi * pulse.frequency * time + pulse.phase)
         sinalpha    = np.sin(2 * np.pi * pulse.frequency * time + pulse.phase)
         mod_matrix  = np.array([[ cosalpha, sinalpha],


### PR DESCRIPTION
A possible improvement for the ``instrument.qblox.GenericPulsar._translate_single_pulse`` method, to improve readability.
Work in progress, not tested yet.

Given that we are planning to integrate ``TIIPulse`` and ``TIIPulseReadout`` with the other ones in `pulse.py` (if possible), should we implement some regression tests to ensure that we don't change the final waveforms?