### PR TITLE
[POC] `Qubit` object to simplify platforms

### DIFF
--- a/src/qibolab/platforms/abstract.py
+++ b/src/qibolab/platforms/abstract.py
@@ -104,17 +104,9 @@ class AbstractPlatform(ABC):
             self.resonator_type = "3D"
         else:
             self.resonator_type = "2D"
-        self.hardware_avg = self.settings["settings"]["hardware_avg"]
-        self.sampling_rate = self.settings["settings"]["sampling_rate"]
-        self.repetition_duration = self.settings["settings"]["repetition_duration"]
 
         self.topology = self.settings["topology"]
         self.channels = self.settings["channels"]
-
-        # Load Characterization settings
-        self.characterization = self.settings["characterization"]
-        # Load Native Gates
-        self.native_gates = self.settings["native_gates"]
 
         self.instruments = {}
         # Instantiate instruments
@@ -130,6 +122,9 @@ class AbstractPlatform(ABC):
 
         # Instantiate Qubit objects and map them to channels and instruments
         self.qubits = [Qubit(q, self.settings) for q in self.settings["qubits"]]
+
+        # Load the rest of settings
+        self.reload_settings()
 
     def __repr__(self):
         return self.name
@@ -155,7 +150,18 @@ class AbstractPlatform(ABC):
     def reload_settings(self):
         with open(self.runcard, "r") as file:
             self.settings = yaml.safe_load(file)
-        self.setup()
+
+        self.hardware_avg = self.settings["settings"]["hardware_avg"]
+        self.sampling_rate = self.settings["settings"]["sampling_rate"]
+        self.repetition_duration = self.settings["settings"]["repetition_duration"]
+
+        # Load Characterization settings
+        self.characterization = self.settings["characterization"]
+        # Load Native Gates
+        self.native_gates = self.settings["native_gates"]
+
+        if self.is_connected:
+            self.setup()
 
     @abstractmethod
     def run_calibration(self, show_plots=False):  # pragma: no cover
@@ -196,6 +202,11 @@ class AbstractPlatform(ABC):
         self.ro_port = {qubit.ro_port for qubit in self.qubits}
         self.qd_port = {qubit.qd_port for qubit in self.qubits}
         self.qf_port = {qubit.qf_port for qubit in self.qubits}
+
+        # Load Characterization settings
+        self.characterization = self.settings["characterization"]
+        # Load Native Gates
+        self.native_gates = self.settings["native_gates"]
 
     def start(self):
         if self.is_connected:

--- a/src/qibolab/platforms/abstract.py
+++ b/src/qibolab/platforms/abstract.py
@@ -39,7 +39,7 @@ class Qubit:
 
         # Generate qubit_instrument_map from qubit_channel_map and the instruments' channel_port_maps
         self.instruments = [None, None, None]
-        for name, value in settings["instruments"].items():
+        for name, value in settings.get("instruments", {}).items():
             instrument_settings = value.get("settings")
             channel_port_map = instrument_settings.get("channel_port_map", [])
             s4g_modules = instrument_settings.get("s4g_modules", [])
@@ -71,7 +71,7 @@ class Qubit:
 
     def get_native_gate(self, name, start, relative_phase):
         kwargs = dict(self.native_one_qubit.get(name))
-        kwargs.pop("phase")
+        kwargs.pop("phase", None)
         kwargs["start"] = start
         kwargs["relative_phase"] = relative_phase
         kwargs["qubit"] = self.index
@@ -111,7 +111,7 @@ class AbstractPlatform(ABC):
 
         self.instruments = {}
         # Instantiate instruments
-        for name, inst_settings in self.settings["instruments"].items():
+        for name, inst_settings in self.settings.get("instruments", {}).items():
             lib = inst_settings["lib"]
             i_class = inst_settings["class"]
             address = inst_settings["address"]

--- a/src/qibolab/platforms/abstract.py
+++ b/src/qibolab/platforms/abstract.py
@@ -39,9 +39,10 @@ class Qubit:
 
         # Generate qubit_instrument_map from qubit_channel_map and the instruments' channel_port_maps
         self.instruments = [None, None, None]
