### PR TITLE
Qpysequence integration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(
             "qblox-instruments==0.6.1",  # 0.6.1
             "quantify-core",  # 0.6.0
             "dash",  # Live plotting
+            "qpysequence @ git+https://github.com/qilimanjaro-tech/qpysequence.git",
         ],
     },
     python_requires=">=3.6.0",

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
             "qblox-instruments==0.6.1",  # 0.6.1
             "quantify-core",  # 0.6.0
             "dash",  # Live plotting
-            "qpysequence @ git+https://github.com/qilimanjaro-tech/qpysequence.git",
+            "qpysequence @ git+https://github.com/qilimanjaro-tech/qpysequence.git@0.3.0",
         ],
     },
     python_requires=">=3.6.0",

--- a/src/qibolab/instruments/qblox.py
+++ b/src/qibolab/instruments/qblox.py
@@ -20,10 +20,8 @@ from qblox_instruments.qcodes_drivers.sequencer import Sequencer as QbloxSequenc
 from qibolab.instruments.abstract import AbstractInstrument, InstrumentException
 from qibolab.pulses import Pulse, PulseSequence, PulseShape, PulseType, Waveform
 
-from qpysequence.program import Program
-from qpysequence.block import Block
-from qpysequence.loop import Loop
-from qpysequence.instructions.real_time import Play, Wait, Acquire
+from qpysequence.program import Program, Loop
+from qpysequence.program.instructions import Play, Acquire, ResetPh
 from qpysequence.library import long_wait
 
 
@@ -663,7 +661,8 @@ class ClusterQRM_RF(AbstractInstrument):
 
                     # Program
                     program = Program()
-                    body = Loop(name="body", iterations=nshots)
+                    body = Loop(name="body", begin=0, end=nshots)
+                    body.append_component(ResetPh())
                     
                     minimum_delay_between_instructions = 4
 


### PR DESCRIPTION
This PR **introduces** the most minimal usage of [QPySequence](https://github.com/qilimanjaro-tech/qpysequence) at its latest version (0.3.0) to generate the program of the Qblox QCM.

Right now the behavior should be the same as in the branch [alvaro/qblox_multiplex_with_calibration](https://github.com/qiboteam/qibolab/tree/alvaro/qblox_multiplex_with_calibration). If @aorgazf can verify it, this PR can be either be merged or be extended with more qpysequence functionalities, although prior to the latter option I would strongly recommend a **major** refactoring in the qblox and pulse classes, along the lines of what was being done in the branch [pulse-refactor](https://github.com/qiboteam/qibolab/tree/pulse-refactor).