### PR TITLE
Remove the use of temporary folders for instruments data

### DIFF
--- a/src/qibolab/instruments/abstract.py
+++ b/src/qibolab/instruments/abstract.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-import tempfile
 from abc import ABC, abstractmethod
-from pathlib import Path
 
 from qibolab.paths import user_folder
 
@@ -21,11 +19,8 @@ class AbstractInstrument(ABC):
         self.is_connected: bool = False
         self.signature: str = f"{type(self).__name__}@{address}"
         # create local storage folder
-        instruments_data_folder = user_folder / "instruments" / "data"
-        instruments_data_folder.mkdir(parents=True, exist_ok=True)
-        # create temporary directory
-        self.tmp_folder = tempfile.TemporaryDirectory(dir=instruments_data_folder)
-        self.data_folder = Path(self.tmp_folder.name)
+        self.data_folder = user_folder / "instruments" / "data"
+        self.data_folder.mkdir(parents=True, exist_ok=True)
 
     @abstractmethod
     def connect(self):


### PR DESCRIPTION
Hi,
I would like to propose the removal of the use of temporary folders for instruments data, for two reasons:

- While debugging, one often wants to inspect the .json files created in this folder. These files are overwritten on each execution, so there is no risk of accumulating many, or using much space. With the use of temporary folders, the files are deleted and cannot be inspected.
- Also the deletion of folders doesn't seem to work as intended; some folders are deleted after use, but many others remain, either empty, or with some files in them. This could eventually lead to consuming much space, as users are normally not aware of their existence.

