### PR TITLE
Move `DummyPlatform` to `DummyInstrument`

### DIFF
--- a/src/qibolab/instruments/dummy.py
+++ b/src/qibolab/instruments/dummy.py
@@ -108,6 +108,7 @@ class DummyInstrument(AbstractInstrument):
             )
             if len(sweepers) > 1:
                 self._sweep_recursion(
+                    qubits,
                     sequence,
                     original_sequence,
                     *sweepers[1:],
@@ -185,8 +186,8 @@ class DummyInstrument(AbstractInstrument):
         if sweeper.qubits is not None:
             for qubit in sweeper.qubits:
                 if sweeper.parameter is Parameter.attenuation:
-                    self.set_attenuation(qubit, value)
+                    qubit.readout.attenuation = value
                 elif sweeper.parameter is Parameter.gain:
-                    self.set_gain(qubit, value)
+                    qubit.drive.gain = value
                 elif sweeper.parameter is Parameter.bias:
-                    self.set_bias(qubit, value)
+                    qubit.flux.offset = float(value)

--- a/src/qibolab/instruments/dummy.py
+++ b/src/qibolab/instruments/dummy.py
@@ -169,9 +169,6 @@ class DummyInstrument(AbstractInstrument):
                         value += qubits[pulses[pulse].qubit].drive_frequency
                     setattr(pulses[pulse], sweeper.parameter.name, value)
                 elif sweeper.parameter is Parameter.amplitude:
-                    # if pulses[pulse].type is PulseType.READOUT:
-                    #    current_amplitude = self.native_gates["single_qubit"][pulses[pulse].qubit]["MZ"]["amplitude"]
-                    # else:
                     current_amplitude = pulses[pulse].amplitude
                     setattr(pulses[pulse], sweeper.parameter.name, float(current_amplitude * value))
                 else:

--- a/src/qibolab/instruments/dummy.py
+++ b/src/qibolab/instruments/dummy.py
@@ -4,49 +4,41 @@ import time
 import numpy as np
 from qibo.config import log, raise_error
 
-from qibolab.platforms.abstract import AbstractPlatform
+from qibolab.instruments.abstract import AbstractInstrument
 from qibolab.pulses import PulseSequence, PulseType
 from qibolab.result import ExecutionResults
 from qibolab.sweeper import Parameter
 
 
-class DummyPlatform(AbstractPlatform):
-    """Dummy platform that returns random voltage values.
+class DummyInstrument(AbstractInstrument):
+    """Dummy instrument that returns random voltage values.
 
     Useful for testing code without requiring access to hardware.
 
     Args:
-        name (str): name of the platform.
+        name (str): name of the instrument.
+        address (int): address to connect to the instrument.
+            Not used since the instrument is dummy, it only
+            exists to keep the same interface with other
+            instruments.
     """
 
-    def __init__(self, name, runcard):
-        super().__init__(name, runcard)
-
     def connect(self):
-        log.info("Connecting to dummy platform.")
+        log.info("Connecting to dummy instrument.")
 
-    def setup(self):
-        log.info("Setting up dummy platform.")
+    def setup(self, *args, **kwargs):
+        log.info("Setting up dummy instrument.")
 
     def start(self):
-        log.info("Starting dummy platform.")
+        log.info("Starting dummy instrument.")
 
     def stop(self):
-        log.info("Stopping dummy platform.")
+        log.info("Stopping dummy instrument.")
 
     def disconnect(self):
-        log.info("Disconnecting dummy platform.")
+        log.info("Disconnecting dummy instrument.")
 
-    def to_sequence(self, sequence, gate):  # pragma: no cover
-        raise_error(NotImplementedError)
-
-    def execute_pulse_sequence(self, sequence, nshots=None, relaxation_time=None):
-        if relaxation_time is None:
-            relaxation_time = self.settings.get("sleep_time")
-
-        if nshots is None:
-            nshots = self.settings["settings"]["hardware_avg"]
-
+    def play(self, qubits, sequence, nshots, relaxation_time):
         time.sleep(relaxation_time)
 
         ro_pulses = {pulse.qubit: pulse.serial for pulse in sequence.ro_pulses}
@@ -56,29 +48,10 @@ class DummyPlatform(AbstractPlatform):
             i = np.random.rand(nshots)
             q = np.random.rand(nshots)
             shots = np.random.rand(nshots)
-            results[qubit] = ExecutionResults.from_components(i, q, shots)
-            results[serial] = copy.copy(results[qubit])
+            results[qubit] = results[serial] = ExecutionResults.from_components(i, q, shots)
         return results
 
-    def set_attenuation(self, qubit, att):
-        """Empty since a dummy platform is not connected to any instrument."""
-
-    def set_bias(self, qubit, bias):
-        """Empty since a dummy platform is not connected to any instrument."""
-
-    def set_gain(self, qubit, gain):
-        """Empty since a dummy platform is not connected to any instrument."""
-
-    def get_attenuation(self, qubit):
-        """Empty since a dummy platform is not connected to any instrument."""
-
-    def get_bias(self, qubit):
-        """Empty since a dummy platform is not connected to any instrument."""
-
-    def get_gain(self, qubit):
-        """Empty since a dummy platform is not connected to any instrument."""
-
-    def sweep(self, sequence, *sweepers, nshots=1024, average=True, relaxation_time=None):
+    def sweep(self, qubits, sequence, *sweepers, nshots=1024, average=True, relaxation_time=None):
         results = {}
         sweeper_pulses = {}
 
@@ -96,6 +69,7 @@ class DummyPlatform(AbstractPlatform):
 
         # perform sweeping recursively
         self._sweep_recursion(
+            qubits,
             copy_sequence,
             copy.deepcopy(sequence),
             *sweepers,
@@ -110,6 +84,7 @@ class DummyPlatform(AbstractPlatform):
 
     def _sweep_recursion(
         self,
+        qubits,
         sequence,
         original_sequence,
         *sweepers,
@@ -129,7 +104,7 @@ class DummyPlatform(AbstractPlatform):
         # perform sweep recursively
         for value in sweeper.values:
             self._update_pulse_sequence_parameters(
-                sweeper, sweeper_pulses, original_sequence, map_original_shifted, value
+                qubits, sweeper, sweeper_pulses, original_sequence, map_original_shifted, value
             )
             if len(sweepers) > 1:
                 self._sweep_recursion(
@@ -145,7 +120,7 @@ class DummyPlatform(AbstractPlatform):
                 )
             else:
                 new_sequence = copy.deepcopy(sequence)
-                result = self.execute_pulse_sequence(new_sequence, nshots)
+                result = self.play(qubits, new_sequence, nshots, relaxation_time)
                 # colllect result and append to original pulse
                 for original_pulse, new_serial in map_original_shifted.items():
                     acquisition = result[new_serial].compute_average() if average else result[new_serial]
@@ -180,7 +155,7 @@ class DummyPlatform(AbstractPlatform):
                 setattr(pulses[pulse], sweeper.parameter.name, original_value[pulse])
 
     def _update_pulse_sequence_parameters(
-        self, sweeper, sweeper_pulses, original_sequence, map_original_shifted, value
+        self, qubits, sweeper, sweeper_pulses, original_sequence, map_original_shifted, value
     ):
         """Helper method for _sweep_recursion"""
         if sweeper.pulses is not None:
@@ -188,15 +163,15 @@ class DummyPlatform(AbstractPlatform):
             for pulse in pulses:
                 if sweeper.parameter is Parameter.frequency:
                     if pulses[pulse].type is PulseType.READOUT:
-                        value += self.qubits[pulses[pulse].qubit].readout_frequency
+                        value += qubits[pulses[pulse].qubit].readout_frequency
                     else:
-                        value += self.qubits[pulses[pulse].qubit].drive_frequency
+                        value += qubits[pulses[pulse].qubit].drive_frequency
                     setattr(pulses[pulse], sweeper.parameter.name, value)
                 elif sweeper.parameter is Parameter.amplitude:
-                    if pulses[pulse].type is PulseType.READOUT:
-                        current_amplitude = self.native_gates["single_qubit"][pulses[pulse].qubit]["MZ"]["amplitude"]
-                    else:
-                        current_amplitude = self.native_gates["single_qubit"][pulses[pulse].qubit]["RX"]["amplitude"]
+                    # if pulses[pulse].type is PulseType.READOUT:
+                    #    current_amplitude = self.native_gates["single_qubit"][pulses[pulse].qubit]["MZ"]["amplitude"]
+                    # else:
+                    current_amplitude = pulses[pulse].amplitude
                     setattr(pulses[pulse], sweeper.parameter.name, float(current_amplitude * value))
                 else:
                     setattr(pulses[pulse], sweeper.parameter.name, value)

--- a/src/qibolab/platform.py
+++ b/src/qibolab/platform.py
@@ -11,7 +11,7 @@ def create_dummy(runcard):
 
     # Create channel objects
     channels = ChannelMap()
-    channels |= ChannelMap.from_names("readout", "drive")
+    channels |= ChannelMap.from_names("readout", "drive", "flux")
 
     # Create dummy controller
     controller = DummyInstrument("dummy", 0)
@@ -23,6 +23,7 @@ def create_dummy(runcard):
     # map channels to qubits
     platform.qubits[0].readout = channels["readout"]
     platform.qubits[0].drive = channels["drive"]
+    platform.qubits[0].flux = channels["flux"]
 
     return platform
 

--- a/src/qibolab/platform.py
+++ b/src/qibolab/platform.py
@@ -7,6 +7,10 @@ from qibolab.platforms.platform import DesignPlatform
 
 
 def create_dummy(runcard):
+    """Create a single qubit platform using the dummy instrument.
+
+    Useful for testing.
+    """
     from qibolab.instruments.dummy import DummyInstrument
 
     # Create channel objects

--- a/src/qibolab/platform.py
+++ b/src/qibolab/platform.py
@@ -1,8 +1,30 @@
 from qibo.config import raise_error
 
+from qibolab.designs.basic import BasicInstrumentDesign
 from qibolab.designs.channels import Channel, ChannelMap
 from qibolab.designs.mixer import MixerInstrumentDesign
 from qibolab.platforms.platform import DesignPlatform
+
+
+def create_dummy(runcard):
+    from qibolab.instruments.dummy import DummyInstrument
+
+    # Create channel objects
+    channels = ChannelMap()
+    channels |= ChannelMap.from_names("readout", "drive")
+
+    # Create dummy controller
+    controller = DummyInstrument("dummy", 0)
+    # Create design
+    design = BasicInstrumentDesign(controller, channels)
+    # Create platform
+    platform = DesignPlatform("dummy", design, runcard)
+
+    # map channels to qubits
+    platform.qubits[0].readout = channels["readout"]
+    platform.qubits[0].drive = channels["drive"]
+
+    return platform
 
 
 def create_tii_qw5q_gold(runcard, simulation_duration=None, address=None, cloud=False):
@@ -143,7 +165,7 @@ def Platform(name, runcard=None, design=None):
             raise_error(RuntimeError, f"Runcard {name} does not exist.")
 
     if name == "dummy":
-        from qibolab.platforms.dummy import DummyPlatform as Device
+        return create_dummy(runcard)
     elif name == "icarusq":
         from qibolab.platforms.icplatform import ICPlatform as Device
     elif name == "qw5q_gold":

--- a/src/qibolab/runcards/dummy.yml
+++ b/src/qibolab/runcards/dummy.yml
@@ -1,24 +1,13 @@
 nqubits: 1
 description: Dummy platform runcard to use for testing.
 
-settings:
-    hardware_avg: 1024
-    sampling_rate: 1_000_000_000
-    repetition_duration: 200_000
-    minimum_delay_between_instructions: 4
-
-sleep_time: 0 # time to sleep every time ``execute_pulse_sequence`` is called
-
 qubits: [0]
 
+settings:
+    sampling_rate: 1_000_000_000
+    repetition_duration: 0
+
 topology: null
-
-channels: [1, 2, 3]
-
-qubit_channel_map: # [ReadOut, QubitDrive, QubitFlux, QubitBias]
-    0: [2, 1, null, null]
-
-instruments: []
 
 native_gates:
     single_qubit:


### PR DESCRIPTION
Moves the functionality of `DummyPlatform` to a `DummyInstrument` that is controlled by the `DesignPlatform`. Since instruments are lower-level qibolab objects, this allows us to test more code (such as the `DesignPlatform` and channels) using the `DummyInstrument`, without access to qpu. It also moves towards the direction of having a single platform that can control different instruments.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