-        for name, inst_settings in settings["instruments"].items():
-            channel_port_map = inst_settings.get("channel_port_map", [])
-            s4g_modules = inst_settings.get("s4g_modules", [])
+        for name, value in settings["instruments"].items():
+            instrument_settings = value.get("settings")
+            channel_port_map = instrument_settings.get("channel_port_map", [])
+            s4g_modules = instrument_settings.get("s4g_modules", [])
             for channel in itertools.chain(channel_port_map, s4g_modules):
                 if channel in self.channels:
                     self.instruments[self.channels.index(channel)] = name
@@ -199,9 +200,9 @@ class AbstractPlatform(ABC):
         for qubit in self.qubits:
             qubit.set_ports(self.instruments)
         # TODO: These dictionaries should be removed but doing so will break compatibility with qcvv
-        self.ro_port = {qubit.ro_port for qubit in self.qubits}
-        self.qd_port = {qubit.qd_port for qubit in self.qubits}
-        self.qf_port = {qubit.qf_port for qubit in self.qubits}
+        self.ro_port = {qubit.index: qubit.ro_port for qubit in self.qubits}
+        self.qd_port = {qubit.index: qubit.qd_port for qubit in self.qubits}
+        self.qf_port = {qubit.index: qubit.qf_port for qubit in self.qubits}
 
         # Load Characterization settings
         self.characterization = self.settings["characterization"]

--- a/src/qibolab/platforms/abstract.py
+++ b/src/qibolab/platforms/abstract.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import itertools
 from abc import ABC, abstractmethod
 
 import yaml
@@ -39,10 +40,9 @@ class Qubit:
         # Generate qubit_instrument_map from qubit_channel_map and the instruments' channel_port_maps
         self.instruments = [None, None, None]
         for name, inst_settings in settings["instruments"].items():
-            for channel in inst_settings.get("channel_port_map", []):
-                if channel in self.channels:
-                    self.instruments[self.channels.index(channel)] = name
-            for channel in inst_settings.get("s4g_modules", []):
+            channel_port_map = inst_settings.get("channel_port_map", [])
+            s4g_modules = inst_settings.get("s4g_modules", [])
+            for channel in itertools.chain(channel_port_map, s4g_modules):
                 if channel in self.channels:
                     self.instruments[self.channels.index(channel)] = name
 
@@ -190,13 +190,9 @@ class AbstractPlatform(ABC):
                 **self.settings["instruments"][name]["settings"],
             )
 
-        # Generate ro_channel[qubit], qd_channel[qubit], qf_channel[qubit], qrm[qubit], qcm[qubit], lo_qrm[qubit], lo_qcm[qubit]
         for qubit in self.qubits:
             qubit.set_ports(self.instruments)
-        # TODO: Remove these dictionaries as they are probably not needed
-        self.ro_channel = {qubit.ro_channel for qubit in self.qubits}
-        self.qd_channel = {qubit.qd_channel for qubit in self.qubits}
-        self.qf_channel = {qubit.qf_channel for qubit in self.qubits}
+        # TODO: These dictionaries should be removed but doing so will break compatibility with qcvv
         self.ro_port = {qubit.ro_port for qubit in self.qubits}
         self.qd_port = {qubit.qd_port for qubit in self.qubits}
         self.qf_port = {qubit.qf_port for qubit in self.qubits}

--- a/src/qibolab/platforms/abstract.py
+++ b/src/qibolab/platforms/abstract.py
@@ -74,10 +74,10 @@ class AbstractPlatform(ABC):
 
         self.instruments = {}
         # Instantiate instruments
