### PR TITLE
Fix initialisation issue

### DIFF
--- a/src/qibolab/instruments/qblox.py
+++ b/src/qibolab/instruments/qblox.py
@@ -607,7 +607,7 @@ class ClusterQRM_RF(AbstractInstrument):
             self.acquisition_hold_off = kwargs["acquisition_hold_off"]
             self.acquisition_duration = kwargs["acquisition_duration"]
 
-            self._last_pulsequence_hash= 0
+            self._last_pulsequence_hash = 0
 
         else:
             raise Exception("The instrument cannot be set up, there is no connection")
@@ -1246,7 +1246,7 @@ class ClusterQRM_RF(AbstractInstrument):
                         # DEBUG: QRM Plot Acquisition_results
                         # from qibolab.debug.debug import plot_acquisition_results
                         # plot_acquisition_results(acquisition_results, pulse, savefig_filename='acquisition_results.png')
-        
+
         return acquisition_results
 
     def _process_acquisition_results(self, acquisition_results, readout_pulse: Pulse, demodulate=True):
@@ -1667,8 +1667,8 @@ class ClusterQCM_RF(AbstractInstrument):
             self.ports["o2"].hardware_mod_en = kwargs["ports"]["o2"]["hardware_mod_en"]  # Default after reboot = False
             self.ports["o2"].nco_freq = 0
             self.ports["o2"].nco_phase_offs = 0
-            
-            self._last_pulsequence_hash= 0
+
+            self._last_pulsequence_hash = 0
         else:
             raise Exception("The instrument cannot be set up, there is no connection")
 
@@ -2382,8 +2382,8 @@ class ClusterQCM(AbstractInstrument):
                 ]  # Default after reboot = False
                 self.ports[port].nco_freq = 0  # Default after reboot = 1
                 self.ports[port].nco_phase_offs = 0  # Default after reboot = 1
-            
-            self._last_pulsequence_hash= 0
+
+            self._last_pulsequence_hash = 0
         else:
             raise Exception("The instrument cannot be set up, there is no connection")
 

--- a/src/qibolab/instruments/qblox.py
+++ b/src/qibolab/instruments/qblox.py
@@ -607,6 +607,8 @@ class ClusterQRM_RF(AbstractInstrument):
             self.acquisition_hold_off = kwargs["acquisition_hold_off"]
             self.acquisition_duration = kwargs["acquisition_duration"]
 
+            self._last_pulsequence_hash= 0
+
         else:
             raise Exception("The instrument cannot be set up, there is no connection")
 
@@ -987,10 +989,6 @@ class ClusterQRM_RF(AbstractInstrument):
         # Start used sequencers
         for sequencer_number in self._used_sequencers_numbers:
             self.device.start_sequencer(sequencer_number)
