### PR TITLE
Fix probability calculation

### DIFF
--- a/src/qibolab/pulses.py
+++ b/src/qibolab/pulses.py
@@ -90,7 +90,7 @@ class PulseShape(ABC):
             )
         num_samples = int(pulse.duration / 1e9 * PulseShape.SAMPLING_RATE)
         time = np.arange(num_samples) / PulseShape.SAMPLING_RATE
-        global_phase = 2 * np.pi * pulse.frequency * pulse.start / 1e9  # pulse start, duration and finish are in ns
+        global_phase = pulse.global_phase
         cosalpha = np.cos(2 * np.pi * pulse.frequency * time + global_phase + pulse.relative_phase)
         sinalpha = np.sin(2 * np.pi * pulse.frequency * time + global_phase + pulse.relative_phase)
 
@@ -428,6 +428,11 @@ class Pulse:
             self._frequency = value
 
     @property
+    def global_phase(self):
+        # pulse start, duration and finish are in ns
+        return 2 * np.pi * self.frequency * self.start / 1e9
+
+    @property
     def relative_phase(self) -> float:
         return self._relative_phase
 
@@ -659,6 +664,12 @@ class ReadoutPulse(Pulse):
     @property
     def serial(self):
         return f"ReadoutPulse({self.start}, {self.duration}, {format(self.amplitude, '.6f').rstrip('0').rstrip('.')}, {format(self.frequency, '_')}, {format(self.relative_phase, '.6f').rstrip('0').rstrip('.')}, {self.shape}, {self.channel}, {self.qubit})"
+
+    @property
+    def global_phase(self):
+        # readout pulses should have zero global phase so that we can
+        # calculate probabilities in the i-q plane
+        return 0
 
 
 class DrivePulse(Pulse):

--- a/src/qibolab/runcards/tii5q.yml
+++ b/src/qibolab/runcards/tii5q.yml
@@ -302,8 +302,8 @@ characterization:
             T2: 8479
             state0_voltage: 1803
             state1_voltage: 3808
-            mean_gnd_states: (-0.0013829998976628089-0.0011577895538555706j)
-            mean_exc_states: (0.0035266558882890505+0.001438625817420428j)
+            mean_gnd_states: (-0.001380117555244612-0.001007037409628658j)
+            mean_exc_states: (-0.0021270638416092127-0.0029602567962559675j)
             sweetspot: -0.00154
         3:
             resonator_freq: 7_678_010_000


### PR DESCRIPTION
Sets the global phase of the readout pulse to 0 so that the probability calculation is independent of the start time of the readout. 

I have updated the `mean_gnd_states` and `mean_exc_states` for qubit 2 of tii5q and the probability calculation seems to work well for this qubit, at least for the ground state, the excited state (with one RX or two RX90) and the superposition state (one RX90). We need to make a few more tests to make sure this is robust, but it should be sufficient to run some randomized benchmarking.

We need to re-calibrate the mean states with the new phase in order to make the rest of the qubits work.