### PR TITLE
Fix missing hardware_avg argument

### DIFF
--- a/src/qibolab/instruments/qblox.py
+++ b/src/qibolab/instruments/qblox.py
@@ -44,17 +44,15 @@ class GenericPulsar(ABC):
             self.device.sequencer0_gain_awg_path0(gain)
             self.device.sequencer0_gain_awg_path1(gain)
 
-    def setup(self, gain, hardware_avg, initial_delay, repetition_duration):
+    def setup(self, gain, initial_delay, repetition_duration):
         """Sets calibration setting to QBlox instruments.
 
         Args:
             gain (float):
-            hardware_avg (int):
             initial_delay ():
             repetition_duration ():
         """
         self.gain = gain
-        self.hardware_avg = hardware_avg
         self.initial_delay = initial_delay
         self.repetition_duration = repetition_duration
 
@@ -253,15 +251,15 @@ class PulsarQRM(GenericPulsar):
         else:
             raise(RuntimeError)
 
-    def setup(self, gain, hardware_avg, initial_delay, repetition_duration,
+    def setup(self, gain, initial_delay, repetition_duration,
               start_sample, integration_length, sampling_rate, mode):
-        super().setup(gain, hardware_avg, initial_delay, repetition_duration)
+        super().setup(gain, initial_delay, repetition_duration)
         self.start_sample = start_sample
         self.integration_length = integration_length
         self.sampling_rate = sampling_rate
         self.mode = mode
 
-    def translate(self, sequence, nshots=None):
+    def translate(self, sequence, nshots):
         # Allocate only readout pulses to PulsarQRM
         waveforms = self.generate_waveforms(sequence.qrm_pulses)
 
@@ -270,8 +268,6 @@ class PulsarQRM(GenericPulsar):
         # Acquire waveforms over remaining duration of acquisition of input vector of length = 16380 with integration weights 0,0
         acquire_instruction = "acquire   0,0,4"
         wait_time = self.duration_base - initial_delay - sequence.delay_before_readout - 4 # FIXME: Not sure why this hardcoded 4 is needed
-        if nshots is None:
-            nshots = self.hardware_avg
         program = self.generate_program(nshots, initial_delay, sequence.delay_before_readout, acquire_instruction, wait_time)
 
         return waveforms, program
@@ -352,8 +348,6 @@ class PulsarQCM(GenericPulsar):
         initial_delay = sequence.qcm_pulses[0].start
         acquire_instruction = ""
         wait_time = self.duration_base - initial_delay - sequence.delay_before_readout
-        if nshots is None:
-            nshots = self.hardware_avg
         program = self.generate_program(nshots, initial_delay, sequence.delay_before_readout, acquire_instruction, wait_time)
 
         return waveforms, program

--- a/src/qibolab/platforms/tiiq.py
+++ b/src/qibolab/platforms/tiiq.py
@@ -193,6 +193,9 @@ class TIIq:
 
         Args:
             sequence (:class:`qibolab.pulses.PulseSequence`): Pulse sequence to execute.
+            nshots (int): Number of shots to sample from the experiment.
+                If ``None`` the default value provided as hardware_avg in the
+                calibration json will be used.
 
         Returns:
             Readout results acquired by :class:`qibolab.instruments.qblox.PulsarQRM`

--- a/src/qibolab/platforms/tiiq_settings.json
+++ b/src/qibolab/platforms/tiiq_settings.json
@@ -37,7 +37,6 @@
     },
     "_QRM_settings": {
         "gain": 0.4,
-        "hardware_avg": 1024,
         "initial_delay": 0,
         "repetition_duration": 200000,
         "start_sample": 130,
@@ -54,7 +53,6 @@
     },
     "_QCM_settings": {
         "gain": 0.14,
-        "hardware_avg": 1024,
         "initial_delay": 0,
         "repetition_duration": 200000
     },


### PR DESCRIPTION
Temporary fix for the missing `hardware_avg` argument identified by @DavidSarlle. David, please retry with this branch and let me know if it works for you.

Before we merge this, the `hardware_avg` argument currently appears in three places in the json: in `_settings`, in `_QRM_settings` and in `_QCM_settings`. The value is 1024 in all cases. Do we really need to define this in three different places, or is it sufficient to define it only in `_settings` and use the same value everywhere?