### PR TITLE
Update runcards qubit_channel_map

### DIFF
--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -28,7 +28,7 @@ jobs:
         pylint src -E -d E1123,E1120
     - name: Test with pytest core
       run: |
-        pytest src/qibolab --cov=qibolab --cov-report=xml --pyargs qibolab -m "not qpu" --platforms tii1q,qw5q_gold
+        pytest src/qibolab --cov=qibolab --cov-report=xml --pyargs qibolab -m "not qpu" --platforms tii1q_b1,qw5q_gold
     - name: Upload coverage to Codecov
       if: startsWith(matrix.os, 'ubuntu')
       uses: codecov/codecov-action@v2

--- a/src/qibolab/runcards/dummy.yml
+++ b/src/qibolab/runcards/dummy.yml
@@ -15,8 +15,8 @@ topology: null
 
 channels: [1, 2, 3]
 
-qubit_channel_map: # [ReadOut, QubitDrive, QubitFlux]
-    0: [2, 1, null]
+qubit_channel_map: # [ReadOut, QubitDrive, QubitFlux, QubitBias]
+    0: [2, 1, null, null]
 
 instruments: null
 

--- a/src/qibolab/runcards/multiqubit_icarusq.yml
+++ b/src/qibolab/runcards/multiqubit_icarusq.yml
@@ -15,8 +15,8 @@ topology: # qubit - qubit connections
 
 channels: [1_ro, 1_qb]
 
-qubit_channel_map: # [ReadOut, QubitDrive, QubitFlux]
-    0: [1_ro, 1_qb, 99]
+qubit_channel_map: # [ReadOut, QubitDrive, QubitFlux, QubitBias]
+    0: [1_ro, 1_qb, 99, 99]
 
 instruments:
     awg:

--- a/src/qibolab/runcards/multiqubit_icarusqfpga.yml
+++ b/src/qibolab/runcards/multiqubit_icarusqfpga.yml
@@ -14,8 +14,8 @@ topology: # qubit - qubit connections
 
 channels: [1_ro, 1_qb]
 
-qubit_channel_map: # [ReadOut, QubitDrive, QubitFlux]
-    0: [1_ro, 1_qb, 99]
+qubit_channel_map: # [ReadOut, QubitDrive, QubitFlux, QubitBias]
+    0: [1_ro, 1_qb, 99, 99]
 
 instruments:
     fpga1:

--- a/src/qibolab/runcards/qili.yml
+++ b/src/qibolab/runcards/qili.yml
@@ -13,8 +13,8 @@ topology: # qubit - qubit connections
 
 channels: [1, 2, 3]
 
-qubit_channel_map: # [ReadOut, QubitDrive, QubitFlux]
-    0: [2, 1, null]
+qubit_channel_map: # [ReadOut, QubitDrive, QubitFlux, QubitBias]
+    0: [2, 1, null, null]
 
 instruments:
     cluster:

--- a/src/qibolab/runcards/tii1q_b1.yml
+++ b/src/qibolab/runcards/tii1q_b1.yml
@@ -11,10 +11,10 @@ qubits: [0]
 topology: # qubit - qubit connections
 -   [1]
 
-channels: ['L3-18_qd', 'L3-18_ro', 'L2-2']
+channels: [L3-18_qd, L3-18_ro, L2-2]
 
-qubit_channel_map: # [ReadOut, QubitDrive, QubitFlux]
-    0: ['L3-18_ro', 'L3-18_qd', null]
+qubit_channel_map: # [ReadOut, QubitDrive, QubitFlux, QubitBias]
+    0: [L3-18_ro, L3-18_qd, null, null]
 
 instruments:
     cluster:
@@ -50,8 +50,8 @@ instruments:
                     threshold: -0.000841
 
             channel_port_map:  # Refrigerator Channel : Instrument port
-                'L3-18_ro': o1 # IQ Port = out0 & out1
-                'L2-2': i1
+                L3-18_ro: o1 # IQ Port = out0 & out1
+                L2-2: i1
 
     qcm_rf:
         lib: qblox
@@ -74,7 +74,7 @@ instruments:
                     hardware_mod_en              : false
 
             channel_port_map:
-                'L3-18_qd': o1 # IQ Port = out0 & out1
+                L3-18_qd: o1 # IQ Port = out0 & out1
                 99: o2
 
     twpa_pump:

--- a/src/qibolab/runcards/tii1q_b4_200U.yml
+++ b/src/qibolab/runcards/tii1q_b4_200U.yml
@@ -13,8 +13,8 @@ topology: # qubit - qubit connections
 
 channels: ['W4_qd', 'W4_ro', 'V2']
 
-qubit_channel_map: # [ReadOut, QubitDrive, QubitFlux]
-    0: ['W4_ro', 'W4_qd', null]
+qubit_channel_map: # [ReadOut, QubitDrive, QubitFlux, QubitBias]
+    0: ['W4_ro', 'W4_qd', null, null]
 
 instruments:
     cluster:


### PR DESCRIPTION
Hi,
This PR updates all runcards `qubit_channel_map` setting in line with the changes introduced in PR #242.
In that PR a new role of instrument was introduced: `bias` so the `qubit_channel_map` needs to be updated so that, for each qubit, it specifies the biassing channel.
Please note that for non-fluxable qubits that QubitFlux and QubitBias channels can be set to null:

```python
qubit_channel_map: # [ReadOut, QubitDrive, QubitFlux, QubitBias]
    0: [1_ro, 1_qb, null, null]
```
I have labelled this PR as urgent as without it, `tii1q_b1` (our current chip in production) does not work (it should have been updated in PR #242)
Checklist:
- [ ] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
