### PR TITLE
Basic transpiler for tii5q connectivity

### DIFF
--- a/src/qibolab/tests/test_transpiler.py
+++ b/src/qibolab/tests/test_transpiler.py
@@ -21,7 +21,7 @@ def generate_random_circuit(nqubits, depth, seed=None):
     for _ in range(depth):
         for i in range(nqubits):
             # generate a random rotation
-            rotation = rotations[np.random.randint(0, 3)]
+            rotation = rotations[int(np.random.randint(0, 3))]
             theta = 2 * np.pi * np.random.random()
             circuit.add(rotation(i, theta=theta))
         # add CZ gates on random qubit pairs
@@ -41,7 +41,7 @@ def transpose_qubits(state, qubits):
 
 
 @pytest.mark.parametrize("run_number", range(50))
-@pytest.mark.parametrize("nqubits", [3, 4, 5])
+@pytest.mark.parametrize("nqubits", [1, 2, 3, 4, 5])
 @pytest.mark.parametrize("depth", [2, 5, 8])
 def test_transpiler(run_number, nqubits, depth):
     """Checks that the transpiled circuit can be executed and is equivalent to original."""

--- a/src/qibolab/transpilers.py
+++ b/src/qibolab/transpilers.py
@@ -66,9 +66,8 @@ def transpile(circuit):
                 )
             break
 
-    add_swap = (
-        False  # the first SWAP is not needed as it can be applied via virtual mapping
-    )
+    # the first SWAP is not needed as it can be applied via virtual mapping
+    add_swap = False
     for i, gate in enumerate(circuit.queue):
         # map gate qubits to hardware
         qubits = tuple(hardware_qubits.index(q) for q in gate.qubits)


### PR DESCRIPTION
Implements a transpile method that transforms an arbitrary circuit to one that respects the connectivity of the chip in tii5q platform by adding SWAP gates. It follows a greedy algorithm described to me by Ruge (@GoGoKo699), according to which for every two-qubit gate that cannot be directly applied, we check the following two-qubit gates to decide which qubit should be swapped in the middle. It is tested on random circuits containing one-qubit rotations and CZ gates (see tests).

* This transformation only takes connectivity into account. To execute the circuit we also need to transform to native gates. For one-qubit gates we can use U3. For two-qubit gates there may be various approaches (for example [arXiv:0307177](https://arxiv.org/pdf/quant-ph/0307177.pdf)). For >three-qubit gates we need to decompose to two-qubit.
* It supports up to two-qubit gates.
* It is hardcoded to the tii5q connectivity.
* I do not have proof that it is optimal, in terms of adding the minimum possible number of SWAPs.