### PR TITLE
Fixing bug related to multiplex

### DIFF
--- a/src/qibolab/platforms/abstract.py
+++ b/src/qibolab/platforms/abstract.py
@@ -124,7 +124,11 @@ class AbstractPlatform(ABC):
             settings = self.settings = yaml.safe_load(file)
 
         self.nqubits = settings["nqubits"]
-        self.resonator_type = settings["resonator_type"]
+        if "resonator_type" in self.settings:
+            self.resonator_type = self.settings["resonator_type"]
+        else:
+            self.resonator_type = "3D" if self.nqubits == 1 else "2D"
+
         self.topology = settings["topology"]
 
         self.relaxation_time = settings["settings"]["repetition_duration"]

--- a/src/qibolab/platforms/abstract.py
+++ b/src/qibolab/platforms/abstract.py
@@ -124,7 +124,7 @@ class AbstractPlatform(ABC):
             settings = self.settings = yaml.safe_load(file)
 
         self.nqubits = settings["nqubits"]
-        self.resonator_type = "3D" if self.nqubits == 1 else "2D"
+        self.resonator_type = settings["resonator_type"]
         self.topology = settings["topology"]
 
         self.relaxation_time = settings["settings"]["repetition_duration"]

--- a/src/qibolab/platforms/multiqubit.py
+++ b/src/qibolab/platforms/multiqubit.py
@@ -251,7 +251,7 @@ class MultiqubitPlatform(AbstractPlatform):
                         pulse.frequency += self.get_lo_drive_frequency(pulse.qubit)
 
         for ro_pulse in ro_pulses.values():
-            data[ro_pulse.serial] = ExecutionResults.from_components(*acquisition_results[key])
+            data[ro_pulse.serial] = ExecutionResults.from_components(*acquisition_results[ro_pulse.serial])
             data[ro_pulse.qubit] = copy.copy(data[ro_pulse.serial])
         return data
 

--- a/src/qibolab/runcards/qili1q_os2.yml
+++ b/src/qibolab/runcards/qili1q_os2.yml
@@ -8,6 +8,8 @@ settings:
 
 qubits: [0]
 
+resonator_type: 3D
+
 topology: # qubit - qubit connections
 -   [1]
 

--- a/src/qibolab/runcards/qw5q_gold.yml
+++ b/src/qibolab/runcards/qw5q_gold.yml
@@ -9,6 +9,8 @@ settings:
     time_of_flight: 280
     smearing: 0
 
+resonator_type: 2D
+
 topology: # qubit - qubit connections
 -   [ 1, 0, 1, 0, 0, 0]
 -   [ 0, 1, 1, 0, 0, 0]


### PR DESCRIPTION
This should fix a bug related to multiplex when using qblox.
I've also introduced a `resonator_type` in the runcard to correct the `lorentzian_fitting` as mentioned by @aorgazf.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
