### PR TITLE
Correct classification parameters in runcard

### DIFF
--- a/src/qibolab/runcards/qw5q_gold_qblox.yml
+++ b/src/qibolab/runcards/qw5q_gold_qblox.yml
@@ -88,11 +88,11 @@ instruments:
 
             classification_parameters:
                 0:  # qubit id
-                    rotation_angle              : 99.772                   # in degrees 0.0<=v<=360.0
-                    threshold                   : 0.005800                  # in V
+                    rotation_angle              : 262.308                   # in degrees 0.0<=v<=360.0
+                    threshold                   : 0.030                 # in V
                 1:  # qubit id
-                    rotation_angle              : 109.202                   # in degrees 0.0<=v<=360.0
-                    threshold                   : 0.023372                  # in V
+                    rotation_angle              : 249.614                   # in degrees 0.0<=v<=360.0
+                    threshold                   : 0.060                 # in V
 
 
             channel_port_map:   # Refrigerator Channel : Instrument port
@@ -119,14 +119,14 @@ instruments:
 
             classification_parameters:
                 2:  # qubit id
-                    rotation_angle              : 296.887                    # in degrees 0.0<=v<=360.0
-                    threshold                   : 0.001114                  # in V
+                    rotation_angle              : 57.163                    # in degrees 0.0<=v<=360.0
+                    threshold                   : 0.002                  # in V
                 3:  # qubit id
-                    rotation_angle              : 306.039                    # in degrees 0.0<=v<=360.0
-                    threshold                   : 0.000914                  # in V
+                    rotation_angle              : 48.932                    # in degrees 0.0<=v<=360.0
+                    threshold                   : 0.003                  # in V
                 4:  # qubit id
-                    rotation_angle              : 63.762                   # in degrees 0.0<=v<=360.0
-                    threshold                   : 0.000371                  # in V
+                    rotation_angle              : 292.292                 # in degrees 0.0<=v<=360.0
+                    threshold                   : 0.000                # in V
 
             channel_port_map:   # Refrigerator Channel : Instrument port
                 'L3-25b' : o1    # IQ Port = out0 & out1


### PR DESCRIPTION
Update `qw5q_gold_qblox` runcard with new classification parameters following qiboteam/qibocal#305.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
