### PR TITLE
Platform reload settings

### DIFF
--- a/src/qibolab/platforms/abstract.py
+++ b/src/qibolab/platforms/abstract.py
@@ -200,13 +200,14 @@ class AbstractPlatform(ABC):
                     self.native_single_qubit_gates[qubit]["RX"]["frequency"] = freq
                     self.current_config["native_gates"]["single_qubit"][qubit]["RX"]["frequency"] = freq
                     
-                    if "if_frequency" in self.native_single_qubit_gates[qubit]["RX"]:
-                        self.native_single_qubit_gates[qubit]["RX"]["if_frequency"] = freq - self.get_lo_drive_frequency(qubit)
-                        self.current_config["native_gates"]["single_qubit"][qubit]["RX"]["if_frequency"] = freq - self.get_lo_drive_frequency(qubit)
+                    # if_frequency in drive_frequency is always fixed
+                    # if "if_frequency" in self.native_single_qubit_gates[qubit]["RX"]:
+                    #     self.native_single_qubit_gates[qubit]["RX"]["if_frequency"] = freq - self.get_lo_drive_frequency(qubit)
+                    #     self.current_config["native_gates"]["single_qubit"][qubit]["RX"]["if_frequency"] = freq - self.get_lo_drive_frequency(qubit)
 
                     # Ask Andrea if needed
-                    self.qubits[qubit].readout_frequency = freq
-                    self.current_config["characterization"]["single_qubit"][qubit]["readout_frequency"] = freq
+                    # self.qubits[qubit].readout_frequency = freq
+                    # self.current_config["characterization"]["single_qubit"][qubit]["readout_frequency"] = freq
 
                     self.qubits[qubit].drive_frequency = freq
                     self.current_config["characterization"]["single_qubit"][qubit]["drive_frequency"] = freq

--- a/src/qibolab/platforms/abstract.py
+++ b/src/qibolab/platforms/abstract.py
@@ -111,7 +111,9 @@ class AbstractPlatform(ABC):
         self.native_single_qubit_gates = {}
         self.native_two_qubit_gates = {}
         self.two_qubit_natives = set()
+        
         # Load platform settings
+        self.current_config = {}
         self.reload_settings()
 
     def __repr__(self):
@@ -122,10 +124,17 @@ class AbstractPlatform(ABC):
             raise_error(RuntimeError, "Cannot access instrument because it is not connected.")
 
     def reload_settings(self):
+        
         # TODO: Remove ``self.settings``
-        with open(self.runcard) as file:
-            settings = self.settings = yaml.safe_load(file)
-
+        if (len(self.current_config) == 0):
+            # Load initial configuration
+            with open(self.runcard) as file:
+                settings = self.settings = yaml.safe_load(file)
+                self.current_config = self.settings
+        else:
+            # Load current configuration
+            settings = self.settings = self.current_config
+        
         self.nqubits = settings["nqubits"]
         if "resonator_type" in self.settings:
             self.resonator_type = self.settings["resonator_type"]
@@ -157,37 +166,9 @@ class AbstractPlatform(ABC):
                 self.qubits[q] = Qubit(q, **settings["characterization"]["single_qubit"][q])
 
     def dump(self, path: Path):
-        general_settings = {}
 
-        # general informations
-        general_settings["nqubits"] = self.nqubits
-        general_settings["qubits"] = list(self.qubits.keys())
-        general_settings["resonator_type"] = self.resonator_type
-        general_settings["topology"] = self.topology
         with open(path, "w") as file:
-            yaml.dump(general_settings, file, sort_keys=False, indent=4, default_flow_style=None)
-
-        settings = {}
-        # settings
-        settings["settings"] = {}
-        settings["settings"]["repetition_duration"] = self.relaxation_time
-        settings["settings"]["sampling_rate"] = self.sampling_rate
-
-        # native gates
-        settings["native_gates"] = {}
-        settings["native_gates"]["single_qubits"] = self.native_single_qubit_gates
-        settings["native_gates"]["two_qubits"] = self.native_two_qubit_gates
-
-        settings["characterization"] = {}
-        settings["characterization"]["single_qubit"] = {}
-        for qubit in general_settings["qubits"]:
-            settings["characterization"]["single_qubit"][qubit] = {}
-            for key, item in self.qubits[qubit].__dict__.items():
-                if isinstance(item, float) or isinstance(item, int) and not key == "name":
-                    settings["characterization"]["single_qubit"][qubit][key] = item
-
-        with open(path, "a") as file:
-            yaml.dump(settings, file, sort_keys=False, indent=4, default_flow_style=False)
+            yaml.dump(self.settings, file, sort_keys=False, indent=4, default_flow_style=None)
 
     def update(self, updates: dict):
         r"""Updates the runcard.
@@ -197,55 +178,105 @@ class AbstractPlatform(ABC):
             updates (dict): Dictionary containing the parameters to update the runcard.
         """
 
