### PR TITLE
Add support for biasing qubits with qblox qcm offsets

### DIFF
--- a/src/qibolab/platforms/multiqubit.py
+++ b/src/qibolab/platforms/multiqubit.py
@@ -68,7 +68,7 @@ class MultiqubitPlatform(AbstractPlatform):
         if qubit in self.qbm:
              self.qb_port[qubit].current = bias
         elif qubit in self.qfm:
-            self.qf_port[qubit].offset == bias
+            self.qf_port[qubit].offset = bias
 
     def get_attenuation(self, qubit):
         return self.ro_port[qubit].attenuation

--- a/src/qibolab/platforms/multiqubit.py
+++ b/src/qibolab/platforms/multiqubit.py
@@ -65,13 +65,19 @@ class MultiqubitPlatform(AbstractPlatform):
         self.qd_port[qubit].gain = gain
 
     def set_bias(self, qubit, bias):
-        self.qb_port[qubit].current = bias
+        if qubit in self.qbm:
+             self.qb_port[qubit].current = bias
+        elif qubit in self.qfm:
+            self.qf_port[qubit].offset == bias
 
     def get_attenuation(self, qubit):
         return self.ro_port[qubit].attenuation
 
     def get_bias(self, qubit):
-        return self.qb_port[qubit].current
+        if qubit in self.qbm:
+            return self.qb_port[qubit].current
+        elif qubit in self.qfm:
+            return self.qf_port[qubit].offset
 
     def get_gain(self, qubit):
         return self.qd_port[qubit].gain


### PR DESCRIPTION
Hi, this PR makes it possible to use qblox qcm offsets to bias qubits flux. In a similar fashion as it is done with QM.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
