### PR TITLE
Intregrating Erasynth LO control in the driver

### DIFF
--- a/src/qibolab/instruments/rfsoc.py
+++ b/src/qibolab/instruments/rfsoc.py
@@ -30,6 +30,7 @@ class QickProgramConfig:
     expts: Optional[int] = None  # TODO remove
     mixer_freq: Optional[int] = None
     LO_freq: Optional[int] = None
+    LO_power: Optional[float] = None
 
 
 @dataclass
@@ -582,5 +583,6 @@ class TII_ZCU111(RFSoC):  # Containes the main settings:
         self.cfg = QickProgramConfig(
             sampling_rate=6_000_000_000,
             mixer_freq=0,
-            LO_freq=7_000_000_000,
+            LO_freq=6_850_000_000,
+            LO_power=15.0,
         )

--- a/src/qibolab/platform.py
+++ b/src/qibolab/platform.py
@@ -213,10 +213,11 @@ def create_tii_zcu111(runcard, address=None):
         address (str): Address and port for the QICK board.
             If ``None`` it will attempt to connect to TII instruments.
     """
-    from qibolab.instruments.dummy_oscillator import (
-        DummyLocalOscillator as LocalOscillator,
-    )
+    #from qibolab.instruments.dummy_oscillator import (
+    #    DummyLocalOscillator as LocalOscillator,
+    #)
     from qibolab.instruments.rfsoc import TII_ZCU111
+    from qibolab.instruments.erasynth import ERA
 
     # Create channel objects
     channels = ChannelMap()
@@ -284,19 +285,18 @@ def create_tii_zcu111(runcard, address=None):
         address = "192.168.0.81:6000"
     controller = TII_ZCU111("tii_zcu111", address)
 
-    # Instantiate local oscillators (HARDCODED) # TODO local oscillators should not be needed
+    # Instantiate local oscillators (HARDCODED) 
     local_oscillators = [
-        LocalOscillator("twpa", "192.168.0.35"),
+        ERA("ErasynthLO", "192.168.000.210"),
     ]
-    # Set TWPA parameters
-    # local_oscillators[0].frequency = 6_511_000_000
-    # local_oscillators[0].power = 4.5
+    # Set ErasynthLO parameters
+    local_oscillators[0].power = 15.0
+    local_oscillators[0].frequency =  6.85e9
 
-    # Map LOs to channels
-    # channels["L4-26"].local_oscillator = local_oscillators[0]  # TODO find the real channel
 
-    # TODO add local_oscillators
-    design = InstrumentDesign([controller], channels)
+
+    instruments = [controller] + local_oscillators
+    design = InstrumentDesign(instruments, channels)
     platform = DesignPlatform("tii_rfsocZCU111", design, runcard)
 
     # assign channels to qubits

--- a/src/qibolab/platform.py
+++ b/src/qibolab/platform.py
@@ -290,8 +290,8 @@ def create_tii_zcu111(runcard, address=None):
         ERA("ErasynthLO", "192.168.000.210"),
     ]
     # Set ErasynthLO parameters
-    local_oscillators[0].power = 15.0
-    local_oscillators[0].frequency =  6.85e9
+    local_oscillators[0].power = controller.cfg.LO_power
+    local_oscillators[0].frequency =  controller.cfg.LO_freq
 
 
 

--- a/src/qibolab/platform.py
+++ b/src/qibolab/platform.py
@@ -213,11 +213,11 @@ def create_tii_zcu111(runcard, address=None):
         address (str): Address and port for the QICK board.
             If ``None`` it will attempt to connect to TII instruments.
     """
-    #from qibolab.instruments.dummy_oscillator import (
+    # from qibolab.instruments.dummy_oscillator import (
     #    DummyLocalOscillator as LocalOscillator,
-    #)
-    from qibolab.instruments.rfsoc import TII_ZCU111
+    # )
     from qibolab.instruments.erasynth import ERA
+    from qibolab.instruments.rfsoc import TII_ZCU111
 
     # Create channel objects
     channels = ChannelMap()
@@ -285,15 +285,13 @@ def create_tii_zcu111(runcard, address=None):
         address = "192.168.0.81:6000"
     controller = TII_ZCU111("tii_zcu111", address)
 
-    # Instantiate local oscillators (HARDCODED) 
+    # Instantiate local oscillators (HARDCODED)
     local_oscillators = [
         ERA("ErasynthLO", "192.168.000.210"),
     ]
     # Set ErasynthLO parameters
     local_oscillators[0].power = controller.cfg.LO_power
-    local_oscillators[0].frequency =  controller.cfg.LO_freq
-
-
+    local_oscillators[0].frequency = controller.cfg.LO_freq
 
     instruments = [controller] + local_oscillators
     design = InstrumentDesign(instruments, channels)


### PR DESCRIPTION
This PR integrates the Erasynth local oscillator into the ZCU111 driver. The local oscillator is needed to upconvert and downconvert the readout.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.

