### PR TITLE
tii1q_b1 QPU runcard

### DIFF
--- a/src/qibolab/platform.py
+++ b/src/qibolab/platform.py
@@ -10,18 +10,17 @@ def Platform(name, runcard=None):
     """
     if not runcard:
         from qibolab.paths import qibolab_folder
-
+        from os.path import exists
         runcard = qibolab_folder / "runcards" / f"{name}.yml"
+        if not exists(runcard):
+            from qibo.config import raise_error
+            raise_error(RuntimeError, f"Runcard {name} does not exist.")
 
-    if name == "tii1q" or name == "qw5q_gold" or name == "qili":
-        from qibolab.platforms.multiqubit import MultiqubitPlatform as Device
+    if name == "dummy":
+        from qibolab.platforms.dummy import DummyPlatform as Device
     elif name == "icarusq":
         from qibolab.platforms.icplatform import ICPlatform as Device
-    elif name == "dummy":
-        from qibolab.platforms.dummy import DummyPlatform as Device
     else:
-        from qibo.config import raise_error
-
-        raise_error(RuntimeError, f"Platform {name} is not supported.")
+        from qibolab.platforms.multiqubit import MultiqubitPlatform as Device
 
     return Device(name, runcard)

--- a/src/qibolab/platform.py
+++ b/src/qibolab/platform.py
@@ -9,11 +9,14 @@ def Platform(name, runcard=None):
         The plaform class.
     """
     if not runcard:
-        from qibolab.paths import qibolab_folder
         from os.path import exists
+
+        from qibolab.paths import qibolab_folder
+
         runcard = qibolab_folder / "runcards" / f"{name}.yml"
         if not exists(runcard):
             from qibo.config import raise_error
+
             raise_error(RuntimeError, f"Runcard {name} does not exist.")
 
     if name == "dummy":

--- a/src/qibolab/runcards/tii1q_b1.yml
+++ b/src/qibolab/runcards/tii1q_b1.yml
@@ -111,5 +111,5 @@ characterization:
             T2: 5800
             state0_voltage: 0
             state1_voltage: 0
-            mean_gnd_states: (0+0j)
-            mean_exc_states: (0+0j)
+            mean_gnd_states: (-0.0012548976062530532-0.00023722554958475822j)
+            mean_exc_states: (-0.0004659510503175379+6.980508060576453e-06j)

--- a/src/qibolab/runcards/tii1q_b1.yml
+++ b/src/qibolab/runcards/tii1q_b1.yml
@@ -1,0 +1,115 @@
+nqubits: 1
+description: TII 1-qubit device (batch1) at XLD fridge, controlled with qblox cluster rf.
+
+settings:
+    hardware_avg: 1024
+    repetition_duration: 200_000
+    sampling_rate: 1_000_000_000
+
+qubits: [0]
+
+topology: # qubit - qubit connections
+-   [1]
+
+channels: ['L3-18_qd', 'L3-18_ro', 'L2-2']
+
+qubit_channel_map: # [ReadOut, QubitDrive, QubitFlux]
+    0: ['L3-18_ro', 'L3-18_qd', null]
+
+instruments:
+    cluster:
+        lib: qblox
+        class: Cluster
+        address: 192.168.0.20
+        roles: [other]
+        settings:
+            reference_clock_source      : internal                      # external or internal
+
+    qrm_rf:
+        lib: qblox
+        class: ClusterQRM_RF
+        address: 192.168.0.20:16
+        roles: [readout]
+        settings:
+            ports:
+                o1:
+                    attenuation                 : 48
+                    lo_enabled                  : true
+                    lo_frequency                : 7_351_405_000                    # (Hz) from 2e9 to 18e9
+                    gain                        : 0.3                           # for path0 and path1 -1.0<=v<=1.0
+                    hardware_mod_en             : false
+                i1:
+                    hardware_demod_en           : true
+
+            acquisition_hold_off        : 200
+            acquisition_duration        : 2000
+
+            classification_parameters:
+                2:
+                    rotation_angle: 345.208
+                    threshold: -0.000841
+
+            channel_port_map:  # Refrigerator Channel : Instrument port
+                'L3-18_ro': o1 # IQ Port = out0 & out1
+                'L2-2': i1
+
+    qcm_rf:
+        lib: qblox
+        class: ClusterQCM_RF
+        address: 192.168.0.20:12
+        roles: [control]
+        settings:
+            ports:
+                o1:
+                    attenuation                  : 0 # (dB)
+                    lo_enabled                   : true
+                    lo_frequency                 : 5_641_445_000 # (Hz) from 2e9 to 18e9
+                    gain                         : 0.266 # for path0 and path1 -1.0<=v<=1.0
+                    hardware_mod_en              : false
+                o2:
+                    attenuation                  : 60 # (dB)
+                    lo_enabled                   : false
+                    lo_frequency                 : 6_000_000_000 # (Hz) from 2e9 to 18e9
+                    gain                         : 0 # for path0 and path1 -1.0<=v<=1.0
+                    hardware_mod_en              : false
+
+            channel_port_map:
+                'L3-18_qd': o1 # IQ Port = out0 & out1
+                99: o2
+
+    # twpa_pump:
+    #     lib: rohde_schwarz
+    #     class: SGS100A
+    #     address: 192.168.0.37
+    #     roles: [other]
+    #     settings:
+    #         frequency: 6_837_500_000 # Hz
+    #         power: 0 # dBm
+
+native_gates:
+    single_qubit:
+        0: # qubit number
+            RX:
+                duration: 40                    # should be multiple of 4
+                amplitude: 0.8
+                frequency: -200_000_000          # difference in qubit frequency 
+                shape: Drag(5,-1.5)
+                type: qd # qubit drive
+            MZ:
+                duration: 2000
+                amplitude: 0.7
+                frequency: 20_000_000           # Difference in resonator frequency 
+                shape: Rectangular()
+                type: ro # readout
+
+characterization:
+    single_qubit:
+        0:
+            resonator_freq: 7_371_405_000 
+            qubit_freq: 5_441_445_000
+            T1: 22881
+            T2: 5800
+            state0_voltage: 0
+            state1_voltage: 0
+            mean_gnd_states: (0+0j)
+            mean_exc_states: (0+0j)