+        #TODO: Call platform.setup() when an instrument parameter is modified after fitting. 
+        # for example att after punchout fitting or threshold/iq_angle after qubit states classification
         for par, values in updates.items():
             for qubit, value in values.items():
+                
+                #fitted resonator frequency from resonator spec experiment
                 if par == "readout_frequency":
                     freq = int(value * 1e9)
                     self.native_single_qubit_gates[qubit]["MZ"]["frequency"] = freq
-                    if "if_frequency" in self.native_single_qubit_gates[qubit]["MZ"]:
-                        self.native_single_qubit_gates[qubit]["MZ"][
-                            "if_frequency"
-                        ] = freq - self.get_lo_readout_frequency(qubit)
-                    self.qubits[qubit].readout_frequency = freq
+                    self.current_config["native_gates"]["single_qubit"][qubit]["MZ"]["frequency"] = freq
 
+                    if "if_frequency" in self.native_single_qubit_gates[qubit]["MZ"]:
+                        self.native_single_qubit_gates[qubit]["MZ"]["if_frequency"] = freq - self.get_lo_readout_frequency(qubit)
+                        self.current_config["native_gates"]["single_qubit"][qubit]["MZ"]["if_frequency"] = freq - self.get_lo_readout_frequency(qubit)
+
+                    self.qubits[qubit].readout_frequency = freq
+                    self.current_config["characterization"]["single_qubit"][qubit]["readout_frequency"] = freq
+
+                #fitted qubit frequency from qubit spec experiment
                 elif par == "drive_frequency":
                     freq = int(value * 1e9)
                     self.native_single_qubit_gates[qubit]["RX"]["frequency"] = freq
+                    self.current_config["native_gates"]["single_qubit"][qubit]["RX"]["frequency"] = freq
+                    
                     if "if_frequency" in self.native_single_qubit_gates[qubit]["RX"]:
-                        self.native_single_qubit_gates[qubit]["RX"][
-                            "if_frequency"
-                        ] = freq - self.get_lo_drive_frequency(qubit)
+                        self.native_single_qubit_gates[qubit]["RX"]["if_frequency"] = freq - self.get_lo_drive_frequency(qubit)
+                        self.current_config["native_gates"]["single_qubit"][qubit]["RX"]["if_frequency"] = freq - self.get_lo_drive_frequency(qubit)
+
+                    # Ask Andrea if needed
                     self.qubits[qubit].readout_frequency = freq
+                    self.current_config["characterization"]["single_qubit"][qubit]["readout_frequency"] = freq
+
                     self.qubits[qubit].drive_frequency = freq
+                    self.current_config["characterization"]["single_qubit"][qubit]["drive_frequency"] = freq
+                
+                #Fitted bare resonator frequency from punchout experiment
+                #Ask Andrea: Needs to be added in all platform runcards?
                 elif par == "bare_resonator_frequency":
                     freq = int(value * 1e9)
                     self.qubits[qubit].bare_resonator_frequency = freq
+                    self.current_config["characterization"]["single_qubit"][qubit]["bare_resonator_frequency"] = freq
+
+                #Fitted RX/MZ pulse amplitude from Rabi/resonator spec experiment
+                #TODO: Add update RX amplitude form flipping. Ask Andrea if we shpuld modify the flipping
                 elif "amplitude" in par:
                     amplitude = float(value)
                     if par == "readout_amplitude":
                         self.native_single_qubit_gates[qubit]["MZ"]["amplitude"] = amplitude
+                        self.current_config["native_gates"]["single_qubit"][qubit]["MZ"]["amplitude"] = amplitude
+
                     if par == "drive_amplitude":
                         self.native_single_qubit_gates[qubit]["RX"]["amplitude"] = amplitude
