### PR TITLE
Include pyvisa-py library in qibolab dependencies [tiiq]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
         "tiiq": [
             "qblox-instruments==0.6.1",
             "qcodes",
+            "pyvisa-py==0.5.3",
         ],
     },
     python_requires=">=3.8.0",


### PR DESCRIPTION
Hi,
Rohde & Schwarz oscillators are needed again, not for up/down conversion, but for biassing TWPAs.
Their drivers require pyvisa-py library, which must have been removed a while back unintentionally. 
This PR adds the installation of pyvisa-py version 0.5.3 back to TII system dependencies.

The installation has succeeded on a windows machine.
No documentation update required.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [x] Tests are passing. 
- [x] Coverage does not decrease.
- [x] Documentation is updated.
