### PR TITLE
Upgrading tiiq dependencies into main dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,8 @@ setup(
         "qibo>=0.1.8rc0",
         "qcodes",  # 0.34.1
         "lmfit",  # 1.0.3
+        "qblox-instruments==0.6.1",  # 0.6.1
+        "quantify-core==0.6.0",  # 0.6.0
     ],
     extras_require={
         "docs": [
@@ -61,13 +63,7 @@ setup(
             "sphinx_markdown_tables",
             "nbsphinx",
             "IPython",
-        ],
-        # TII system dependencies
-        "tiiq": [
-            "qblox-instruments",  # 0.6.1
-            "quantify-core",  # 0.6.0
-            "dash",  # Live plotting
-        ],
+        ]
     },
     python_requires=">=3.6.0",
     long_description=long_description,


### PR DESCRIPTION
Following the discussion in qiboteam/qcvv#21, it should be easier to maintain qcvv if we remove the extra dependencies from qibolab and treat every dependency as a core dependency in qibolab. Moreover, if the user didn't install the `tiiq` dependency the functionalities of qibolab are quite limited, apart from the recently added dummy platform in #140 .

I've also fixed the versions of `qblox-instruments` and `quantify-core` in the setup.py.
I've dropped the `plotly` dependency since we have agreed that qcvv will cover the live-plotting instead of qibolab. This change will not affect the older branches that are using plotly.

Let me know what you think.
If everyone agrees I will change the documentation accordingly.