+                        self.current_config["native_gates"]["single_qubit"][qubit]["RX"]["amplitude"] = amplitude
+
+                #Fitted T2 from Ramsey experiment.
+                #Not a good T2 fitting. Probably we should remove from Ramsey and use only spin echo 
                 elif par == "t2":
                     self.qubits[qubit].T2 = float(value)
+                    self.current_config["characterization"]["single_qubit"][qubit]["T2"] = float(value)
+
+                #Fitted T2 from spin echo experiment. 
+                elif par == "t2_spin_echo":
+                    self.qubits[qubit].T2_spin_echo = int(value)
+                    self.current_config["characterization"]["single_qubit"][qubit]["t2_spin_echo"] = float(value)
+
+                #Fitted T1 from t1 experiment. 
                 elif "t1" == par:
                     self.qubits[qubit].T1 = float(value)
-                elif "thresold" == par:
+                    self.current_config["characterization"]["single_qubit"][qubit]["T2"] = float(value)
+
+                #Fitted threshold from classify qubit states experiment. 
+                #In qblox runcard these parameters are part of the instruments!
+                elif "threshold" == par:
                     self.qubits[qubit].thresold = float(value)
+                    self.current_config["characterization"]["single_qubit"][qubit]["threshold"] = float(value)
+                
+                #Fitted iq_angle from classify qubit states experiment. 
+                #In qblox runcard these parameters are part of the instruments!
                 elif "iq_angle" == par:
                     self.qubits[qubit].iq_angle = float(value)
+                    self.current_config["characterization"]["single_qubit"][qubit]["iq_angle"] = float(value)
+
+                #Fitted drive pulse Drag beta parameter from allXY drag pulse tunning experiment. 
                 elif "beta" in par:
                     shape = self.native_single_qubit_gates[qubit]["RX"]["shape"]
                     rel_sigma = re.findall(r"[\d]+[.\d]+|[\d]*[.][\d]+|[\d]+", shape)[0]
                     self.native_single_qubit_gates[qubit]["RX"]["shape"] = f"Drag({rel_sigma}, {float(value)})"
+                    self.current_config["native_gates"]["single_qubit"][qubit]["RX"]["shape"] = f"Drag({rel_sigma}, {float(value)})"
 
-                elif "length" in par:  # assume only drive length
+                #Fitted drive pulse length from Rabi experiment. 
+                elif "drive_length" in par:
                     self.native_single_qubit_gates[qubit]["RX"]["duration"] = int(value)
-                elif par == "t2_spin_echo":
-                    self.qubits[qubit].T2_spin_echo = int(value)
+                    self.current_config["native_gates"]["single_qubit"][qubit]["RX"]["duration"] = f"Drag({rel_sigma}, {float(value)})"
 
                 else:
                     raise_error(ValueError, "Unknown parameter.")
+        
+        #reload_settings after execute any calibration routine keeping fitted parameters
+        self.reload_settings()
 
     @abstractmethod
     def connect(self):

