### PR TITLE
Fixing bug for `sweep` method with multiplex for dummy and qblox

### DIFF
--- a/src/qibolab/instruments/dummy.py
+++ b/src/qibolab/instruments/dummy.py
@@ -122,17 +122,16 @@ class DummyInstrument(AbstractInstrument):
             else:
                 new_sequence = copy.deepcopy(sequence)
                 result = self.play(qubits, new_sequence, nshots, relaxation_time)
+
                 # colllect result and append to original pulse
                 for original_pulse, new_serial in map_original_shifted.items():
                     acquisition = result[new_serial].compute_average() if average else result[new_serial]
-
-                    if results:
+                    if original_pulse.serial in results:
                         results[original_pulse.serial] += acquisition
                         results[original_pulse.qubit] += acquisition
                     else:
                         results[original_pulse.serial] = acquisition
                         results[original_pulse.qubit] = copy.copy(results[original_pulse.serial])
-
         # restore initial value of the pulse
         if sweeper.pulses is not None:
             self._restore_initial_value(sweeper, sweeper_pulses, original_value)
@@ -145,7 +144,6 @@ class DummyInstrument(AbstractInstrument):
         for pulse in pulses:
             if sweeper.parameter not in [Parameter.attenuation, Parameter.gain, Parameter.bias]:
                 original_value[pulse] = getattr(pulses[pulse], sweeper.parameter.name)
-
         return original_value
 
     def _restore_initial_value(self, sweeper, sweeper_pulses, original_value):

--- a/src/qibolab/platforms/multiqubit.py
+++ b/src/qibolab/platforms/multiqubit.py
@@ -328,7 +328,7 @@ class MultiqubitPlatform(AbstractPlatform):
                 for original_pulse, new_serial in map_original_shifted.items():
                     acquisition = result[new_serial].compute_average() if average else result[new_serial]
 
-                    if results:
+                    if original_pulse.serial in results:
                         results[original_pulse.serial] += acquisition
                         results[original_pulse.qubit] += acquisition
                     else:

--- a/src/qibolab/runcards/dummy.yml
+++ b/src/qibolab/runcards/dummy.yml
@@ -158,7 +158,7 @@ native_gates:
 characterization:
     single_qubit:
         0:
-            readout_frequency: 0.0
+            readout_frequency: 7_226_500_000
             drive_frequency: 0.0
             T1: 0.0
             T2: 0.0
@@ -219,7 +219,7 @@ characterization:
             mixer_readout_g: 0.0
             mixer_readout_phi: 0.0
         3:
-            readout_frequency: 7_802_391_000
+            readout_frequency: 7_802_191_000
             drive_frequency: 6_760_700_000
             T1: 0.0
             T2: 0.0


### PR DESCRIPTION
As title says.

Tests are failing only for coverage related to qblox.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [ ] Coverage does not decrease.
- [x] Documentation is updated.
