### PR TITLE
QM sweeper for duration of flux pulses

### DIFF
--- a/src/qibolab/instruments/qm.py
+++ b/src/qibolab/instruments/qm.py
@@ -980,7 +980,9 @@ class QMOPX(AbstractInstrument):
                             while to_process:
                                 next_qmpulse = to_process.pop()
                                 to_process |= next_qmpulse.next
-                                next_qmpulse.wait_time_variable = value // 4
+                                next_qmpulse.wait_time += value // 4
+                                if value % 4 != 0:
+                                    next_qmpulse.wait_time += 1
 
                         self.sweep_recursion(sweepers[1:], qubits, qmsequence, relaxation_time)
 

--- a/src/qibolab/instruments/qm.py
+++ b/src/qibolab/instruments/qm.py
@@ -818,7 +818,7 @@ class QMOPX(AbstractInstrument):
                     Ist_temp = acquisition.I_stream
                     Qst_temp = acquisition.Q_stream
                     if not average and acquisition.threshold is not None:
-                        shots_temp = qmpulse.shots
+                        shots_temp = acquisition.shots
                     for sweeper in reversed(sweepers):
                         Ist_temp = Ist_temp.buffer(len(sweeper.values))
                         Qst_temp = Qst_temp.buffer(len(sweeper.values))

--- a/src/qibolab/instruments/qm.py
+++ b/src/qibolab/instruments/qm.py
@@ -969,7 +969,7 @@ class QMOPX(AbstractInstrument):
                 qmpulse.pulse.duration = original_duration
 
         with for_(*from_array(duration, values)):
-            with switch_(duration, unsafe=True):
+            with switch_(duration):
                 for i, value in enumerate(values):
                     with case_(value):
                         for pulse in sweeper.pulses:

--- a/src/qibolab/sweeper.py
+++ b/src/qibolab/sweeper.py
@@ -12,6 +12,7 @@ class Parameter(Enum):
     amplitude = auto()
     relative_phase = auto()
     delay = auto()
+    duration = auto()
 
     attenuation = auto()
     gain = auto()

--- a/tests/test_instruments_qm.py
+++ b/tests/test_instruments_qm.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 from qm import qua
 
-from qibolab.instruments.qm import QMOPX, QMPulse, Sequence
+from qibolab.instruments.qm import QMOPX, QMPulse, Sequence, bake
 from qibolab.paths import qibolab_folder
 from qibolab.platform import create_tii_qw5q_gold
 from qibolab.pulses import FluxPulse, Pulse, ReadoutPulse, Rectangular
@@ -229,7 +229,7 @@ def test_qmopx_register_baked_pulse(duration):
     pulse = FluxPulse(3, duration, 0.05, Rectangular(), qubit.flux.name, qubit=qubit.name)
     qmpulse = QMPulse(pulse)
     config = opx.config
-    qmpulse.bake(config)
+    qmpulse.baked = bake(qmpulse, config)
 
     assert config.elements["flux3"]["operations"] == {"baked_Op_0": "flux3_baked_pulse_0"}
     if duration == 0:

--- a/tests/test_instruments_qmsim.py
+++ b/tests/test_instruments_qmsim.py
@@ -257,13 +257,14 @@ def test_qmsim_allxy(simulator, folder, count, gate_pair):
     assert_regression(samples, folder, f"allxy{count}")
 
 
-def test_qmsim_chevron(simulator, folder):
+@pytest.mark.parametrize("duration", [31, 32])
+def test_qmsim_chevron(simulator, folder, duration):
     lowfreq, highfreq = 1, 2
     initialize_1 = simulator.create_RX_pulse(lowfreq, start=0, relative_phase=0)
     initialize_2 = simulator.create_RX_pulse(highfreq, start=0, relative_phase=0)
     flux_pulse = FluxPulse(
         start=initialize_2.finish,
-        duration=31,
+        duration=duration,
         amplitude=0.05,
         shape=Rectangular(),
         channel=simulator.qubits[highfreq].flux.name,
@@ -280,7 +281,7 @@ def test_qmsim_chevron(simulator, folder):
 
     result = simulator.execute_pulse_sequence(sequence, nshots=1)
     samples = result.get_simulated_samples()
-    assert_regression(samples, folder, "chevron")
+    assert_regression(samples, folder, f"chevron_{duration}")
 
 
 def test_qmsim_chevron_sweeper(simulator, folder):

--- a/tests/test_instruments_qmsim.py
+++ b/tests/test_instruments_qmsim.py
@@ -290,7 +290,7 @@ def test_qmsim_chevron_sweeper(simulator, folder):
     initialize_2 = simulator.create_RX_pulse(highfreq, start=0, relative_phase=0)
     flux_pulse = FluxPulse(
         start=initialize_2.finish,
-        duration=20,
+        duration=1,
         amplitude=0.05,
         shape=Rectangular(),
         channel=simulator.qubits[highfreq].flux.name,


### PR DESCRIPTION
Implements a sweeper for the duration of flux pulses that are baked. This could be useful to generate the Chevron plot. Note that the sweeper does not work on pulses that are not baked (drive, readout).

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
