### PR TITLE
Fixing rfsoc amplitude sweeps

### DIFF
--- a/src/qibolab/instruments/rfsoc.py
+++ b/src/qibolab/instruments/rfsoc.py
@@ -477,7 +477,7 @@ class TII_RFSOC4x2(AbstractInstrument):
             if sweeper.parameter == Parameter.frequency:
                 sweeper.values += sweeper.pulses[0].frequency
             elif sweeper.parameter == Parameter.amplitude:
-                continue  # amp does not need modification, here for clarity
+                sweeper.values *= sweeper.pulses[0].amplitude
 
         sweepsequence = sequence.copy()
 
@@ -488,6 +488,6 @@ class TII_RFSOC4x2(AbstractInstrument):
             if sweeper.parameter == Parameter.frequency:
                 sweeper.values -= sweeper.pulses[0].frequency
             elif sweeper.parameter == Parameter.amplitude:
-                continue
+                sweeper.values /= sweeper.pulses[0].amplitude
 
         return results


### PR DESCRIPTION
Fixing the amplitude sweeper for the rfsoc driver (solving #377).

In the multiqubit version the sweeper will be done in a different way and the code will be more clean, for now this should work.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [ ] Documentation is updated.
