### PR TITLE
[POC] QICK Platform

### DIFF
--- a/src/qibolab/platform.py
+++ b/src/qibolab/platform.py
@@ -19,6 +19,8 @@ def Platform(name, runcard=None):
         from qibolab.platforms.icplatform import ICPlatform as Device
     elif name == "dummy":
         from qibolab.platforms.dummy import DummyPlatform as Device
+    elif name == "rfsoc":
+        from qibolab.platforms.rfsoc import RFSocPlatform as Device
     else:
         from qibo.config import raise_error
 

--- a/src/qibolab/platforms/rfsoc.py
+++ b/src/qibolab/platforms/rfsoc.py
@@ -1,0 +1,130 @@
+from qick import AveragerProgram, QickSoc
+
+from qibolab.platforms.abstract import AbstractPlatform
+
+
+class Program(AveragerProgram):
+    def __init__(self, soc, cfg, sequence):
+        super().__init__(soc, cfg)
+        self.sequence = sequence
+        # TODO: Move all cfg declarations in __init__
+
+    def initialize(self):
+        ro_channel = self.cfg["resonator_channel"]
+        qd_channel = self.cfg["qubit_channel"]
+
+        self.declare_gen(ch=ro_channel, nqz=1)  # Readout
+        self.declare_gen(ch=qd_channel, nqz=2)  # Qubit
+
+        # assume one drive and one ro pulse
+        qd_pulse = self.sequence.qd_pulses[0]
+        ro_pulse = self.sequence.ro_pulses[0]
+        assert qd_pulse.channel == qd_channel
+        assert ro_pulse.channel == ro_channel
+
+        # conver pulse lengths to clock ticks
+        ro_length = self.soc.us2cycles(ro_pulse.duration * 1e-3, gen_ch=ro_channel)
+        qd_length = self.soc.us2cycles(qd_pulse.duration * 1e-3, gen_ch=qd_channel)
+
+        for ch in [0, 1]:  # configure the readout lengths and downconversion frequencies
+            self.declare_readout(ch=ch, length=ro_length, freq=ro_pulse.frequency * 1e-6, gen_ch=ro_channel)
+
+        # convert frequencies to dac register value
+        # TODO: Why are frequencies converted after declaring the readout?
+        ro_frequency = self.freq2reg(ro_pulse.frequency * 1e-6, gen_ch=ro_channel, ro_ch=0)
+        qd_frequency = self.freq2reg(qd_pulse.frequency * 1e-6, gen_ch=qd_channel)
+
+        # calculate pulse gain from amplitude
+        max_gain = self.cfg["max_gain"]
+        qd_gain = qd_pulse.amplitude * max_gain
+        ro_gain = ro_pulse.amplitude * max_gain
+
+        # add qubit and readout pulses to respective channels
+        # TODO: Register proper shapes and phases to pulses
+        self.set_pulse_registers(
+            ch=qd_channel,
+            style="const",
+            freq=qd_frequency,
+            phase=qd_pulse.phase,
+            gain=qd_gain,
+            length=qd_pulse.duration,
+        )
+        self.set_pulse_registers(
+            ch=ro_channel,
+            style="const",
+            freq=ro_frequency,
+            phase=ro_pulse.phase,
+            gain=ro_gain,
+            length=ro_pulse.duration,
+        )
+
+        self.synci(200)
+
+    def body(self):
+        ro_channel = self.cfg["resonator_channel"]
+        qd_channel = self.cfg["qubit_channel"]
+        delay_before_readout = self.cfg["delay_before_readout"]
+        delay_before_readout = self.us2cycles(delay_before_readout * 1e-3)
+
+        # play drive pulse
+        self.pulse(ch=qd_channel)
+        # align channels and wait some time (defined in the runcard)
+        self.sync_all(delay_before_readout)
+
+        # trigger measurement, play measurement pulse, wait for qubit to relax
+        syncdelay = self.us2cycles(self.cfg["relax_delay"] * 1e-3)
+        self.measure(pulse_ch=self.cfg["resonator_channel"], adcs=[0, 1], wait=True, syncdelay=syncdelay)
+
+
+class RFSocPlatform(AbstractPlatform):
+    def __init__(self, name, runcard):
+        log.info(f"Loading platform {name} from runcard {runcard}")
+        self.name = name
+        self.runcard = runcard
+        self.is_connected = False
+        # Load platform settings
+        with open(runcard) as file:
+            self.settings = yaml.safe_load(file)
+
+        self.nqubits = self.settings.get("nqubits")
+        if self.nqubits == 1:
+            self.resonator_type = "3D"
+        else:
+            self.resonator_type = "2D"
+
+        self.resonator_channel = self.settings.get("hardware_config").get("resonator_channel")
+        self.qubit_channel = self.settings.get("hardware_config").get("qubit_channel")
+
+        self.soc = QickSoc()
+        self.cfg = {"reps": self.settings.get("reps")}
+        self.cfg.update(self.settings.get("hardware_config"))
+        self.cfg.update(self.settings.get("readout_config"))
+        self.cfg.update(self.settings.get("qubit_config"))
+        # self.cfg["sigma"] = self.soc.us2cycles(0.025, gen_ch=qubit_channel)
+
+    def reload_settings(self):
+        raise NotImplementedError
+
+    def run_calibration(self, show_plots=False):  # pragma: no cover
+        raise NotImplementedError
+
+    def connect(self):
+        raise NotImplementedError
+
+    def setup(self):
+        raise NotImplementedError
+
+    def start(self):
+        raise NotImplementedError
+
+    def stop(self):
+        raise NotImplementedError
+
+    def disconnect(self):
+        raise NotImplementedError
+
+    def execute_pulse_sequence(self, sequence, nshots=None):
+        program = Program(self.soc, self.cfg, sequence)
+        # TODO: Pass optional values: ``threshold``
+        avgi, avgq = program.acquire(self.soc, load_pulses=True, progress=False, debug=False)
+        return avgi, avgq

