### PR TITLE
Fix sequence json name for QCM

### DIFF
--- a/src/qibolab/instruments/qblox.py
+++ b/src/qibolab/instruments/qblox.py
@@ -176,7 +176,7 @@ class GenericPulsar(ABC):
                 waveforms[name]["data"] = waveforms[name]["data"].tolist()  # JSON only supports lists
 
         # Add sequence program and waveforms to single dictionary and write to JSON file
-        filename = f"{data_folder}/qrm_sequence.json"
+        filename = f"{data_folder}/{self.name}_sequence.json"
         program_dict = {
             "waveforms": waveforms,
             "weights": self.weights,


### PR DESCRIPTION
As discovered by @DavidSarlle, among some other issues, our code has a bug and generates a single sequence json file (the file that defines the pulses at the instrument level) for both QCM and QRM. This small change should fix this issue and generate two seperate files, although this is not tested.

This issue exists in all versions of `main` since December so it is not clear why our examples were working. One explanation is that proper instructions are generated and uploaded to both instruments during runtime but due to the name collision only the QRM instructions are maintained on the json that is saved on disk. So the QCM instructions are generated and uploaded to the instrument properly but then overwritten by QRM which is executed second. Not sure if that is the case though.