### PR TITLE
Temporarily set multiqubit as default platform for multiple runcards

### DIFF
--- a/src/qibolab/platform.py
+++ b/src/qibolab/platform.py
@@ -10,18 +10,17 @@ def Platform(name, runcard=None):
     """
     if not runcard:
         from qibolab.paths import qibolab_folder
-
+        from os.path import exists
         runcard = qibolab_folder / "runcards" / f"{name}.yml"
+        if not exists(runcard):
+            from qibo.config import raise_error
+            raise_error(RuntimeError, f"Runcard {name} does not exist.")
 
-    if name == "tii1q" or name == "qw5q_gold" or name == "qili":
-        from qibolab.platforms.multiqubit import MultiqubitPlatform as Device
+    if name == "dummy":
+        from qibolab.platforms.dummy import DummyPlatform as Device
     elif name == "icarusq":
         from qibolab.platforms.icplatform import ICPlatform as Device
-    elif name == "dummy":
-        from qibolab.platforms.dummy import DummyPlatform as Device
     else:
-        from qibo.config import raise_error
-
-        raise_error(RuntimeError, f"Platform {name} is not supported.")
+        from qibolab.platforms.multiqubit import MultiqubitPlatform as Device
 
     return Device(name, runcard)

--- a/src/qibolab/platform.py
+++ b/src/qibolab/platform.py
@@ -9,11 +9,14 @@ def Platform(name, runcard=None):
         The plaform class.
     """
     if not runcard:
-        from qibolab.paths import qibolab_folder
         from os.path import exists
+
+        from qibolab.paths import qibolab_folder
+
         runcard = qibolab_folder / "runcards" / f"{name}.yml"
         if not exists(runcard):
             from qibo.config import raise_error
+
             raise_error(RuntimeError, f"Runcard {name} does not exist.")
 
     if name == "dummy":


### PR DESCRIPTION
Hi,
Currently we have multiple QPUs, each with its own runcard (qw5q_gold.yml, iqm5q.yml, etc.).
In qibocal action runcard, one can only specify the platform, but not the platform runcard.
When we want to use a new runcard, we used to modify platform.py to load any of these QPUs with multiqubit platform like this:
```python
def Platform(name, runcard=None):
    """..."""
    if not runcard:
        from qibolab.paths import qibolab_folder

        runcard = qibolab_folder / "runcards" / f"{name}.yml"

    if name == "tii1q" or name == "qw5q_gold" or name == "qili":  #<- HERE
        from qibolab.platforms.multiqubit import MultiqubitPlatform as Device
    elif name == "icarusq":
        from qibolab.platforms.icplatform import ICPlatform as Device
    elif name == "dummy":
```

To avoid having to do this and until qibocal suports platform and QPR runcards, I propose to default to multiqubit (qblox) platform.

Checklist:
- [x] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