--- a/src/qibolab/platforms/rfsoc.py
+++ b/src/qibolab/platforms/rfsoc.py
@@ -50,7 +50,7 @@ class Program(AveragerProgram):
             ch=qd_channel,
             style="const",
             freq=qd_frequency,
-            phase=0,
+            phase=int(qd_pulse.phase),
             gain=qd_gain,
             length=qd_length,
         )
@@ -58,7 +58,7 @@ class Program(AveragerProgram):
             ch=ro_channel,
             style="const",
             freq=ro_frequency,
-            phase=3097210280,
+            phase=int(ro_pulse.phase),
             gain=ro_gain,
             length=ro_length,
         )

--- a/src/qibolab/runcards/rfsoc.yml
+++ b/src/qibolab/runcards/rfsoc.yml
@@ -6,27 +6,25 @@ qubits: [0]
 topology: # qubit - qubit connections
 -   [1]
 
-reps: 1024
-max_gain: 30000
-delay_before_readout: 50 # [ns]
-
-qubit_channel_map: [0, 1] # [readout, drive]
+qubit_channel_map: [[0, 1]] # [readout, drive]
 # TODO: Remove repetition because these channels are defined here
-# and in configs below
+# and in the config below
 
-hardware_config:
+config:
+    reps: 1024
+    max_gain: 30000
+    delay_before_readout: 50 # [ns]
+    # channel config
     #jpa_channel: 6
     resonator_channel: 0
     qubit_channel: 1
     #storage_channel: 0
-
-readout_config:
+    # resonator config
     f_res: 7271.25 # [MHz] (not used)
     resonator_phase: 3097210280 # (not used)
     adc_trig_offset: 200 # [Clock ticks]
     resonator_gain: 600 # (not used)
-
-qubit_config:
+    # qubit config
     pi_gain: 9000 # (not used)
     #pi2_gain: 9000 // 2
     f_ge: 8014.6 # [MHz] (not used)
@@ -47,15 +45,3 @@ native_gates:
                 frequency: 7_271_250_000
                 shape: Rectangular()
                 type: ro # readout
