### PR TITLE
Accelerate waveforms and program upload

### DIFF
--- a/src/qibolab/instruments/qblox.py
+++ b/src/qibolab/instruments/qblox.py
@@ -861,19 +861,21 @@ class ClusterQRM_RF(AbstractInstrument):
             sequencer: Sequencer
             for port in self._output_ports_keys:
                 for sequencer in self._sequencers[port]:
-                    # Add sequence program and waveforms to single dictionary and write to JSON file
-                    filename = f"{self.name}_sequencer{sequencer.number}_sequence.json"
+                    # Add sequence program and waveforms to single dictionary
                     qblox_dict[sequencer] = {
                         "waveforms": sequencer.waveforms,
                         "weights": sequencer.weights,
                         "acquisitions": sequencer.acquisitions,
                         "program": sequencer.program,
                     }
-                    with open(self.data_folder / filename, "w", encoding="utf-8") as file:
-                        json.dump(qblox_dict[sequencer], file, indent=4)
 
-                    # Upload json file to the device sequencers
-                    self.device.sequencers[sequencer.number].sequence(str(self.data_folder / filename))
+                    # Upload dictionary to the device sequencers
+                    self.device.sequencers[sequencer.number].sequence(qblox_dict[sequencer])
+
+                    # DEBUG: Save sequence to file
+                    # filename = f"{self.name}_sequencer{sequencer.number}_sequence.json"
+                    # with open(self.data_folder / filename, "w", encoding="utf-8") as file:
+                    #     json.dump(qblox_dict[sequencer], file, indent=4)
 
         # Arm sequencers
         for sequencer_number in self._used_sequencers_numbers:
@@ -1610,19 +1612,21 @@ class ClusterQCM_RF(AbstractInstrument):
             sequencer: Sequencer
             for port in self._output_ports_keys:
                 for sequencer in self._sequencers[port]:
-                    # Add sequence program and waveforms to single dictionary and write to JSON file
-                    filename = f"{self.name}_sequencer{sequencer.number}_sequence.json"
+                    # Add sequence program and waveforms to single dictionary
                     qblox_dict[sequencer] = {
                         "waveforms": sequencer.waveforms,
                         "weights": sequencer.weights,
                         "acquisitions": sequencer.acquisitions,
                         "program": sequencer.program,
                     }
-                    with open(self.data_folder / filename, "w", encoding="utf-8") as file:
-                        json.dump(qblox_dict[sequencer], file, indent=4)
 
-                    # Upload json file to the device sequencers
-                    self.device.sequencers[sequencer.number].sequence(str(self.data_folder / filename))
+                    # Upload dictionary to the device sequencers
+                    self.device.sequencers[sequencer.number].sequence(qblox_dict[sequencer])
+
+                    # DEBUG: Save sequence to file
+                    # filename = f"{self.name}_sequencer{sequencer.number}_sequence.json"
+                    # with open(self.data_folder / filename, "w", encoding="utf-8") as file:
+                    #     json.dump(qblox_dict[sequencer], file, indent=4)
 
         # Arm sequencers
         for sequencer_number in self._used_sequencers_numbers:


### PR DESCRIPTION
This PR improves the way in which waveforms and programs are uploaded to Qblox devices.
Qblox have recently advised that the dictionary that contains the waveforms and the program can be uploaded directly to the device, without having to save it first as a json file.
This simple change is expected to accelerate some routines in which either the waveforms or the program change from one iteration to the next.
```python
	for sequencer in self._sequencers[port]:
		# Add sequence program and waveforms to single dictionary
		qblox_dict[sequencer] = {
			"waveforms": sequencer.waveforms,
			"weights": sequencer.weights,
			"acquisitions": sequencer.acquisitions,
			"program": sequencer.program,
		}

		# Upload dictionary to the device sequencers
		self.device.sequencers[sequencer.number].sequence(qblox_dict[sequencer])

		# DEBUG: Save sequence to file
		# filename = f"{self.name}_sequencer{sequencer.number}_sequence.json"
		# with open(self.data_folder / filename, "w", encoding="utf-8") as file:
		#     json.dump(qblox_dict[sequencer], file, indent=4)
```