### PR TITLE
Fix bug in `ExecutionResults`

### DIFF
--- a/src/qibolab/result.py
+++ b/src/qibolab/result.py
@@ -101,7 +101,7 @@ class ExecutionResults:
         """Perform average over i and q"""
         return AveragedResults(self.array.i.mean(), self.array.q.mean())
 
-    def to_dict(self, average=False):
+    def to_dict(self, average=True):
         """Serialize output in dict.
         Args:
             average (bool): If `True` returns a dictionary of the form


### PR DESCRIPTION
This PR fixes a bug in `ExecutionResults` which was causing qibocal main to not work with the current main of qibolab.
This could require some changes in qiboteam/qibocal#195. I think that it is important to merge this now if we planning to release both qibocal and qibolab shortly.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