-
-characterization:
-    single_qubit:
-        0:
-            resonator_freq: 7824847574
-            qubit_freq: 5082293989
-            T1: 17744
-            T2: 8385
-            state0_voltage: 891
-            state1_voltage: 357
-            mean_gnd_states: (-5.543255134868772e-05+0.0008975930158821524j)
-            mean_exc_states: (0.0001446400604158933+0.0003369969077198778j)

--- a/src/qibolab/runcards/rfsoc.yml
+++ b/src/qibolab/runcards/rfsoc.yml
@@ -1,0 +1,61 @@
+nqubits: 1
+description: TODO
+
+qubits: [0]
+
+topology: # qubit - qubit connections
+-   [1]
+
+reps: 1024
+max_gain: 30000
+delay_before_readout: 50 # [ns]
+
+qubit_channel_map: [0, 1] # [readout, drive]
+# TODO: Remove repetition because these channels are defined here
+# and in configs below
+
+hardware_config:
+    #jpa_channel: 6
+    resonator_channel: 0
+    qubit_channel: 1
+    #storage_channel: 0
+
+readout_config:
+    f_res: 7271.25 # [MHz] (not used)
+    resonator_phase: 3097210280 # (not used)
+    adc_trig_offset: 200 # [Clock ticks]
+    resonator_gain: 600 # (not used)
+
+qubit_config:
+    pi_gain: 9000 # (not used)
+    #pi2_gain: 9000 // 2
+    f_ge: 8014.6 # [MHz] (not used)
+    relax_delay: 500_000 # [ns]
+
+native_gates:
+    single_qubit:
+        0: # qubit number
+            RX:
+                duration: 40
+                amplitude: 0.566
+                frequency: 8_014_600_000
+                shape: Drag(5, 0.05096)
+                type: qd # qubit drive
+            MZ:
+                duration: 3000
+                amplitude: 0.02
+                frequency: 7_271_250_000
+                shape: Rectangular()
+                type: ro # readout
+
+characterization:
+    single_qubit:
+        0:
+            resonator_freq: 7824847574
+            qubit_freq: 5082293989
+            T1: 17744
+            T2: 8385
+            state0_voltage: 891
+            state1_voltage: 357
+            mean_gnd_states: (-5.543255134868772e-05+0.0008975930158821524j)
+            mean_exc_states: (0.0001446400604158933+0.0003369969077198778j)


### PR DESCRIPTION
Implements a driver for the RFSoC device based on the [QICK](https://github.com/openquantumhardware/qick) libary. 

This is a quick implementation and very limited in features, containing almost only what is needed to perform Rabi oscillations. There will be big changes in the next days so I would suggest to not spend time going through the code yet.

The runcard contains the latest calibration from @JavierSerranoGarcia and I could perform Rabi oscillations using the following:
```py
import numpy as np
import matplotlib.pyplot as plt
from qibolab import Platform
from qibolab.pulses import PulseSequence

start = 10
stop = 800
step = 5

lengths = np.arange(start, stop, step)
results = []
for i, length in enumerate(lengths):
    qd_pulse = platform.create_RX_pulse(0, start=0)
    qd_pulse.duration = length
    ro_pulse = platform.create_MZ_pulse(0, start=length)

    sequence = PulseSequence()
    sequence.add(qd_pulse)
    sequence.add(ro_pulse)

    result = platform.execute_pulse_sequence(sequence)
    results.append(result)

results = np.array(results)
amp = np.abs(results[:, 0, 0, 0] + 1j * results[:, 1, 0, 0])

plt.figure(figsize=(10, 6))
plt.plot(lengths, amp, 'o-')
plt.title("Length Rabi Oscillation")
plt.xlabel("Drive length (ns)")
plt.ylabel("Amplitude (ADC level)")
plt.show()
```

![length_rabi](https://user-images.githubusercontent.com/35475381/201368702-1fbac1e1-5168-43b4-913f-269cfad5c15a.png)


Checklist:
- [ ] Fix the TODOs in the code.
- [ ] Implement possibility to execute multiple pulses with proper phases, shapes, start, etc.
- [ ] Fix output format.
- [ ] Move `soc` initialization to `platform.connect()`?
- [ ] Consider using `QickProgram` instead of `AveragerProgram`.
- [ ] Test all calibration routines.
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
