### PR TITLE
Upload coverage from selfhosted

### DIFF
--- a/.github/workflows/selfhosted.yml
+++ b/.github/workflows/selfhosted.yml
@@ -76,5 +76,5 @@ jobs:
         message: |
           Run on QPU completed! :atom:
 
-          > *You can download the coverage report as an artifact, from the workflow summary page:* 
+          > *You can download the coverage report as an artifact, from the workflow summary page:*
           > ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/selfhosted.yml
+++ b/.github/workflows/selfhosted.yml
@@ -61,7 +61,10 @@ jobs:
       run: |
         sed -i 's/$PLATFORM/'${{ matrix.platform }}'/' qputests.sh
         srun -p ${{ matrix.platform }} qputests.sh
+        mkdir coverage
+        mv coverage.xml coverage/
+        mv htmlcov coverage/
     - uses: actions/upload-artifact@v3
       with:
         name: coverage-from-self-hosted
-        path: coverage.xml
+        path: coverage/

--- a/.github/workflows/selfhosted.yml
+++ b/.github/workflows/selfhosted.yml
@@ -59,4 +59,25 @@ jobs:
         pip install .[tiiq]
     - name: Test ${{ matrix.platform }}
       run: |
-        srun -p ${{ matrix.platform }} pytest -m qpu --no-cov --platforms ${{ matrix.platform }}
+        # create script for slurm
+        platform=${{ matrix.platform }}
+        echo \#\!/bin/bash >> ci_tests
+        echo >> ci_tests
+        echo "mkdir /tmp/qibolab" >> ci_tests
+        echo "ln -sr src/qibolab/tests /tmp/qibolab" >> ci_tests
+        echo "cd /tmp/qibolab" >> ci_tests
+        echo "pytest --cov=qibolab --cov-report=xml --platform $platform -rx" >> ci_tests
+        echo "cd -" >> ci_tests
+        echo "mv /tmp/qibolab/coverage.xml ." >> ci_tests
+        echo "rm -r /tmp/qibolab/" >> ci_tests
+        # execute script in the queue
+        chmod +x ci_tests
+        srun -p ${{ matrix.platform }} ci_tests
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v2
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: ./coverage.xml
+        flags: unittests
+        name: codecov-umbrella
+        fail_ci_if_error: true

--- a/.github/workflows/selfhosted.yml
+++ b/.github/workflows/selfhosted.yml
@@ -68,3 +68,13 @@ jobs:
       with:
         name: coverage-from-self-hosted
         path: coverage/
+    - name: Notify the Pull Request
+      uses: unsplash/comment-on-pr@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        msg: |
+          Run on QPU completed! :atom:
+
+          > *You can download the coverage report as an artifact, from the workflow summary page:* 
+          > ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/selfhosted.yml
+++ b/.github/workflows/selfhosted.yml
@@ -74,7 +74,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         message: |
-          Run on QPU `{{ $matrix.platform }}` completed! :atom:
+          Run on QPU `${{ matrix.platform }}` completed! :atom:
 
           > *You can download the coverage report as an artifact, from the workflow summary page:*
           > ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/selfhosted.yml
+++ b/.github/workflows/selfhosted.yml
@@ -69,11 +69,9 @@ jobs:
         name: coverage-from-self-hosted
         path: coverage/
     - name: Notify the Pull Request
-      uses: unsplash/comment-on-pr@master
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: thollander/actions-comment-pull-request@v2
       with:
-        msg: |
+        message: |
           Run on QPU completed! :atom:
 
           > *You can download the coverage report as an artifact, from the workflow summary page:*

