### PR TITLE
Allow executing circuit with `None` initial state

### DIFF
--- a/src/qibolab/backends.py
+++ b/src/qibolab/backends.py
@@ -53,17 +53,17 @@ class QibolabBackend(NumpyBackend):
         Returns:
             CircuitResult object containing the results acquired from the execution.
         """
-        if not isinstance(initial_state, type(circuit)):
-            raise_error(
-                ValueError,
-                "Hardware backend only supports circuits as initial states.",
-            )
-        else:
+        if isinstance(initial_state, type(circuit)):
             self.execute_circuit(
                 circuit=initial_state + circuit,
                 nshots=nshots,
                 fuse_one_qubit=fuse_one_qubit,
                 check_transpiled=check_transpiled,
+            )
+        elif initial_state is not None:
+            raise_error(
+                ValueError,
+                "Hardware backend only supports circuits as initial states.",
             )
 
         two_qubit_natives = self.platform.two_qubit_natives


### PR DESCRIPTION
After merging #322 an error is raised if `initial_state` is `None`. Instead the default |00...0> (ground state) should be used.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
