### PR TITLE
Set minimum qibo version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         "Topic :: Scientific/Engineering :: Physics",
     ],
     install_requires=[
-        "qibo",
+        "qibo>=0.1.8rc0",
         "qcodes",   # 0.34.1
         "lmfit",    # 1.0.3
     ],


### PR DESCRIPTION
Qibo 0.1.8rc0 is set as minimum requirement in setup.py.