### PR TITLE
Fix minor bug in loading the platform native two-qubit gates

### DIFF
--- a/src/qibolab/platforms/abstract.py
+++ b/src/qibolab/platforms/abstract.py
@@ -108,7 +108,7 @@ class AbstractPlatform(ABC):
         # Load two qubit Native Gates, if multiqubit platform
         if "two_qubit" in self.native_gates.keys():
             for pairs, gates in self.native_gates["two_qubit"].items():
-                self.two_qubit_natives &= set(gates.keys())
+                self.two_qubit_natives |= set(gates.keys())
         else:
             self.two_qubit_natives = ["CZ"]
 


### PR DESCRIPTION
Fixes a minor bug in loading the platform native two-qubit gates.

```python
        if "two_qubit" in self.native_gates.keys():
            for pairs, gates in self.native_gates["two_qubit"].items():
                self.two_qubit_natives |= set(gates.keys())
```

Checklist:
- [x] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
