### PR TITLE
new runcard for tii1q with 2 single-qubit devices

### DIFF
--- a/src/qibolab/runcards/tii1q.yml
+++ b/src/qibolab/runcards/tii1q.yml
@@ -1,87 +1,128 @@
 nqubits: 1
-description: 1-qubit device from Qilimanjaro at TII SD fridge, controlled with qblox cluster rf.
+description: 2 1-qubit devices fabricated by TII at TII SD fridge, controlled with qblox cluster rf.
 
 settings:
     hardware_avg: 1024
-    sampling_rate: 1_000_000_000
     repetition_duration: 200_000
-    minimum_delay_between_instructions: 4 # must be a multiple of 4
+    sampling_rate: 1_000_000_000
 
-qubits: [0]
+qubits: [0, 1]
 
 topology: # qubit - qubit connections
--   [1]
+-   [ 1, 0]
+-   [ 0, 1]
 
-channels: [1, 2, 3]
+channels: ['w4_qd', 'w4_ro', 'v2', 'w6_qd', 'w6_ro', 'v1']
 
 qubit_channel_map: # [ReadOut, QubitDrive, QubitFlux]
-    0: [2, 1, null]
+    0:     [w4_ro, w4_qd, null]
+    1:   [w6_ro, w6_qd, null]
 
 instruments:
     cluster:
         lib: qblox
         class: Cluster
         address: 192.168.0.3
+        roles: [other]
         settings:
             reference_clock_source      : internal                      # external or internal
 
-    qrm_rf:
+    qrm_rf1: # 0
         lib: qblox
         class: ClusterQRM_RF
-        address: 192.168.0.3:5 #:7 for loopback
+        address: 192.168.0.3:9
+        roles: [readout]
         settings:
             ports:
                 o1:
-                    attenuation                 : 58
+                    attenuation                 : 40
                     lo_enabled                  : true
-                    lo_frequency                : 7804847574                    # (Hz) from 2e9 to 18e9
-                    gain                        : 0.4                           # for path0 and path1 -1.0<=v<=1.0
+                    lo_frequency                : 7_276_161_000                    # (Hz) from 2e9 to 18e9
+                    gain                        : 0.3                              # for path0 and path1 -1.0<=v<=1.0
                     hardware_mod_en             : false
                 i1:
                     hardware_demod_en           : false
 
-            acquisition_hold_off        : 200                           # minimum 4ns
+            acquisition_hold_off        : 200
             acquisition_duration        : 2000
 
-            channel_port_map:  # Refrigerator Channel : Instrument port
-                2: o1 # IQ Port = out0 & out1
-                3: i1
+            channel_port_map:   # Refrigerator Channel : Instrument port
+                'w4_ro' : o1    # IQ Port = out0 & out1
+                'v2'    : i1
 
-    qcm_rf:
+    qrm_rf2: # 1
         lib: qblox
-        class: ClusterQCM_RF
-        address: 192.168.0.3:2
+        class: ClusterQRM_RF
+        address: 192.168.0.3:5
+        roles: [readout]
         settings:
             ports:
                 o1:
-                    attenuation                  : 8 # (dB)
-                    lo_enabled                   : true
-                    lo_frequency                 : 5282273989 # (Hz) from 2e9 to 18e9
-                    gain                         : 0.38 # for path0 and path1 -1.0<=v<=1.0
-                    hardware_mod_en              : false
+                    attenuation                 : 40
+                    lo_enabled                  : true
+                    lo_frequency                : 7_274_641_000                    # (Hz) from 2e9 to 18e9
+                    gain                        : 0.3                              # for path0 and path1 -1.0<=v<=1.0
+                    hardware_mod_en             : false
+                i1:
+                    hardware_demod_en           : false
+
+            acquisition_hold_off        : 200
+            acquisition_duration        : 2000
+
+            channel_port_map:   # Refrigerator Channel : Instrument port
+                'w6_ro' : o1    # IQ Port = out0 & out1
+                'v1'    : i1
+
+    qcm_rf1:
+        lib: qblox
+        class: ClusterQCM_RF
+        address: 192.168.0.3:2
+        roles: [control]
+        settings:
+            ports:
                 o2:
