### PR TITLE
Adding `version` attribute for `QibolabBackend`

### DIFF
--- a/src/qibolab/backends.py
+++ b/src/qibolab/backends.py
@@ -6,13 +6,19 @@ from qibo.states import CircuitResult
 
 class QibolabBackend(NumpyBackend):
     def __init__(self, platform, runcard=None):
+        from qibo import __version__ as qibo_version
+
         from qibolab import __version__
         from qibolab.platform import Platform
 
         super().__init__()
         self.name = "qibolab"
         self.platform = Platform(platform, runcard)
-        self.version = __version__
+        self.versions = {
+            "qibo": qibo_version,
+            "numpy": self.np.__version__,
+            "qibolab": __version__,
+        }
 
     def apply_gate(self, gate, state, nqubits):  # pragma: no cover
         raise_error(NotImplementedError, "Qibolab cannot apply gates directly.")


### PR DESCRIPTION
This PR is correlated to qiboteam/qibo#643 and qiboteam/qibojit#87.
It is required by qiboteam/qcvv#66.
I'm adding an attribute `version` inside the backend object.