--- a/src/qibolab/platforms/abstract.py
+++ b/src/qibolab/platforms/abstract.py
@@ -178,8 +178,6 @@ class AbstractPlatform(ABC):
             updates (dict): Dictionary containing the parameters to update the runcard.
         """
 
-        #TODO: Call platform.setup() when an instrument parameter is modified after fitting. 
-        # for example att after punchout fitting or threshold/iq_angle after qubit states classification
         for par, values in updates.items():
             for qubit, value in values.items():
                 

--- a/src/qibolab/platforms/multiqubit.py
+++ b/src/qibolab/platforms/multiqubit.py
@@ -60,27 +60,40 @@ class MultiqubitPlatform(AbstractPlatform):
                 # log.info(f"qubit qubit drive channel: {self.qd_channel[qubit]}")
                 # log.info(f"qubit qubit bias channel: {self.qb_channel[qubit]}")
                 # log.info(f"qubit qubit flux channel: {self.qf_channel[qubit]}")
+                if par == "drive_frequency":
+                    freq = int(value * 1e9)
+                    #update QCM LO_frequency
+                    instrument_name = self.qubit_instrument_map[qubit][1]
+                    port = self.qdm[qubit].channel_port_map[self.qubit_channel_map[qubit][1]]
+                    drive_if = self.native_single_qubit_gates[qubit]["RX"]["if_frequency"]
+                    # log.info(f"qubit: {qubit} - instrument: {instrument_name} - port: {port} - drive freq: {freq}  - new drive LO freq : {freq - drive_if}")
+                    self.current_config["instruments"][instrument_name]["settings"]["ports"][port]["lo_frequency"] = freq - drive_if
+                    
+                    #configure LO drive frequency
+                    self.qd_port[qubit].lo_frequency = freq - drive_if
 
-                if "attenuation" == par:
+                elif par == "attenuation":
                     attenuation = float(value)
                     #save current_config
                     instrument_name = self.qubit_instrument_map[qubit][0]
-                    self.current_config[instrument_name]["settings"]["ports"]["o1"] = attenuation
+                    port = self.qrm[qubit].channel_port_map[self.qubit_channel_map[qubit][0]]
+                    #log.info(f"qubit: {qubit} - instrument: {instrument_name} - port: {port} ")
+                    self.current_config["instruments"][instrument_name]["settings"]["ports"][port]["attenuation"] = attenuation
                     #configure RO attenuation
                     self.ro_port[qubit].attenuation = attenuation
                 
-                elif "threshold" == par:
+                elif par == "threshold":
                     threshold = float(value)
                     #save current_config
                     instrument_name = self.qubit_instrument_map[qubit][0]
-                    self.current_config[instrument_name]["settings"]["classification_parameters"][qubit]["threshold"] = threshold
+                    self.current_config["instruments"][instrument_name]["settings"]["classification_parameters"][qubit]["threshold"] = threshold
                     instrument_name.setup( **self.current_config["settings"], **self.current_config["instruments"][instrument_name]["settings"])
                 
-                elif "rotation_angle" == par:
+                elif par == "rotation_angle":
                     rotation_angle = float(value)
                     #save current_config
                     instrument_name = self.qubit_instrument_map[qubit][0]
-                    self.current_config[instrument_name]["settings"]["classification_parameters"][qubit]["rotation_angle"] = rotation_angle
+                    self.current_config["instruments"][instrument_name]["settings"]["classification_parameters"][qubit]["rotation_angle"] = rotation_angle
                     instrument_name.setup( **self.current_config["settings"], **self.current_config["instruments"][instrument_name]["settings"])
 
                 else:

--- a/src/qibolab/platforms/multiqubit.py
+++ b/src/qibolab/platforms/multiqubit.py
@@ -45,6 +45,46 @@ class MultiqubitPlatform(AbstractPlatform):
         self.qubit_channel_map = self.settings["qubit_channel_map"]
         self.hardware_avg = self.settings["settings"]["hardware_avg"]
         self.repetition_duration = self.settings["settings"]["repetition_duration"]
+    
+    def update(self, updates: dict):
+        # update platform dependent parameters linked to instruments
+        for par, values in updates.items():
+            for qubit, value in values.items():
+                # log.info(f"qubit: {qubit} - parameter: {par} - values: {value}")
+                # log.info(f"qubit readout instrument: {self.qubit_instrument_map[qubit][0]}")
+                # log.info(f"qubit drive instrument: {self.qubit_instrument_map[qubit][1]}")
+                # log.info(f"qubit bias instrument: {self.qubit_instrument_map[qubit][2]}")
+                # log.info(f"qubit flux instrument: {self.qubit_instrument_map[qubit][3]}")
+
+                # log.info(f"qubit read out channel: {self.ro_channel[qubit]}")
+                # log.info(f"qubit qubit drive channel: {self.qd_channel[qubit]}")
+                # log.info(f"qubit qubit bias channel: {self.qb_channel[qubit]}")
+                # log.info(f"qubit qubit flux channel: {self.qf_channel[qubit]}")
+
+                if "attenuation" == par:
+                    attenuation = float(value)
+                    #save current_config
+                    instrument_name = self.qubit_instrument_map[qubit][0]
+                    self.current_config[instrument_name]["settings"]["ports"]["o1"] = attenuation
+                    #configure RO attenuation
+                    self.ro_port[qubit].attenuation = attenuation
+                
+                elif "threshold" == par:
+                    threshold = float(value)
+                    #save current_config
+                    instrument_name = self.qubit_instrument_map[qubit][0]
+                    self.current_config[instrument_name]["settings"]["classification_parameters"][qubit]["threshold"] = threshold
+                    instrument_name.setup( **self.current_config["settings"], **self.current_config["instruments"][instrument_name]["settings"])
+                
+                elif "rotation_angle" == par:
+                    rotation_angle = float(value)
+                    #save current_config
+                    instrument_name = self.qubit_instrument_map[qubit][0]
+                    self.current_config[instrument_name]["settings"]["classification_parameters"][qubit]["rotation_angle"] = rotation_angle
+                    instrument_name.setup( **self.current_config["settings"], **self.current_config["instruments"][instrument_name]["settings"])
+
+                else:
+                    super().update(updates)
 
     def set_lo_drive_frequency(self, qubit, freq):
         self.qd_port[qubit].lo_frequency = freq

--- a/src/qibolab/runcards/qw5q_gold_qblox.yml
+++ b/src/qibolab/runcards/qw5q_gold_qblox.yml
@@ -1,0 +1,395 @@
+nqubits: 5
+description: 5-qubit device at XLD fridge, controlled with qblox cluster rf.
+
+settings:
+    hardware_avg: 1024
+    repetition_duration: 20_000 # 200_000
+    sampling_rate: 1_000_000_000
+
+qubits: [0, 1, 2, 3, 4, 5]
+
+resonator_type: 2D
+
+topology: # qubit - qubit connections
+-   [ 1, 0, 1, 0, 0, 0]
+-   [ 0, 1, 1, 0, 0, 0]
+-   [ 1, 1, 1, 1, 1, 0]
+-   [ 0, 0, 1, 1, 0, 0]
+-   [ 0, 0, 1, 0, 1, 0]
+-   [ 0, 0, 0, 0, 0, 1]
+
+# Drive:
+# L3-15:mod8-o1 q0
+# L3-11:mod3-o1 q1
+# L3-12:mod3-o2 q2
+# L3-13:mod4-o1 q3
+# L3-14:mod4-o2 q4
+
+
+# Flux:
+# L4-5:mod5-o1 q0
+# L4-1:mod2-o1 q1
+# L4-2:mod2-o2 q2
+# L4-3:mod2-o3 q3
+# L4-4:mod2-o4 q4
+
+
+# Readout out:
+# L3-25:mod12 and mod10 (out)
+# L2-25:mod12 and mod10 (in)
+
+# Cluster IP:
+# 192.168.0.6
+
+
+# no bias line, using qblox offset from qcm_bbc
+channels: [
+  'L2-5a','L2-5b', 'L3-25a', 'L3-25b', #RO channels: Ro lines L2-5 and L3-25 splitted
+  'L3-15', 'L3-11', 'L3-12', 'L3-13', 'L3-14', 'L3-16', # Drive channels q0, q1, q2, q3, q4 | not used ports label: L3-16
+  'L4-5', 'L4-1', 'L4-2', 'L4-3', 'L4-4', 'L4-6', 'L4-7', 'L4-8', # Flux channels q0, q1, q2, q3, q4 | not used labels: 'L4-6', 'L4-7', 'L4-8'
+]
+
+# [ReadOut, QubitDrive, QubitFlux, QubitBias]
+qubit_channel_map:
+    0:   [L3-25a, L3-15, L4-5, null] #q0
+    1:   [L3-25a, L3-11, L4-1, null] #q1
+    2:   [L3-25b, L3-12, L4-2, null] #q2
+    3:   [L3-25b, L3-13, L4-3, null] #q3
+    4:   [L3-25b, L3-14, L4-4, null] #q4
+    5:   [L3-25a,  null, null, null] #q5 witness
+
+instruments:
+    cluster:
+        lib: qblox
+        class: Cluster
+        address: 192.168.0.6
+        roles: [other]
+        settings:
+            reference_clock_source      : internal                      # external or internal
+
+    qrm_rf0: # ReadOut module 10 controlling qubits q0, q1, q5
+        lib: qblox
+        class: ClusterQRM_RF
+        address: 192.168.0.6:10
+        roles: [readout]
+        settings:
+            ports:
+                o1:
+                    attenuation                 : 44 # should be multiple of 2
+                    lo_enabled                  : true
+                    lo_frequency                : 7_250_000_000                    # (Hz) from 2e9 to 18e9
+                    gain                        : 0.6                              # for path0 and path1 -1.0<=v<=1.0
+                    hardware_mod_en             : false
+                i1:
+                    hardware_demod_en           : true
+
+            acquisition_hold_off        : 500
+            acquisition_duration        : 900
+
+            classification_parameters:
+                0:  # qubit id
+                    rotation_angle: 164.437           # in degrees 0.0<=v<=360.0
+                    threshold: 0.005354                # in V
+                1:  # qubit id
+                    rotation_angle: 280.880     # in degrees 0.0<=v<=360.0
+                    threshold: 0.001779         # in V
+
+
+            channel_port_map:   # Refrigerator Channel : Instrument port
+                'L3-25a' : o1    # IQ Port = out0 & out1
+                'L2-5a' : i1     # Labeled but not used
+    qrm_rf1: # ReadOut module 12: controlling qubits q2, q3, q4
+        lib: qblox
+        class: ClusterQRM_RF
+        address: 192.168.0.6:12
+        roles: [readout]
+        settings:
+            ports:
+                o1:
+                    attenuation                 : 44 # should be multiple of 2
+                    lo_enabled                  : true
+                    lo_frequency                : 7_850_000_000                   # (Hz) from 2e9 to 18e9
+                    gain                        : 0.6                              # for path0 and path1 -1.0<=v<=1.0
+                    hardware_mod_en             : false
+                i1:
+                    hardware_demod_en           : true
+
+            acquisition_hold_off        : 500
+            acquisition_duration        : 900
+
+            classification_parameters:
+                2:  # qubit id
+                    rotation_angle: 37.102     # in degrees 0.0<=v<=360.0
+                    threshold: 0.001768         # in V
+                3:  # qubit id
+                    rotation_angle: 38.279           # in degrees 0.0<=v<=360.0
+                    threshold: 0.002435                # in V
+                4:  # qubit id
+                    rotation_angle: 285.730           # in degrees 0.0<=v<=360.0
+                    threshold: 0.000354                # in V
+
+            channel_port_map:   # Refrigerator Channel : Instrument port
+                'L3-25b' : o1    # IQ Port = out0 & out1
+                'L2-5b' : i1     # Labeled but not used
+
+    qcm_rf2:
+        lib: qblox
+        class: ClusterQCM_RF
+        address: 192.168.0.6:8
+        roles: [control]
+        settings:
+            ports:
+                o1: # qubit q0
+                    attenuation                  : 20 # (dB) # should be multiple of 2
+                    lo_enabled                   : true
+                    lo_frequency                 : 5_246_600_000 # (Hz) from 2e9 to 18e9
+                    gain                         : 0.488 # for path0 and path1 -1.0<=v<=1.0
+                    hardware_mod_en              : false
+                o2: # not used
+                    attenuation                  : 0 # (dB)
+                    lo_enabled                   : false
+                    lo_frequency                 : 2_000_000_000 # (Hz) from 2e9 to 18e9
+                    gain                         : 0 # for path0 and path1 -1.0<=v<=1.0
+                    hardware_mod_en              : false
+
+            channel_port_map:
+                'L3-15': o1 # q0
+                'L3-16': o2 # not used port
+    qcm_rf3:
+        lib: qblox
+        class: ClusterQCM_RF
+        address: 192.168.0.6:3
+        roles: [control]
+        settings:
+            ports:
+                o1: # qubit q1
+                    attenuation                  : 20 # (dB)
+                    lo_enabled                   : true
+                    lo_frequency                 : 5_052_013_000 # (Hz) from 2e9 to 18e9
+                    gain                         : 0.56 # for path0 and path1 -1.0<=v<=1.0
+                    hardware_mod_en              : false
+                o2: # qubit q2
+                    attenuation                  : 20 # (dB)
+                    lo_enabled                   : true
+                    lo_frequency                 : 5_995_026_000 # (Hz) from 2e9 to 18e9
+                    gain                         : 0.647 # for path0 and path1 -1.0<=v<=1.0
+                    hardware_mod_en              : false
+
+            channel_port_map:
+                'L3-11': o1 # q1
+                'L3-12': o2 # q2
+    qcm_rf4:
+        lib: qblox
+        class: ClusterQCM_RF
+        address: 192.168.0.6:4
+        roles: [control]
+        settings:
+            ports:
+                o1: # qubit q3
+                    attenuation                  : 20 # (dB)
+                    lo_enabled                   : true
+                    lo_frequency                 : 6_961_250_000 # (Hz) from 2e9 to 18e9
+                    gain                         : 0.538 # for path0 and path1 -1.0<=v<=1.0
+                    hardware_mod_en              : false
+                o2: # qubit q4
+                    attenuation                  : 20 # (dB)
+                    lo_enabled                   : true
+                    lo_frequency                 : 6_788_003_000 # (Hz) from 2e9 to 18e9
+                    gain                         : 0.645 # for path0 and path1 -1.0<=v<=1.0
+                    hardware_mod_en              : false
+
+            channel_port_map:
+                'L3-13': o1 # 1
+                'L3-14': o2 # 0
+
+    #Cluster QCM usado para bias mediante el offset
+    qcm_bb1:
+        lib: qblox
+        class: ClusterQCM
+        address: 192.168.0.6:2
+        roles: [control]
+        settings:
+            ports:
+                o1: {gain: 1, offset:  0.151, hardware_mod_en: false} #q1
+                o2: {gain: 1, offset: -0.257, hardware_mod_en: false} #q2
+                o3: {gain: 1, offset:  0.878, hardware_mod_en: false} #q3
+                o4: {gain: 1, offset: -0.559, hardware_mod_en: false} #q4
+            channel_port_map: {L4-1: o1, L4-2: o2, L4-3: o3, L4-4: o4}
+
+    #Cluster QCM usado para bias mediante el offset
+    qcm_bb2:
+        lib: qblox
+        class: ClusterQCM
+        address: 192.168.0.6:5
+        roles: [control]
+        settings:
+            ports:
+                o1: {gain: 1, offset: 0.427, hardware_mod_en: false} #q0
+                o2: {gain: 0, offset: 0.0, hardware_mod_en: false} #not used
+                o3: {gain: 0, offset: 0.0, hardware_mod_en: false} #not used
+                o4: {gain: 0, offset: 0.0, hardware_mod_en: false} #not used
+            channel_port_map: {L4-5: o1, L4-6: o2, L4-7: o3, L4-8: o4}
+
+    twpa_pump:
+        lib: rohde_schwarz
+        class: SGS100A
+        address: 192.168.0.37
+        roles: [other]
+        settings:
+            frequency: 6_511_000_000 # Hz
+            power: 4.5 # dBm
+
+native_gates:
+    single_qubit:
+        0: # qubit id
+            RX:
+                duration: 40                   # should be multiple of 4
+                amplitude: 0.5
+                frequency: 5_046_600_000    # qubit frequency
+                if_frequency: -200_000_000    # difference in qubit frequency
+                shape: Gaussian(5)
+                type: qd                    # qubit drive
+            MZ:
+                duration: 2000
+                amplitude: 0.4
+                frequency: 7_212_407_558     # resonator frequency
+                if_frequency: -37_592_442    # difference in resonator frequency
+                shape: Rectangular()
+                type: ro                    # readout
+        1: # qubit id
+            RX:
+                duration: 40                  # should be multiple of 4
+                amplitude: 0.5
+                frequency: 4_852_013_000    # qubit frequency
+                if_frequency: -200_000_000    # difference in qubit frequency
+                shape: Gaussian(5)
+                type: qd                    # qubit drive
+            MZ:
+                duration: 2000
+                amplitude: 0.4
+                frequency: 7_453_190_140    # resonator frequency
+                if_frequency: 203_190_140    # difference in resonator frequency
+                shape: Rectangular()
+                type: ro                    # readout
+        2: # qubit id
+            RX:
+                duration: 40                   # should be multiple of 4
+                amplitude: 0.5
+                frequency: 5_795_026_000    # qubit frequency
+                if_frequency: -200_000_000    # difference in qubit frequency
+                shape: Gaussian(5)
+                type: qd                    # qubit drive
+            MZ:
+                duration: 2000
+                amplitude: 0.4
+                frequency: 7_655_148_879    # resonator frequency
+                if_frequency: -194_851_121    # difference in resonator frequency
+                shape: Rectangular()
+                type: ro                    # readout
+        3: # qubit id
+            RX:
+                duration: 40                   # should be multiple of 4
+                amplitude: 0.5
+                frequency: 6_761_250_000    # qubit frequency
+                if_frequency: -200_000_000    # difference in qubit frequency
+                shape: Gaussian(5)
+                type: qd                    # qubit drive
+            MZ:
+                duration: 2000
+                amplitude: 0.4
+                frequency: 7_803_437_704    # resonator frequency
+                if_frequency: -46_562_296    # difference in resonator frequency
+                shape: Rectangular()
+                type: ro                    # readout
+        4: # qubit id
+            RX:
+                duration: 40                # should be multiple of 4
+                amplitude: 0.5
+                frequency: 6_588_003_000    # qubit frequency
+                if_frequency: -200_000_000    # difference in qubit frequency
+                shape: Gaussian(5)
+                type: qd                    # qubit drive
+            MZ:
+                duration: 2000
+                amplitude: 0.4
+                frequency: 8_058_746_969      # resonator frequency
+                if_frequency: 208_746_969    # difference in resonator frequency
+                shape: Rectangular()
+                type: ro                    # readout
+        5: # qubit id
+            RX:
+                duration: 40                # should be multiple of 4
+                amplitude: 0.5
+                frequency: 4_700_000_000    # qubit frequency
+                if_frequency: -200_000_000    # difference in qubit frequency
+                shape: Gaussian(5)
+                type: qd                    # qubit drive
+            MZ:
+                duration: 2000
+                amplitude: 0.4
+                frequency: 7_118_680_035      # resonator frequency
+                if_frequency: -131_319_965    # difference in resonator frequency
+                shape: Rectangular()
+                type: ro                    # readout
+characterization:
+    single_qubit:
+        0:
+            readout_frequency: 7_212_407_558 # 7_225_820_798 # 7_218_000_000
+            drive_frequency: 5_046_600_000
+            T1: 0
+            T2: 0
+            state0_voltage: 0.0
+            state1_voltage: 0.0
+            mean_gnd_states: (-0.0+0.0j)
+            mean_exc_states: (0.0+0.0j)
+            sweetspot: 0.427
+        1:
+            readout_frequency: 7_453_190_140
+            drive_frequency: 4_852_013_000
+            T1: 1_283
+            T2: 130
+            state0_voltage: 0.0
+            state1_voltage: 0.0
+            mean_gnd_states: (-0.0+0.0j)
+            mean_exc_states: (0.0+0.0j)
+            sweetspot: 0.151
+        2:
+            readout_frequency: 7_655_148_879
+            drive_frequency: 5_795_026_000
+            T1: 1_807
+            T2: 0
+            state0_voltage: 0.0
+            state1_voltage: 0.0
+            mean_gnd_states: (-0.0+0.0j)
+            mean_exc_states: (0.0+0.0j)
+            sweetspot: -0.257
+        3:
+            readout_frequency: 7_803_437_704
+            drive_frequency: 6_761_250_000
+            T1: 3529
+            T2: 0
+            state0_voltage: 0.0
+            state1_voltage: 0.0
+            mean_gnd_states: (-0.0+0.0j)
+            mean_exc_states: (0.0+0.0j)
+            sweetspot: 0.878
+        4:
+            readout_frequency: 8_058_746_969
+            drive_frequency: 6_588_003_000
+            T1: 469
+            T2: 0
+            state0_voltage: 0.0
+            state1_voltage: 0.0
+            mean_gnd_states: (-0.0+0.0j)
+            mean_exc_states: (0.0+0.0j)
+            sweetspot: -0.559
+        5:
+            readout_frequency: 7_118_680_035
+            drive_frequency: 4_700_000_000
+            T1: 0
+            T2: 0
+            state0_voltage: 0.0
+            state1_voltage: 0.0
+            mean_gnd_states: (-0.0+0.0j)
+            mean_exc_states: (0.0+0.0j)
+            sweetspot: 0


### PR DESCRIPTION
Thsi PR implements:
- platform.reload_settings() from static file (used for initialization of the platform when allocated) or from a dictionary (used when executing calibration action with the tree executor)
- Modified platform.dump() to be able to write all the custom data of each platform in the new platform runcard .yml
- Modified platform.update() called after fitting parameters from autocalibration. The common parameters fitted are updated in the abstract platform method and the platform dependent parameters are updated in the specific platform class update method. 
- Excution of extra actions if required after fitting data (for example in qblox, we neeed to set up again some instruments depending on the fitted param)  

@aorgazf @stavros11 @andrea-pasquale we should discuss which parameters are going to be common in all platforms runcards (at least in QM and QBlox) and decide the final name of them. Also we will need to remove some of the parameters...
For example now, we have "iq_angle" and "rotation_angle" located in different sections (because in qblox is a parameter related with the instrument). So we need to decide.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
