### PR TITLE
Use arbitrary queue names for qpu tests

### DIFF
--- a/.github/workflows/selfhosted.yml
+++ b/.github/workflows/selfhosted.yml
@@ -11,24 +11,26 @@ concurrency:
 
 jobs:
   prepare:
-    if: contains(github.event.pull_request.labels.*.name, 'run-on-tii1q') ||
-        contains(github.event.pull_request.labels.*.name, 'run-on-tii5q')
+    if: contains(join(github.event.pull_request.labels.*.name), 'run-on')
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - id: set-matrix
+        env:
+          LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
         run: |
           platforms="{\"platform\":["
           combined=""
-          if ${{ contains(github.event.pull_request.labels.*.name, 'run-on-tii1q') }}; then
-            platforms="${platforms}${combined:+,}\"tii1q\""
-            combined=${platforms}
-          fi
-          if ${{ contains(github.event.pull_request.labels.*.name, 'run-on-tii5q') }}; then
-            platforms="${platforms}${combined:+,}\"tii5q\""
-          fi
-          platforms="${platforms}]}"
+          shopt -s lastpipe
+          jq -c '.[]' <<< "$LABELS" | while read label; do
+              platform=(${label//-/ })
+              if [ ${platform[0]} == "\"run" ] && [ ${platform[1]} == "on" ]; then
+                platforms="${platforms}${combined:+,}\"${platform[2]}"
+                combined=${platforms}
+              fi
+          done
+          platforms+="]}"
           echo ${platforms}
           echo matrix="${platforms}" >> $GITHUB_OUTPUT
   build:


### PR DESCRIPTION
Generalizes the script that uses labels to submit qpu tests. Now any label of the form `run-on-*` will trigger a test that is submitted to the queue `*`, so that we don't need to update the code every time we change the queue structure, we just need to change the label names. @scarrazza let me know if you agree.

Checklist:
- [x] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