--- a/.github/workflows/selfhosted.yml
+++ b/.github/workflows/selfhosted.yml
@@ -43,9 +43,9 @@ jobs:
     - name: Cleanup workspace manually
       run: |
         rm -rf _work/*
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
     - name: Install package
@@ -70,9 +70,11 @@ jobs:
         path: coverage/
     - name: Notify the Pull Request
       uses: thollander/actions-comment-pull-request@v2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         message: |
           Run on QPU completed! :atom:
 
-          > *You can download the coverage report as an artifact, from the workflow summary page:*
+          > *You can download the coverage report as an artifact, from the workflow summary page:* 
           > ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/selfhosted.yml
+++ b/.github/workflows/selfhosted.yml
@@ -61,5 +61,7 @@ jobs:
       run: |
         sed -i 's/$PLATFORM/'${{ matrix.platform }}'/' qputests.sh
         srun -p ${{ matrix.platform }} qputests.sh
-        # TODO: Find a better way to upload coverage
-        cat coverage.xml
+- uses: actions/upload-artifact@v3
+  with:
+    name: coverage-from-self-hosted
+    path: coverage.xml

--- a/.github/workflows/selfhosted.yml
+++ b/.github/workflows/selfhosted.yml
@@ -76,5 +76,5 @@ jobs:
         msg: |
           Run on QPU completed! :atom:
 
-          > *You can download the coverage report as an artifact, from the workflow summary page:* 
+          > *You can download the coverage report as an artifact, from the workflow summary page:*
           > ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/selfhosted.yml
+++ b/.github/workflows/selfhosted.yml
@@ -59,7 +59,7 @@ jobs:
         pip install .[tiiq]
     - name: Test ${{ matrix.platform }}
       run: |
-        sed -i 's/$PLATFORM/'${{ matrix.platform }}'/' slurmjob.sh
-        srun -p ${{ matrix.platform }} slurmjob.sh
+        sed -i 's/$PLATFORM/'${{ matrix.platform }}'/' qputests.sh
+        srun -p ${{ matrix.platform }} qputests.sh
         # TODO: Find a better way to upload coverage
         cat coverage.xml

--- a/.github/workflows/selfhosted.yml
+++ b/.github/workflows/selfhosted.yml
@@ -61,7 +61,7 @@ jobs:
       run: |
         sed -i 's/$PLATFORM/'${{ matrix.platform }}'/' qputests.sh
         srun -p ${{ matrix.platform }} qputests.sh
-- uses: actions/upload-artifact@v3
-  with:
-    name: coverage-from-self-hosted
-    path: coverage.xml
+    - uses: actions/upload-artifact@v3
+      with:
+        name: coverage-from-self-hosted
+        path: coverage.xml

--- a/.github/workflows/selfhosted.yml
+++ b/.github/workflows/selfhosted.yml
@@ -74,7 +74,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         message: |
-          Run on QPU completed! :atom:
+          Run on QPU `{{ $matrix.platform }}` completed! :atom:
 
           > *You can download the coverage report as an artifact, from the workflow summary page:*
           > ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/selfhosted.yml
+++ b/.github/workflows/selfhosted.yml
@@ -59,25 +59,7 @@ jobs:
         pip install .[tiiq]
     - name: Test ${{ matrix.platform }}
       run: |
-        # create script for slurm
-        platform=${{ matrix.platform }}
-        echo \#\!/bin/bash >> ci_tests
-        echo >> ci_tests
-        echo "mkdir /tmp/qibolab" >> ci_tests
-        echo "ln -sr src/qibolab/tests /tmp/qibolab" >> ci_tests
-        echo "cd /tmp/qibolab" >> ci_tests
-        echo "pytest --cov=qibolab --cov-report=xml --platform $platform -rx" >> ci_tests
-        echo "cd -" >> ci_tests
-        echo "mv /tmp/qibolab/coverage.xml ." >> ci_tests
-        echo "rm -r /tmp/qibolab/" >> ci_tests
-        # execute script in the queue
-        chmod +x ci_tests
-        srun -p ${{ matrix.platform }} ci_tests
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v2
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage.xml
-        flags: unittests
-        name: codecov-umbrella
-        fail_ci_if_error: true
+        sed -i 's/$PLATFORM/'${{ matrix.platform }}'/' slurmjob.sh
+        srun -p ${{ matrix.platform }} slurmjob.sh
+        # TODO: Find a better way to upload coverage
+        cat coverage.xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,4 +6,9 @@ disable = ["E1123", "E1120"]
 [tool.pytest.ini_options]
 testpaths = ['tests/']
 markers = ["qpu: mark tests that require qpu"]
-addopts = ['--cov=qibolab', '--cov-report=xml', '-m not qpu']
+addopts = [
+  '--cov=qibolab',
+  '--cov-report=xml',
+  '--cov-report=html',
+  '-m not qpu',
+]

--- a/qputests.sh
+++ b/qputests.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Script for running the selfhosted tests on QPUs directly from GitHub
+# Tests need to be copied to /tmp/ because coverage does not work with NFS
+
 cp -r tests /tmp/
 cd /tmp/tests
 pytest --cov=qibolab --cov-report=xml -m qpu --platforms $PLATFORM

--- a/qputests.sh
+++ b/qputests.sh
@@ -4,11 +4,10 @@
 # Tests need to be copied to /tmp/ because coverage does not work with NFS
 
 cp -r tests /tmp/
+cp pyproject.toml /tmp/
 cd /tmp/tests
-pytest --cov=qibolab --cov-report=xml -m qpu --platforms $PLATFORM
+pytest -m qpu --platforms $PLATFORM
 cd -
 mv /tmp/tests/coverage.xml .
-ls /tmp/tests/
 mv /tmp/tests/htmlcov .
-ls
 rm -r /tmp/tests

--- a/qputests.sh
+++ b/qputests.sh
@@ -8,4 +8,5 @@ cd /tmp/tests
 pytest --cov=qibolab --cov-report=xml -m qpu --platforms $PLATFORM
 cd -
 mv /tmp/tests/coverage.xml .
+mv /tmp/tests/htmlcov .
 rm -r /tmp/tests

--- a/qputests.sh
+++ b/qputests.sh
@@ -8,5 +8,7 @@ cd /tmp/tests
 pytest --cov=qibolab --cov-report=xml -m qpu --platforms $PLATFORM
 cd -
 mv /tmp/tests/coverage.xml .
+ls /tmp/tests/
 mv /tmp/tests/htmlcov .
+ls
 rm -r /tmp/tests

--- a/slurmjob.sh
+++ b/slurmjob.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+cp -r tests /tmp/
+cd /tmp/tests
+pytest --cov=qibolab --cov-report=xml -m qpu --platforms $PLATFORM
+cd -
+mv /tmp/tests/coverage.xml .
+rm -r /tmp/tests


### PR DESCRIPTION
Final implementation of #265 with the commits squashed to one to clean history. I think this should work but I still need to check how the coverage is logged in the website.

It appears that the coverage is increased by 13% since parts of the instrument code are now included. However I think the coverage of the test files is not logged properly because I am using symbolic links to put them in the /tmp/ directory.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
