### PR TITLE
pre-commit: extend line length to 120

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,8 @@ repos:
     rev: 22.3.0
     hooks:
       - id: black
+        args:
+          - --line-length=120 # --------------------------------------------80>| --------------100>| --------------120>|
   - repo: https://github.com/pycqa/isort
     rev: 5.10.1
     hooks:


### PR DESCRIPTION
Hi all,
I would like to propose that we extend the maximum length of the line to 120 characters (or at least 100) from the current value of 80.
The current setting very frequently splits the code into many lines that in my opinion make it harder to read.
Given the size and resolution of today's screens, these 120 characters can be displayed in full even if the screen is split in two.
If the proposal is accepted, please replicate it in the other repositories of the project.