### PR TITLE
Bug fix in qblox multiqubit platform affecting multiplexed readout

### DIFF
--- a/src/qibolab/platforms/multiqubit.py
+++ b/src/qibolab/platforms/multiqubit.py
@@ -217,14 +217,6 @@ class MultiqubitPlatform(AbstractPlatform):
             if "readout" in roles[name]:
                 if not instrument_pulses[name].is_empty:
                     if not instrument_pulses[name].ro_pulses.is_empty:
-                        if all([pulse.serial in changed for pulse in instrument_pulses[name].ro_pulses]):
-                            # FIXME: for precision sweep in resonator spectroscopy
-                            # change necessary to perform precision sweep
-                            # TODO: move this to instruments (ask Alvaro)
-                            # TODO: check if this will work with multiplex
-                            for sequencers in self.instruments[name]._sequencers.values():
-                                for sequencer in sequencers:
-                                    sequencer.pulses = instrument_pulses[name].ro_pulses
                         results = self.instruments[name].acquire()
                         existing_keys = set(acquisition_results.keys()) & set(results.keys())
                         for key, value in results.items():


### PR DESCRIPTION
This PR fixes the issue #329 Multiplex not working for QBlox, for all routines except for the precision scans of the spectroscopies. 
The precision scans are going to be removed in qibocal https://github.com/qiboteam/qibocal/pull/270, soon, until then, one can comment out the precision sections of the resonator and qubit spectroscopies.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
