### PR TITLE
Fix call to Pulse.copy() method, closes #328

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,12 +41,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Topic :: Scientific/Engineering :: Physics",
     ],
-    install_requires=[
-        "qibo>=0.1.8",
-        "networkx",
-        "more-itertools",
-        "pyyaml"
-    ],
+    install_requires=["qibo>=0.1.8", "networkx", "more-itertools", "pyyaml"],
     extras_require={
         "docs": [
             "sphinx",

--- a/src/qibolab/pulses.py
+++ b/src/qibolab/pulses.py
@@ -1470,13 +1470,13 @@ class PulseSequence:
 
         return PulseSequence(*self.pulses)
 
-    def deep_copy(self):
+    def copy(self):
         """Returns a deep copy of the sequence.
 
         It returns a new PulseSequence with replicates of each of the pulses contained in the original sequence.
         """
 
-        return PulseSequence(*[pulse.deep_copy() for pulse in self.pulses])
+        return PulseSequence(*[pulse.copy() for pulse in self.pulses])
 
     @property
     def ro_pulses(self):


### PR DESCRIPTION
Hi, this PR fixes issue #328
Fix call to Pulse.copy() method and rename `PulseSequence.deep_copy()` as `PulseSequence.copy()` for consistency.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