-            # DEBUG sync_en
-            # print(
-            #     f"device: {self.name}, sequencer: {sequencer_number}, sync_en: {self.device.sequencers[sequencer_number].get('sync_en')}"
-            # )
 
     def acquire(self):
         """Retrieves the readout results.
@@ -1245,6 +1243,10 @@ class ClusterQRM_RF(AbstractInstrument):
                         # DEBUG: QRM Plot Incomming Pulses
                         # import qibolab.instruments.debug.incomming_pulse_plotting as pp
                         # pp.plot(raw_results)
+                        # DEBUG: QRM Plot Acquisition_results
+                        # from qibolab.debug.debug import plot_acquisition_results
+                        # plot_acquisition_results(acquisition_results, pulse, savefig_filename='acquisition_results.png')
+        
         return acquisition_results
 
     def _process_acquisition_results(self, acquisition_results, readout_pulse: Pulse, demodulate=True):
@@ -1486,7 +1488,7 @@ class ClusterQCM_RF(AbstractInstrument):
                 )()
 
                 self.ports["o2"] = type(
-                    f"port_o1",
+                    f"port_o2",
                     (),
                     {
                         "attenuation": self.property_wrapper("out1_att"),
@@ -1653,8 +1655,8 @@ class ClusterQCM_RF(AbstractInstrument):
             ]  # Default after reboot = 6_000_000_000
             self.ports["o1"].gain = kwargs["ports"]["o1"]["gain"]  # Default after reboot = 1
             self.ports["o1"].hardware_mod_en = kwargs["ports"]["o1"]["hardware_mod_en"]  # Default after reboot = False
-            self.ports["o1"].nco_freq = 0  # Default after reboot = 1
-            self.ports["o1"].nco_phase_offs = 0  # Default after reboot = 1
+            self.ports["o1"].nco_freq = 0
+            self.ports["o1"].nco_phase_offs = 0
 
             self.ports["o2"].attenuation = kwargs["ports"]["o2"]["attenuation"]
             self.ports["o2"].lo_enabled = kwargs["ports"]["o2"]["lo_enabled"]  # Default after reboot = True
@@ -1663,9 +1665,10 @@ class ClusterQCM_RF(AbstractInstrument):
             ]  # Default after reboot = 6_000_000_000
             self.ports["o2"].gain = kwargs["ports"]["o2"]["gain"]  # Default after reboot = 1
             self.ports["o2"].hardware_mod_en = kwargs["ports"]["o2"]["hardware_mod_en"]  # Default after reboot = False
-            self.ports["o2"].nco_freq = 0  # Default after reboot = 1
-            self.ports["o2"].nco_phase_offs = 0  # Default after reboot = 1
-
+            self.ports["o2"].nco_freq = 0
+            self.ports["o2"].nco_phase_offs = 0
+            
+            self._last_pulsequence_hash= 0
         else:
             raise Exception("The instrument cannot be set up, there is no connection")
 
@@ -2379,7 +2382,8 @@ class ClusterQCM(AbstractInstrument):
                 ]  # Default after reboot = False
                 self.ports[port].nco_freq = 0  # Default after reboot = 1
                 self.ports[port].nco_phase_offs = 0  # Default after reboot = 1
-
+            
+            self._last_pulsequence_hash= 0
         else:
             raise Exception("The instrument cannot be set up, there is no connection")
 


### PR DESCRIPTION
Hi,
This PR fixes a recently found issue that manifested in certain (not very common) scenarios, when executing multiple calibration actions in qibocal.
The driver initialises the `noc_freq` to 0 at setup and it is then set during the first execution.
Subsequent calibration routines were calling `platform.reload_settings()` (which was resetting the `nco_freq`) to 0, however, if the sequence to be played was the same as the one in the last calibration routine, the driver would used the cached values and skipped setting .

To fix it, on every setup, the pulse sequence hash is cleared (forcing a reevaluation).

The bug can be reproduced with the following action runcard:
```yaml
platform: qblox

runcard: qibolab/src/qibolab/runcards/tii1q_b1.yml
qubits: [0]

format: csv

actions:
  resonator_spectroscopy: # narrow
    lowres_width: 10_000_000
    lowres_step: 500_000
    highres_width: 1_000_000
    highres_step: 50_000
    precision_width: 1_000_000
    precision_step: 50_000
    software_averages: 1
    points: 5

  resonator_punchout:
    freq_width: 10_000_000
    freq_step: 200_000
    min_att: 2
    max_att: 50
    step_att: 2
    software_averages: 1
    points: 5
```
You will notice that the punchout routine does not display any resonances.
![image](https://user-images.githubusercontent.com/55031026/210547522-6a0d93e2-20dc-4ecc-a118-c6a5c16db139.png)

runing the punchout alone renders the expected results:
```yaml
platform: qblox

runcard: qibolab/src/qibolab/runcards/tii1q_b1.yml
qubits: [0]

format: csv

actions:
  resonator_punchout:
    freq_width: 10_000_000
    freq_step: 200_000
    min_att: 2
    max_att: 50
    step_att: 2
    software_averages: 1
    points: 5
```
![image](https://user-images.githubusercontent.com/55031026/210549167-ef75e586-87d2-4445-8ad0-1d369686d62c.png)


Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
