### PR TITLE
Fix missing qubits from the acquisition results

### DIFF
--- a/src/qibolab/instruments/qblox.py
+++ b/src/qibolab/instruments/qblox.py
@@ -965,12 +965,15 @@ class ClusterQRM_RF(AbstractInstrument):
                     self.device.store_scope_acquisition(sequencer.number, "scope_acquisition")
                     scope_acquisition_raw_results = self.device.get_acquisitions(sequencer.number)["scope_acquisition"]
 
+        acquisition_results["demodulated_integrated_averaged"] = {}
+        acquisition_results["averaged_raw"] = {}
+        acquisition_results["averaged_demodulated_integrated"] = {}
+        acquisition_results["demodulated_integrated_binned"] = {}
+        acquisition_results["demodulated_integrated_classified_binned"] = {}
+        acquisition_results["probability"] = {}
         for port in self._output_ports_keys:
             for sequencer in self._sequencers[port]:
-
                 if not self.ports["i1"].hardware_demod_en:  # Software Demodulation
-                    acquisition_results["averaged_raw"] = {}
-                    acquisition_results["averaged_demodulated_integrated"] = {}
                     if len(sequencer.pulses.ro_pulses) == 1:
                         pulse = sequencer.pulses.ro_pulses[0]
 
@@ -1014,12 +1017,6 @@ class ClusterQRM_RF(AbstractInstrument):
                 else:  # Hardware Demodulation
                     binned_raw_results = self.device.get_acquisitions(sequencer.number)
 
-                    acquisition_results["demodulated_integrated_averaged"] = {}
-                    acquisition_results["averaged_raw"] = {}
-                    acquisition_results["averaged_demodulated_integrated"] = {}
-                    acquisition_results["demodulated_integrated_binned"] = {}
-                    acquisition_results["demodulated_integrated_classified_binned"] = {}
-                    acquisition_results["probability"] = {}
                     for pulse in sequencer.pulses.ro_pulses:
                         acquisition_name = pulse.serial
                         i, q = self._process_acquisition_results(

--- a/src/qibolab/platforms/multiqubit.py
+++ b/src/qibolab/platforms/multiqubit.py
@@ -45,8 +45,13 @@ class MultiqubitPlatform(AbstractPlatform):
             if "readout" in roles[name]:
                 if not instrument_pulses[name].is_empty:
                     if not instrument_pulses[name].ro_pulses.is_empty:
-                        acquisition_results.update(self.instruments[name].acquire())
-
+                        results = self.instruments[name].acquire()
+                        existing_keys = set(acquisition_results.keys()) & set(results.keys())
+                        for key, value in results.items():
+                            if key in existing_keys:
+                                acquisition_results[key].update(value)
+                            else:
+                                acquisition_results[key] = value
         return acquisition_results
 
     def measure_fidelity(self, qubits=None, nshots=None):


### PR DESCRIPTION
In the following
```py
from qibolab import Platform
from qibolab.pulses import Pulse, PulseSequence, ReadoutPulse

platform = Platform("qw5q_gold")

platform.connect()
platform.setup()
platform.start()

ro_pulse1 = platform.create_MZ_pulse(1, start=0)
ro_pulse2 = platform.create_MZ_pulse(2, start=0)
ro_pulse3 = platform.create_MZ_pulse(3, start=0)
sequence = PulseSequence()
sequence.add(ro_pulse1)
sequence.add(ro_pulse2)
sequence.add(ro_pulse3)

results = platform.execute_pulse_sequence(sequence, nshots=5000)

platform.stop()
platform.disconnect()
```
the results object is missing several outputs associated with qubits 1 and 2. For example
```
results["demodulated_integrated_binned"]
```
contains values for qubit 3 but not for 1 and 2. This PR should fix this issue. @aorgazf / @DavidSarlle / @maxhant please confirm.

This is a quick fix because this bug blocks the single shot measurements in #195. I strongly disagree with how the results are handled, because it follows the usual approach of nested dictionaries to define an interface, for which a Python object is usually more suitable.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