--- a/src/qibolab/runcards/tii1q_b1.yml
+++ b/src/qibolab/runcards/tii1q_b1.yml
@@ -77,14 +77,14 @@ instruments:
                 'L3-18_qd': o1 # IQ Port = out0 & out1
                 99: o2
 
-    # twpa_pump:
-    #     lib: rohde_schwarz
-    #     class: SGS100A
-    #     address: 192.168.0.37
-    #     roles: [other]
-    #     settings:
-    #         frequency: 6_837_500_000 # Hz
-    #         power: 0 # dBm
+    twpa_pump:
+        lib: rohde_schwarz
+        class: SGS100A
+        address: 192.168.0.37
+        roles: [other]
+        settings:
+            frequency: 6_837_500_000 # Hz
+            power: 0 # dBm
 
 native_gates:
     single_qubit:

--- a/src/qibolab/runcards/tii1q_b1.yml
+++ b/src/qibolab/runcards/tii1q_b1.yml
@@ -45,7 +45,7 @@ instruments:
             acquisition_duration        : 2000
 
             classification_parameters:
-                2:
+                0:
                     rotation_angle: 345.208
                     threshold: -0.000841
 

--- a/src/qibolab/runcards/tii1q_b1.yml
+++ b/src/qibolab/runcards/tii1q_b1.yml
@@ -92,20 +92,20 @@ native_gates:
             RX:
                 duration: 40                    # should be multiple of 4
                 amplitude: 0.8
-                frequency: -200_000_000          # difference in qubit frequency 
+                frequency: -200_000_000          # difference in qubit frequency
                 shape: Drag(5,-1.5)
                 type: qd # qubit drive
             MZ:
                 duration: 2000
                 amplitude: 0.7
-                frequency: 20_000_000           # Difference in resonator frequency 
+                frequency: 20_000_000           # Difference in resonator frequency
                 shape: Rectangular()
                 type: ro # readout
 
 characterization:
     single_qubit:
         0:
-            resonator_freq: 7_371_405_000 
+            resonator_freq: 7_371_405_000
             qubit_freq: 5_441_445_000
             T1: 22881
             T2: 5800


### PR DESCRIPTION
Dear All,
Please find a runcard for **tii1q_b1** qpu.
This processor belongs to the first batch fabricated by TII. It is installed at the XLD and controlled with Qblox Cluster and R&S local oscillator to drive the TWPA.

If you have not done it already, please ensure your environment has the latest version of pivisa-py and qblox-instruments 0.7.0:
```
pip install pyvisa-py
pip install qblox-instruments==0.7.0
```
The chip is installed in `reem2` node partition `tii1q_b1`.

My launching batch file looks like this:

```bash
#!/bin/bash

#SBATCH --job-name=qibocal_1q
#SBATCH --partition=tii1q_b1
#SBATCH --output=logs/latest_experiment_1q.log

qq ~/qibocal_1q.yml -o reports/$(date +'%Y%m%d')_latest_1q -f

```

Here are the fidelities measured with it:
![image](https://user-images.githubusercontent.com/55031026/208614555-a9572912-a61f-410a-9c89-9a6c95ceabc0.png)

Below some results obtained by @stavros11 :
```python
import qibo
from qibo import gates
from qibo.models import Circuit

qibo.set_backend("qibolab", platform="tii1q_b1")

c = Circuit(1)
c.add(gates.M(0))
result = c(nshots=5000)
print("Hardware frequencies:", result.frequencies())
# Hardware frequencies: Counter({'0': 4497, '1': 503})

c = Circuit(1)
c.add(gates.X(0))
c.add(gates.M(0))
result = c(nshots=5000)
print("Hardware frequencies:", result.frequencies())
# Hardware frequencies: Counter({'1': 4277, '0': 723})

c = Circuit(1)
c.add(gates.H(0))
c.add(gates.M(0))
result = c(nshots=5000)
print("Hardware frequencies:", result.frequencies())
# Hardware frequencies: Counter({'0': 2614, '1': 2386})
```



Checklist:
- [x] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
