### PR TITLE
Fix bug with unitary gates

### DIFF
--- a/src/qibolab/tests/test_transpilers_connectivity.py
+++ b/src/qibolab/tests/test_transpilers_connectivity.py
@@ -55,3 +55,30 @@ def test_fix_connectivity(run_number, nqubits, depth):
     target_state = backend.execute_circuit(original).state()
     target_state = transpose_qubits(target_state, hardware_qubits)
     np.testing.assert_allclose(final_state, target_state)
+
+
+@pytest.mark.parametrize("run_number", range(30))
+@pytest.mark.parametrize("nqubits", [2, 3, 4, 5])
+@pytest.mark.parametrize("unitary_dim", [1, 2])
+@pytest.mark.parametrize("depth", [2, 5, 8])
+def test_fix_connectivity_unitaries(run_number, nqubits, unitary_dim, depth):
+    """Checks that the transpiled circuit can be executed and is equivalent to original
+    when using unitaries."""
+
+    from qibolab.tests.test_transpilers_decompositions import random_unitary
+
+    original = Circuit(nqubits)
+    pairs = list(itertools.combinations(range(nqubits), unitary_dim))
+    for _ in range(depth):
+        qubits = pairs[np.random.randint(len(pairs))]
+        original.add(gates.Unitary(random_unitary(unitary_dim), *qubits))
+
+    transpiled, hardware_qubits = fix_connectivity(original)
+    # check that transpiled circuit can be executed
+    assert respects_connectivity(transpiled)
+    # check that execution results agree with original (using simulation)
+    backend = NumpyBackend()
+    final_state = backend.execute_circuit(transpiled).state()
+    target_state = backend.execute_circuit(original).state()
+    target_state = transpose_qubits(target_state, hardware_qubits)
+    np.testing.assert_allclose(final_state, target_state)

--- a/src/qibolab/tests/test_transpilers_connectivity.py
+++ b/src/qibolab/tests/test_transpilers_connectivity.py
@@ -70,7 +70,7 @@ def test_fix_connectivity_unitaries(run_number, nqubits, unitary_dim, depth):
     original = Circuit(nqubits)
     pairs = list(itertools.combinations(range(nqubits), unitary_dim))
     for _ in range(depth):
-        qubits = pairs[np.random.randint(len(pairs))]
+        qubits = pairs[int(np.random.randint(len(pairs)))]
         original.add(gates.Unitary(random_unitary(unitary_dim), *qubits))
 
     transpiled, hardware_qubits = fix_connectivity(original)

--- a/src/qibolab/transpilers/connectivity.py
+++ b/src/qibolab/transpilers/connectivity.py
@@ -94,7 +94,11 @@ def fix_connectivity(circuit):
             qubits = tuple(hardware_qubits.index(q) for q in gate.qubits)
 
         # add gate to the hardware circuit
-        new.add(gate.__class__(*qubits, **gate.init_kwargs))
+        if isinstance(gate, gates.Unitary):
+            # gates.Unitary requires matrix as first argument
+            new.add(gate.__class__(gate.matrix, *qubits, **gate.init_kwargs))
+        else:
+            new.add(gate.__class__(*qubits, **gate.init_kwargs))
         if len(qubits) == 2:
             add_swap = True
 


### PR DESCRIPTION
This PR fixes an issue regarding the transpilation of a circuit containing unitary gates.
Code to raise the error:
```python
import qibo
from qibo import gates
from qibo.models import Circuit

qibo.set_backend("qibolab", platform="tii5q")

qubit = 2

c = Circuit(5)
c.add(gates.Unitary(gates.H(0).matrix,qubit))
c.add(gates.M(qubit))
result = c(nshots=5000)
```
I've also implemented tests for this particular case.
@wilkensJ feel free to use this branch for RB in qibocal.


Checklist:
- [x] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