-                    attenuation                  : 60 # (dB)
+                    attenuation                  : 10 # (dB)
                     lo_enabled                   : true
-                    lo_frequency                 : 6_000_000_000 # (Hz) from 2e9 to 18e9
-                    gain                         : 0 # for path0 and path1 -1.0<=v<=1.0
+                    lo_frequency                 : 5_589_780_000 # (Hz) from 2e9 to 18e9
+                    gain                         : 0.55 # for path0 and path1 -1.0<=v<=1.0
+                    hardware_mod_en              : false
+                o1:
+                    attenuation                  : 10 # (dB)
+                    lo_enabled                   : true
+                    lo_frequency                 : 6_087_942_000 # (Hz) from 2e9 to 18e9
+                    gain                         : 0.63 # for path0 and path1 -1.0<=v<=1.0
                     hardware_mod_en              : false
 
             channel_port_map:
-                1: o1 # IQ Port = out0 & out1
+                'w4_qd': o2 # 0
+                'w6_qd': o1 # 1
 
 native_gates:
     single_qubit:
-        0: # qubit number
+        0: # qubit id
             RX:
                 duration: 40                    # should be multiple of 4
-                amplitude: 0.8695
-                frequency: -200_000_000
-                shape: Gaussian(5) # , 0.9058)
-                type: qd # qubit drive
-                drag_shape: Drag(5, 0)
-            MZ:
-                duration: 2400
                 amplitude: 0.9
+                frequency: -200_000_000
+                shape: Gaussian(5)
+                type: qd # qubit drive
+            MZ:
+                duration: 2000
+                amplitude: 0.1
+                frequency: 20_000_000
+                shape: Rectangular()
+                type: ro # readout
+
+        1: # qubit id
+            RX:
+                duration: 40                    # should be multiple of 4
+                amplitude: 0.9
+                frequency: -200_000_000
+                shape: Gaussian(5)
+                type: qd # qubit drive
+            MZ:
+                duration: 2000
+                amplitude: 0.1
                 frequency: 20_000_000
                 shape: Rectangular()
                 type: ro # readout
@@ -89,11 +130,21 @@ native_gates:
 characterization:
     single_qubit:
         0:
-            resonator_freq: 7824847574
-            qubit_freq: 5082273989
-            T1: 17744
-            T2: 11816
-            state0_voltage: 875
-            state1_voltage: 350
-            mean_gnd_states: (-5.543255134868772e-05+0.0008975930158821524j)
-            mean_exc_states: (0.0001446400604158933+0.0003369969077198778j)
+            resonator_freq: 7_296_161_000
+            qubit_freq: 5_389_780_000
+            T1: 18107
+            T2: 0
+            state0_voltage: 0
+            state1_voltage: 0
+            mean_gnd_states: (0+0j)
+            mean_exc_states: (0+0j)
+
+        1:
+            resonator_freq: 7_294_641_000
+            qubit_freq: 5_887_942_000
+            T1: 8401
+            T2: 0
+            state0_voltage: 0
+            state1_voltage: 0
+            mean_gnd_states: (0+0j)
+            mean_exc_states: (0+0j)


### PR DESCRIPTION
This PR contains a new version of `tii1q.yml` runcard, that gives simultaneous access to 2 single-qubit fixed-frequency devices fabricated by TII and installed at TII SD fridge.
The characterization of the devices is not very fine, but enough to test code and perform further characterizations.

Please not that since the calculation of `AbstractPlatform.resonator_type` is done based on `AbstractPlatform.nqubits`, like so:
```python
        self.nqubits = self.settings["nqubits"]
        if self.nqubits == 1:
            self.resonator_type = "3D"
        else:
            self.resonator_type = "2D"
```
the number of qubits in the new runcard has been left as 1 on purpose:

```yaml
nqubits: 1
description: 2 1-qubit devices fabricated by TII at TII SD fridge, controlled with qblox cluster rf.
```

On a separate PR I will propose the addition of `resonator_type ` to the runcard, so that the platform reads it from the runcard, instead of inferring it from the number of qubits.
