### PR TITLE
exclude read-only parameter sequence

### DIFF
--- a/src/qibolab/instruments/qblox.py
+++ b/src/qibolab/instruments/qblox.py
@@ -631,7 +631,12 @@ class ClusterQRM_RF(AbstractInstrument):
         if next_sequencer_number != self.DEFAULT_SEQUENCERS[port]:
             for parameter in self.device.sequencers[self.DEFAULT_SEQUENCERS[port]].parameters:
                 # exclude read-only parameter `present` and others that have wrong default values (qblox bug)
-                if not parameter in ["present", "thresholded_acq_marker_address", "thresholded_acq_trigger_address", "sequence"]:
+                if not parameter in [
+                    "present",
+                    "thresholded_acq_marker_address",
+                    "thresholded_acq_trigger_address",
+                    "sequence",
+                ]:
                     value = self.device.sequencers[self.DEFAULT_SEQUENCERS[port]].get(param_name=parameter)
                     if value:
                         target = self.device.sequencers[next_sequencer_number]

--- a/src/qibolab/instruments/qblox.py
+++ b/src/qibolab/instruments/qblox.py
@@ -631,7 +631,7 @@ class ClusterQRM_RF(AbstractInstrument):
         if next_sequencer_number != self.DEFAULT_SEQUENCERS[port]:
             for parameter in self.device.sequencers[self.DEFAULT_SEQUENCERS[port]].parameters:
                 # exclude read-only parameter `present` and others that have wrong default values (qblox bug)
-                if not parameter in ["present", "thresholded_acq_marker_address", "thresholded_acq_trigger_address"]:
+                if not parameter in ["present", "thresholded_acq_marker_address", "thresholded_acq_trigger_address", "sequence"]:
                     value = self.device.sequencers[self.DEFAULT_SEQUENCERS[port]].get(param_name=parameter)
                     if value:
                         target = self.device.sequencers[next_sequencer_number]

--- a/src/qibolab/instruments/qblox.py
+++ b/src/qibolab/instruments/qblox.py
@@ -373,7 +373,7 @@ class ClusterQRM_RF(AbstractInstrument):
 
     DEFAULT_SEQUENCERS: dict = {"o1": 0, "i1": 0}
     SAMPLING_RATE: int = 1e9  # 1 GSPS
-    FREQUENCY_LIMIT = 300e6
+    FREQUENCY_LIMIT = 500e6
 
     property_wrapper = lambda parent, *parameter: property(
         lambda self: parent.device.get(parameter[0]),
@@ -630,13 +630,8 @@ class ClusterQRM_RF(AbstractInstrument):
         next_sequencer_number = self._free_sequencers_numbers.pop(0)
         if next_sequencer_number != self.DEFAULT_SEQUENCERS[port]:
             for parameter in self.device.sequencers[self.DEFAULT_SEQUENCERS[port]].parameters:
-                # exclude read-only parameter `present` and others that have wrong default values (qblox bug)
-                if not parameter in [
-                    "present",
-                    "thresholded_acq_marker_address",
-                    "thresholded_acq_trigger_address",
-                    "sequence",
-                ]:
+                # exclude read-only parameter `sequence` and others that have wrong default values (qblox bug)
+                if not parameter in ["sequence", "thresholded_acq_marker_address", "thresholded_acq_trigger_address"]:
                     value = self.device.sequencers[self.DEFAULT_SEQUENCERS[port]].get(param_name=parameter)
                     if value:
                         target = self.device.sequencers[next_sequencer_number]
@@ -1700,8 +1695,8 @@ class ClusterQCM_RF(AbstractInstrument):
         next_sequencer_number = self._free_sequencers_numbers.pop(0)
         if next_sequencer_number != self.DEFAULT_SEQUENCERS[port]:
             for parameter in self.device.sequencers[self.DEFAULT_SEQUENCERS[port]].parameters:
-                # exclude read-only parameter `present`
-                if not parameter in ["present"]:
+                # exclude read-only parameter `sequence`
+                if not parameter in ["sequence"]:
                     value = self.device.sequencers[self.DEFAULT_SEQUENCERS[port]].get(param_name=parameter)
                     if value:
                         target = self.device.sequencers[next_sequencer_number]
@@ -2401,8 +2396,8 @@ class ClusterQCM(AbstractInstrument):
         next_sequencer_number = self._free_sequencers_numbers.pop(0)
         if next_sequencer_number != self.DEFAULT_SEQUENCERS[port]:
             for parameter in self.device.sequencers[self.DEFAULT_SEQUENCERS[port]].parameters:
-                # exclude read-only parameter `present`
-                if not parameter in ["present"]:
+                # exclude read-only parameter `sequence`
+                if not parameter in ["sequence"]:
                     value = self.device.sequencers[self.DEFAULT_SEQUENCERS[port]].get(param_name=parameter)
                     if value:
                         target = self.device.sequencers[next_sequencer_number]


### PR DESCRIPTION
Fixing bug introdued in the new firmware of qblox. Related with PR #347.
Excluding read-only parameter sequence from ClusterQRM_RF

Checklist:
- [x] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
