### PR TITLE
ZCU111-driver: auto searching LO for not conflicting frequencies

### DIFF
--- a/src/qibolab/instruments/rfsoc.py
+++ b/src/qibolab/instruments/rfsoc.py
@@ -196,6 +196,7 @@ class RFSoC(AbstractInstrument):
         while limits[0][1] - lo_freq < (fs / 32.0):
             if self.check_frequencies_conflicts_limits(limits, lo_freq):
                 self.local_oscillator.frequency = lo_freq
+                self.cfg.LO_freq = lo_freq
                 return True
             else:
                 lo_freq = lo_freq + 1_000_000
@@ -285,6 +286,12 @@ class RFSoC(AbstractInstrument):
         Returns:
             Lists of I and Q value measured
         """
+
+        if self.local_oscillator:
+            limits = self.find_frequency_limits_sweep(sequence, sweeper)
+            if not self.check_frequencies_conflicts_limits(limits, self.cfg.LO_freq):
+                if not self.set_best_LO(limits):
+                    raise ValueError("Optimal LO frequency not found")
 
         server_commands = {
             "operation_code": "execute_single_sweep",

--- a/src/qibolab/platform.py
+++ b/src/qibolab/platform.py
@@ -279,24 +279,21 @@ def create_tii_zcu111(runcard, address=None):
     # Flux
     channels["L1-25_fl"].ports = [("dac2", 2)]
 
-    # Instantiate QICK instruments
+    # Instantiate local oscillators (HARDCODED)
+    local_oscillators = [
+        ERA("ErasynthLO", "192.168.0.210"),
+    ]
 
+    # Instantiate QICK instruments
     if address is None:
         address = "192.168.0.81:6000"
-    controller = TII_ZCU111("tii_zcu111", address)
+    controller = TII_ZCU111("tii_zcu111", address, local_oscillators[0])
 
-    # Instantiate local oscillators (HARDCODED)
-    """
-    local_oscillators = [
-        ERA("ErasynthLO", "192.168.0.210", ethernet=False),
-    ]
     # Set ErasynthLO parameters
     local_oscillators[0].power = controller.cfg.LO_power
     local_oscillators[0].frequency = controller.cfg.LO_freq
 
     instruments = [controller] + local_oscillators
-    """
-    instruments = [controller]
 
     design = InstrumentDesign(instruments, channels)
     platform = DesignPlatform("tii_rfsocZCU111", design, runcard)

--- a/src/qibolab/platform.py
+++ b/src/qibolab/platform.py
@@ -281,7 +281,7 @@ def create_tii_zcu111(runcard, address=None):
 
     # Instantiate local oscillators (HARDCODED)
     local_oscillators = [
-        ERA("ErasynthLO", "192.168.0.210"),
+        ERA("ErasynthLO", "192.168.0.210", ethernet=True),
     ]
 
     # Instantiate QICK instruments
@@ -293,8 +293,7 @@ def create_tii_zcu111(runcard, address=None):
     local_oscillators[0].power = controller.cfg.LO_power
     local_oscillators[0].frequency = controller.cfg.LO_freq
 
-    # instruments = [controller] + local_oscillators
-    instruments = [controller]  # + local_oscillators
+    instruments = [controller] + local_oscillators
 
     design = InstrumentDesign(instruments, channels)
     platform = DesignPlatform("tii_rfsocZCU111", design, runcard)


### PR DESCRIPTION
Here I tried to add some function to automatically look for a valid LO frequency given a sequence.
This is needed, in some cases at least, because the firmware for multiplexed readout makes the multiplexed DAC have very small bands of possible frequencies.
In particular they are limited by `(fs/32)(2i + 1)` where fs is the ADC sampling frequency (3072 MHz).

This implementation is very slow because it changes the LO at every execute_pulse_sequences, but avoids errors.
We could improve this easily by just checking for collisions and then, only if there are some, looking for a good LO.

Also, this is now done only for pulse sequences, but would be important in particular for sweepers.


Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
