### PR TITLE
Fix circular import

### DIFF
--- a/src/qibolab/platforms/abstract.py
+++ b/src/qibolab/platforms/abstract.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 import yaml
-from qibo.config import raise_error, log
+
 
 class AbstractPlatform(ABC):
     """Abstract platform for controlling quantum devices.
@@ -11,6 +11,7 @@ class AbstractPlatform(ABC):
     """
 
     def __init__(self, name, runcard):
+        from qibo.config import log
         log.info(f"Loading platform {name}")
         log.info(f"Loading runcard {runcard}")
         self.name = name
@@ -38,6 +39,7 @@ class AbstractPlatform(ABC):
 
     def _check_connected(self):
         if not self.is_connected:
+            from qibo.config import raise_error
             raise_error(RuntimeError, "Cannot access instrument because it is not connected.")
 
     def reload_settings(self):
@@ -120,7 +122,7 @@ class AbstractPlatform(ABC):
     @abstractmethod
     def run_calibration(self):  # pragma: no cover
         """Executes calibration routines and updates the settings yml file"""
-        raise_error(NotImplementedError)
+        raise NotImplementedError
 
     def __call__(self, sequence, nshots=None):
         return self.execute(sequence, nshots)
@@ -128,27 +130,27 @@ class AbstractPlatform(ABC):
     @abstractmethod
     def connect(self):  # pragma: no cover
         """Connects to lab instruments using the details specified in the calibration settings."""
-        raise_error(NotImplementedError)
+        raise NotImplementedError
 
     @abstractmethod
     def setup(self):  # pragma: no cover
         """Configures instruments using the loaded calibration settings."""
-        raise_error(NotImplementedError)
+        raise NotImplementedError
 
     @abstractmethod
     def start(self):  # pragma: no cover
         """Turns on the local oscillators."""
-        raise_error(NotImplementedError)
+        raise NotImplementedError
 
     @abstractmethod
     def stop(self):  # pragma: no cover
         """Turns off all the lab instruments."""
-        raise_error(NotImplementedError)
+        raise NotImplementedError
 
     @abstractmethod
     def disconnect(self):  # pragma: no cover
         """Disconnects from the lab instruments."""
-        raise_error(NotImplementedError)
+        raise NotImplementedError
 
     @abstractmethod
     def execute(self, sequence, nshots=None):  # pragma: no cover
@@ -163,4 +165,4 @@ class AbstractPlatform(ABC):
         Returns:
             Readout results acquired by after execution.
         """
-        raise_error(NotImplementedError)
+        raise NotImplementedError

--- a/src/qibolab/platforms/icplatform.py
+++ b/src/qibolab/platforms/icplatform.py
@@ -1,5 +1,4 @@
 import copy
-from qibo.config import raise_error, log
 from qibolab.platforms.abstract import AbstractPlatform
 
 class Qubit:
@@ -57,11 +56,13 @@ class ICPlatform(AbstractPlatform):
             self.qubits.append(Qubit(**qubit_dict))
 
     def run_calibration(self):  # pragma: no cover
+        from qibo.config import raise_error
         raise_error(NotImplementedError)
     
     def connect(self):
         """Connects to lab instruments using the details specified in the calibration settings."""
         if not self.is_connected:
+            from qibo.config import log
             log.info(f"Connecting to {self.name} instruments.")
             try:
                 import qibolab.instruments as qi
@@ -79,6 +80,7 @@ class ICPlatform(AbstractPlatform):
                     
                 self.is_connected = True
             except Exception as exception:
+                from qibo.config import raise_error
                 raise_error(RuntimeError, "Cannot establish connection to "
                             f"{self.name} instruments. "
                             f"Error captured: '{exception}'")
@@ -131,6 +133,7 @@ class ICPlatform(AbstractPlatform):
             after execution.
         """
         if not self.is_connected:
+            from qibo.config import raise_error
             raise_error(
                 RuntimeError, "Execution failed because instruments are not connected.")
         if nshots is None:
@@ -191,6 +194,7 @@ class ICPlatform(AbstractPlatform):
             res = next(inst for inst in self._instruments if inst.name == name)
             return res
         except StopIteration:
+            from qibo.config import raise_error
             raise_error(Exception, "Instrument not found")
 
     def fetch_qubit(self, qubit_id=0) -> Qubit:

--- a/src/qibolab/platforms/qbloxplatform.py
+++ b/src/qibolab/platforms/qbloxplatform.py
@@ -1,5 +1,5 @@
-from qibo.config import raise_error, log
 from qibolab.platforms.abstract import AbstractPlatform
+
 
 class QBloxPlatform(AbstractPlatform):
     """Platform for controlling quantum devices using QCM and QRM.
@@ -73,6 +73,7 @@ class QBloxPlatform(AbstractPlatform):
     def connect(self):
         """Connects to lab instruments using the details specified in the calibration settings."""
         if not self.is_connected:
+            from qibo.config import log
             log.info(f"Connecting to {self.name} instruments.")
             try:
                 from qibolab.instruments import PulsarQRM, PulsarQCM, SGS100A
@@ -82,6 +83,7 @@ class QBloxPlatform(AbstractPlatform):
                 self._LO_qcm = SGS100A(**self._settings.get("LO_QCM_init_settings"))
                 self.is_connected = True
             except Exception as exception:
+                from qibo.config import raise_error
                 raise_error(RuntimeError, "Cannot establish connection to "
                             f"{self.name} instruments. "
                             f"Error captured: '{exception}'")
@@ -137,6 +139,7 @@ class QBloxPlatform(AbstractPlatform):
             after execution.
         """
         if not self.is_connected:
+            from qibo.config import raise_error
             raise_error(RuntimeError, "Execution failed because instruments are not connected.")
         if nshots is None:
             nshots = self.hardware_avg

--- a/src/qibolab/tests/test_backend.py
+++ b/src/qibolab/tests/test_backend.py
@@ -1,8 +1,8 @@
 import pytest
-from qibolab.backend import QibolabBackend
 
 
 def test_backend_init():
+    from qibolab.backend import QibolabBackend
     from qibolab.platforms.qbloxplatform import QBloxPlatform
     backend = QibolabBackend()
     assert backend.is_hardware
@@ -10,6 +10,7 @@ def test_backend_init():
 
 
 def test_backend_platform():
+    from qibolab.backend import QibolabBackend
     from qibolab.platforms.qbloxplatform import QBloxPlatform
     from qibolab.platforms.icplatform import ICPlatform
     backend = QibolabBackend()
@@ -31,6 +32,7 @@ def test_backend_platform():
 
 
 def test_backend_circuit_class():
+    from qibolab.backend import QibolabBackend
     from qibolab.circuit import HardwareCircuit
     backend = QibolabBackend()
     assert backend.circuit_class() == HardwareCircuit


### PR DESCRIPTION
Quick fix for #99, @scarrazza let me know if it works for you. Note that issue #99 appears only if qibolab is set as the default qibo backend in profiles.yml.

Hopefully this kind of errors will disappear when we simplify the backend/engine mechanism in qibo.