### PR TITLE
Fix relative phase issues with hardware modulation

### DIFF
--- a/src/qibolab/instruments/abstract.py
+++ b/src/qibolab/instruments/abstract.py
@@ -21,8 +21,11 @@ class AbstractInstrument(ABC):
         self.is_connected: bool = False
         self.signature: str = f"{type(self).__name__}@{address}"
         # create local storage folder
-        self.data_folder = user_folder / "instruments" / "data"
-        self.data_folder.mkdir(parents=True, exist_ok=True)
+        instruments_data_folder = user_folder / "instruments" / "data"
+        instruments_data_folder.mkdir(parents=True, exist_ok=True)
+        # create temporary directory
+        self.tmp_folder = tempfile.TemporaryDirectory(dir=instruments_data_folder)
+        self.data_folder = Path(self.tmp_folder.name)
 
     @abstractmethod
     def connect(self):

--- a/src/qibolab/runcards/tii5q.yml
+++ b/src/qibolab/runcards/tii5q.yml
@@ -35,7 +35,7 @@ instruments:
         address: 192.168.0.4
         roles: [other]
         settings:
-            reference_clock_source      : external                      # external or internal
+            reference_clock_source      : internal                      # external or internal
 
     qrm_rf:
         lib: qblox
@@ -45,10 +45,10 @@ instruments:
         settings:
             ports:
                 o1:
-                    attenuation                 : 42
+                    attenuation                 : 10
                     lo_enabled                  : true
                     lo_frequency                :  7_712_825_000                 # (Hz) from 2e9 to 18e9
-                    gain                        : 0.1                           # for path0 and path1 -1.0<=v<=1.0
+                    gain                        : 0.3                           # for path0 and path1 -1.0<=v<=1.0
                     hardware_mod_en             : false
                 i1:
                     hardware_demod_en           : false
@@ -74,10 +74,10 @@ instruments:
                     gain                         : 0.17 # for path0 and path1 -1.0<=v<=1.0
                     hardware_mod_en              : false
                 o2:
-                    attenuation                  : 20 # (dB)
+                    attenuation                  : 26 # (dB)
                     lo_enabled                   : true
-                    lo_frequency                 : 5_091_350_000 # (Hz) from 2e9 to 18e9
-                    gain                         : 0.35 # for path0 and path1 -1.0<=v<=1.0
+                    lo_frequency                 : 5_091_461_000 # (Hz) from 2e9 to 18e9
+                    gain                         : 0.28 # for path0 and path1 -1.0<=v<=1.0
                     hardware_mod_en              : false
 
             channel_port_map:
@@ -92,9 +92,9 @@ instruments:
         settings:
             ports:
                 o1:
-                    attenuation                  : 34 # (dB)
+                    attenuation                  : 26 # (dB)
                     lo_enabled                   : true
-                    lo_frequency                 : 6_309_400_000 # (Hz) from 2e9 to 18e9
+                    lo_frequency                 : 6_308_500_000 # (Hz) from 2e9 to 18e9
                     gain                         : 0.35 # for path0 and path1 -1.0<=v<=1.0
                     hardware_mod_en              : false
                 o2:
@@ -187,7 +187,7 @@ native_gates:
         2: # qubit number
             RX:
                 duration: 40
-                amplitude: 0.4485
+                amplitude: 0.8
                 frequency: -200_000_000
                 shape: Gaussian(5)
                 type: qd # qubit drive
@@ -196,7 +196,7 @@ native_gates:
             MZ:
                 duration: 2000
                 amplitude: 0.1
-                frequency: -155_201_000
+                frequency: -155_181_000
                 shape: Rectangular()
                 type: ro # readout
                 start: 0
@@ -213,7 +213,7 @@ native_gates:
             MZ:
                 duration: 2000
                 amplitude: 0.1
-                frequency: -34_845_000
+                frequency: -34_815_000
                 shape: Rectangular()
                 type: ro # readout
                 start: 0
@@ -296,18 +296,18 @@ characterization:
             mean_exc_states: (-0.01143767040340675+0.006593184205517083j)
             sweetspot: -0.00384
         2:
-            resonator_freq: 7_557_624_144
-            qubit_freq: 4_891_350_000 # 4_891_155_529
+            resonator_freq: 7_557_724_144
+            qubit_freq: 4_891_461_000 # 4_891_155_529
             T1: 33875
             T2: 0
-            state0_voltage: 9893
-            state1_voltage: 27140
+            state0_voltage: 5175
+            state1_voltage: 15442
             mean_gnd_states: (-0.003939859338033963-0.00335499560437317j)
-            mean_exc_states: (0.007495619698642739+0.005741169222622128j)
+            mean_exc_states: (-0.015165640448602356+0.0029071903433933377j)
             sweetspot: -0.00154
         3:
-            resonator_freq: 7_677_980_000
-            qubit_freq: 6_109_400_000
+            resonator_freq: 7_678_010_000
+            qubit_freq: 6_108_500_000
             T1: 2192.895853326451
             T2: 6933.310025260633
             state0_voltage: 3777


### PR DESCRIPTION
This PR addresses an issue raised by @maxhant: 
*The results of running Ramsey with hardware modulation turned on, differ from those when turned off.*

In the implementation of  hardware modulation, I had forgotten to set the relative phase of each pulse within the qasm pseudo-assembler.
An instruction `set_ph` is now included for every pulse with relative_phase != 0, when hardware modulation or demodulation are turned on. Below an example of the qasm code generated for a `qcm` instrument as part of a Ramsey experiment.
```asm
	move 1024,R0             # nshots
	nop
	wait_sync 4
	loop:
	reset_ph
	# wait 0
	play 0,1,764             # play waveforms Pulse(0, 40, 0.22425, -200_000_000, 0, Gaussian(5), 22, PulseType.DRIVE, 2)
	set_ph 36, 0, 0          # set relative phase -12.00088393671301 rads
	play 0,1,44              # play waveforms Pulse(764, 40, 0.22425, -200_000_000, -12.000884, Gaussian(5), 22, PulseType.DRIVE, 2)
	# wait 199192 ns
	move 199,R2
	nop
	waitloop2:
		wait 1000
		loop R2,@waitloop2
	wait 192
	loop R0,@loop
	stop
```