### PR TITLE
Fix circular import when qibolab is the default qibo backend

### DIFF
--- a/src/qibolab/platform.py
+++ b/src/qibolab/platform.py
@@ -1,5 +1,4 @@
 import pathlib
-from qibo.config import raise_error
 
 
 def Platform(name, runcard=None):
@@ -19,5 +18,6 @@ def Platform(name, runcard=None):
     elif name == 'icarusq':
         from qibolab.platforms.icplatform import ICPlatform as Device
     else:
+        from qibo.config import raise_error
         raise_error(RuntimeError, f"Platform {name} is not supported.")
     return Device(name, runcard)


### PR DESCRIPTION
Fixes the issue described in qiboteam/qrccluster#2. I made qibolab the default backend in qibo's profiles.yml and tried both the pulse API (the minimal example in qibolab README) and the circuit API (executing a qibo circuit with qibolab). Both examples work after this fix. @scarrazza let me know if it works for you.