### PR TITLE
Annotations are not comments

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,1 +1,2 @@
-comment: false
+github_checks:
+  annotations: false


### PR DESCRIPTION
Another chapter in the unsuccessful saga about the fight against Codecov noise...

Here the reference:
https://docs.codecov.com/docs/github-checks#disabling-github-checks-patch-annotations-via-yaml

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