-        for name in self.settings["instruments"]:
-            lib = self.settings["instruments"][name]["lib"]
-            i_class = self.settings["instruments"][name]["class"]
-            address = self.settings["instruments"][name]["address"]
+        for name, inst_settings in self.settings["instruments"].items():
+            lib = inst_settings["lib"]
+            i_class = inst_settings["class"]
+            address = inst_settings["address"]
             from importlib import import_module
 
             InstrumentClass = getattr(import_module(f"qibolab.instruments.{lib}"), i_class)
@@ -153,9 +153,9 @@ class AbstractPlatform(ABC):
                 "There is no connection to the instruments, the setup cannot be completed",
             )
 
-        for name in self.instruments:
+        for name, instrument in self.instruments.items():
             # Set up every with the platform settings and the instrument settings
-            self.instruments[name].setup(
+            instrument.setup(
                 **self.settings["settings"],
                 **self.settings["instruments"][name]["settings"],
             )
@@ -191,18 +191,18 @@ class AbstractPlatform(ABC):
 
     def start(self):
         if self.is_connected:
-            for name in self.instruments:
-                self.instruments[name].start()
+            for instrument in self.instruments.values():
+                instrument.start()
 
     def stop(self):
         if self.is_connected:
-            for name in self.instruments:
-                self.instruments[name].stop()
+            for instrument in self.instruments.values():
+                instrument.stop()
 
     def disconnect(self):
         if self.is_connected:
-            for name in self.instruments:
-                self.instruments[name].disconnect()
+            for instrument in self.instruments.values():
+                instrument.disconnect()
             self.is_connected = False
 
     # TRANSPILATION

--- a/src/qibolab/platforms/abstract.py
+++ b/src/qibolab/platforms/abstract.py
@@ -21,15 +21,14 @@ class Qubit:
     """Data structure that holds information about all instruments controlling a qubit.
 
     Args:
-        index (int): Qubit index (read from runcard).
-        channels (list): List of channels (int) associated to the qubit (read from runcard).
-        instruments (dict): Dictionary containing the instrument objects created in ``AbstractPlatform``.
+        index (int): Qubit index.
+        settings (dict): Settings dictionary as read from the runcard yaml.
 
     Attributes:
         instruments (list): List of the three instrument names (str) controlling this qubit.
-        channels (list): List of channels (int) associated to the qubit.
-        ro_channel, qd_channel, qf_channel (int)
-        ro_port, qd_port, qf_port
+        channels (list): List of the three channels (int) associated to the qubit.
+        ro_channel, qd_channel, qf_channel (int): Explicit references to the channels.
+        ro_port, qd_port, qf_port: Explicit references to the ports.
     """
 
     def __init__(self, index, settings):
@@ -70,6 +69,20 @@ class Qubit:
             self.qf_port = qbm.dacs[self.channels[2]]
 
     def get_native_gate(self, name, start, relative_phase):
+        """Get one-qubit native gate acting on this qubit.
+
+        This maps the gate to a single pulse and works for the native gates
+        provided in the runcard.
+
+        Args:
+            name (str): Name of the native gate (should agree with the runcard).
+            start (float): Start time for the corresponding pulse.
+            relative_phase (float): Relative phase of the corresponding pulse.
+
+        Returns
+            kwargs (dict): Dictionary containing all the arguments required
+                for constructing the single pulse that implements the given gate.
+        """
         kwargs = dict(self.native_one_qubit.get(name))
         kwargs.pop("phase", None)
         kwargs["start"] = start

--- a/src/qibolab/platforms/dummy.py
+++ b/src/qibolab/platforms/dummy.py
@@ -26,20 +26,6 @@ class DummyPlatform(AbstractPlatform):
         name (str): name of the platform.
     """
 
-    def __init__(self, name, runcard):
-        self.name = name
-        self.runcard = runcard
-        self.is_connected = False
-        # Load platform settings
-        with open(runcard, "r") as file:
-            self.settings = yaml.safe_load(file)
-
-        # create dummy instruments
-        nqubits = self.settings.get("nqubits")
-        # TODO: Remove these when platform abstraction is fixed
-        self.qcm = {i: DummyInstrument() for i in range(nqubits)}
-        self.qrm = {i: DummyInstrument() for i in range(nqubits)}
-
     def reload_settings(self):  # pragma: no cover
         log.info("Dummy platform does not support setting reloading.")
 

--- a/src/qibolab/platforms/multiqubit.py
+++ b/src/qibolab/platforms/multiqubit.py
@@ -29,16 +29,14 @@ class MultiqubitPlatform(AbstractPlatform):
                 instrument.upload()
 
         for name, instrument in self.instruments.items():
-            if "control" in roles[name]:
-                if not instrument_pulses[name].is_empty:
-                    instrument.play_sequence()
+            if "control" in roles[name] and not instrument_pulses[name].is_empty:
+                instrument.play_sequence()
 
         acquisition_results = {}
         for name, instrument in self.instruments.items():
-            if "readout" in roles[name]:
-                if not instrument_pulses[name].is_empty:
-                    if not instrument_pulses[name].ro_pulses.is_empty:
-                        acquisition_results.update(instrument.play_sequence_and_acquire())
-                    else:
-                        instrument.play_sequence()
+            if "readout" in roles[name] and not instrument_pulses[name].is_empty:
+                if not instrument_pulses[name].ro_pulses.is_empty:
+                    acquisition_results.update(instrument.play_sequence_and_acquire())
+                else:
+                    instrument.play_sequence()
         return acquisition_results

--- a/src/qibolab/platforms/multiqubit.py
+++ b/src/qibolab/platforms/multiqubit.py
@@ -21,24 +21,24 @@ class MultiqubitPlatform(AbstractPlatform):
         # Process Pulse Sequence. Assign pulses to instruments and generate waveforms & program
         instrument_pulses = {}
         roles = {}
-        for name in self.instruments:
+        for name, instrument in self.instruments.items():
             roles[name] = self.settings["instruments"][name]["roles"]
             if "readout" in roles[name] or "control" in roles[name]:
-                instrument_pulses[name] = sequence.get_channel_pulses(*self.instruments[name].channels)
-                self.instruments[name].process_pulse_sequence(instrument_pulses[name], nshots, self.repetition_duration)
-                self.instruments[name].upload()
+                instrument_pulses[name] = sequence.get_channel_pulses(*instrument.channels)
+                instrument.process_pulse_sequence(instrument_pulses[name], nshots, self.repetition_duration)
+                instrument.upload()
 
-        for name in self.instruments:
+        for name, instrument in self.instruments.items():
             if "control" in roles[name]:
                 if not instrument_pulses[name].is_empty:
-                    self.instruments[name].play_sequence()
+                    instrument.play_sequence()
 
         acquisition_results = {}
-        for name in self.instruments:
+        for name, instrument in self.instruments.items():
             if "readout" in roles[name]:
                 if not instrument_pulses[name].is_empty:
                     if not instrument_pulses[name].ro_pulses.is_empty:
-                        acquisition_results.update(self.instruments[name].play_sequence_and_acquire())
+                        acquisition_results.update(instrument.play_sequence_and_acquire())
                     else:
-                        self.instruments[name].play_sequence()
+                        instrument.play_sequence()
         return acquisition_results

--- a/src/qibolab/runcards/dummy.yml
+++ b/src/qibolab/runcards/dummy.yml
@@ -18,8 +18,6 @@ channels: [1, 2, 3]
 qubit_channel_map: # [ReadOut, QubitDrive, QubitFlux]
     0: [2, 1, null]
 
-instruments: null
-
 native_gates:
     single_qubit:
         0: # qubit number


### PR DESCRIPTION
Looking through the `AbstractPlatform` object I noticed that there are many dictionaries mapping qubit IDs to various properties, such as channels, instruments, ports. Here I implemented a `Qubit` class which holds these properties and also simplified some dictionary loops and the methods that convert native gates to pulses.

This could be a first step to simplifying the dictonary structure, however we would also need to implement some setter methods that can be used by qcvv.

Also fixes the `platform.reload_settings()` issue reported in qiboteam/qcvv#82.