### PR TITLE
Fix `platform.reload_settings`

### DIFF
--- a/src/qibolab/platforms/abstract.py
+++ b/src/qibolab/platforms/abstract.py
@@ -38,19 +38,11 @@ class AbstractPlatform(ABC):
             self.resonator_type = "3D"
         else:
             self.resonator_type = "2D"
-        self.hardware_avg = self.settings["settings"]["hardware_avg"]
-        self.sampling_rate = self.settings["settings"]["sampling_rate"]
-        self.repetition_duration = self.settings["settings"]["repetition_duration"]
 
         self.qubits = self.settings["qubits"]
         self.topology = self.settings["topology"]
         self.channels = self.settings["channels"]
         self.qubit_channel_map = self.settings["qubit_channel_map"]
-
-        # Load Characterization settings
-        self.characterization = self.settings["characterization"]
-        # Load Native Gates
-        self.native_gates = self.settings["native_gates"]
 
         self.instruments = {}
         # Instantiate instruments
@@ -78,6 +70,8 @@ class AbstractPlatform(ABC):
                         if channel in self.qubit_channel_map[qubit]:
                             self.qubit_instrument_map[qubit][self.qubit_channel_map[qubit].index(channel)] = name
 
+        self.reload_settings()
+
     def __repr__(self):
         return self.name
 
@@ -102,7 +96,18 @@ class AbstractPlatform(ABC):
     def reload_settings(self):
         with open(self.runcard, "r") as file:
             self.settings = yaml.safe_load(file)
-        self.setup()
+
+        self.hardware_avg = self.settings["settings"]["hardware_avg"]
+        self.sampling_rate = self.settings["settings"]["sampling_rate"]
+        self.repetition_duration = self.settings["settings"]["repetition_duration"]
+
+        # Load Characterization settings
+        self.characterization = self.settings["characterization"]
+        # Load Native Gates
+        self.native_gates = self.settings["native_gates"]
+
+        if self.is_connected:
+            self.setup()
 
     @abstractmethod
     def run_calibration(self, show_plots=False):  # pragma: no cover

--- a/src/qibolab/runcards/tii5q.yml
+++ b/src/qibolab/runcards/tii5q.yml
@@ -300,7 +300,7 @@ characterization:
             qubit_freq: 4_891_370_569
             T1: 33875
             T2: 8479
-            state0_voltage: 1803 
+            state0_voltage: 1803
             state1_voltage: 3808
             mean_gnd_states: (-0.0013829998976628089-0.0011577895538555706j)
             mean_exc_states: (0.0035266558882890505+0.001438625817420428j)


### PR DESCRIPTION
Updates `platform.reload_settings` to load new settings for frequencies, etc. if the runcard yaml is updated. This is included in #166 but I do not think this will be merged soon, so I fix this here seperately because I believe it is relevant for passing parameters from calibration to the next in qibocal (see qiboteam/qibocal#82).