### PR TITLE
Exposing TWPA parameters for abstract and multiqubit

### DIFF
--- a/src/qibolab/platforms/abstract.py
+++ b/src/qibolab/platforms/abstract.py
@@ -474,6 +474,32 @@ class AbstractPlatform(ABC):
         """Get frequency of the qubit readout local oscillator in Hz."""
 
     @abstractmethod
+    def set_lo_twpa_frequency(self, qubit, freq):
+        """Set frequency of the local oscillator of the TWPA to which the qubit's feedline is connected to.
+
+        Args:
+            qubit (int): qubit whose local oscillator will be modified.
+            freq (int): new value of the frequency in Hz.
+        """
+
+    @abstractmethod
+    def get_lo_twpa_frequency(self, qubit):
+        """Get frequency of the local oscillator of the TWPA to which the qubit's feedline is connected to in Hz."""
+    
+    @abstractmethod
+    def set_lo_twpa_power(self, qubit, power):
+        """Set power of the local oscillator of the TWPA to which the qubit's feedline is connected to.
+
+        Args:
+            qubit (int): qubit whose local oscillator will be modified.
+            power (int): new value of the power in dBm.
+        """
+    
+    @abstractmethod
+    def get_lo_twpa_power(self, qubit):
+        """Get power of the local oscillator of the TWPA to which the qubit's feedline is connected to in dBm."""
+
+    @abstractmethod
     def set_attenuation(self, qubit, att):
         """Set attenuation value. Usefeul for calibration routines such as punchout.
 

--- a/src/qibolab/platforms/multiqubit.py
+++ b/src/qibolab/platforms/multiqubit.py
@@ -63,11 +63,8 @@ class MultiqubitPlatform(AbstractPlatform):
             if "twpa" in instrument:
                 self.instruments[instrument].frequency = freq
                 return None
-        raise_error(
-            NotImplementedError,
-            "No twpa instrument found in the platform. "
-        )
-        
+        raise_error(NotImplementedError, "No twpa instrument found in the platform. ")
+
     def get_lo_twpa_frequency(self, qubit):
         for instrument in self.instruments:
             if "twpa" in instrument:
@@ -79,10 +76,7 @@ class MultiqubitPlatform(AbstractPlatform):
             if "twpa" in instrument:
                 self.instruments[instrument].power = power
                 return None
-        raise_error(
-            NotImplementedError,
-            "No twpa instrument found in the platform. "
-        )
+        raise_error(NotImplementedError, "No twpa instrument found in the platform. ")
 
     def get_lo_twpa_power(self, qubit):
         for instrument in self.instruments:

--- a/src/qibolab/platforms/multiqubit.py
+++ b/src/qibolab/platforms/multiqubit.py
@@ -62,7 +62,7 @@ class MultiqubitPlatform(AbstractPlatform):
         for instrument in self.instruments:
             if "twpa" in instrument:
                 self.instruments[instrument].frequency = freq
-                break
+                return None
         raise_error(
             NotImplementedError,
             "No twpa instrument found in the platform. "
@@ -81,7 +81,7 @@ class MultiqubitPlatform(AbstractPlatform):
         for instrument in self.instruments:
             if "twpa" in instrument:
                 self.instruments[instrument].power = power
-                break
+                return None
         raise_error(
             NotImplementedError,
             "No twpa instrument found in the platform. "

--- a/src/qibolab/platforms/multiqubit.py
+++ b/src/qibolab/platforms/multiqubit.py
@@ -62,21 +62,39 @@ class MultiqubitPlatform(AbstractPlatform):
         for instrument in self.instruments:
             if "twpa" in instrument:
                 self.instruments[instrument].frequency = freq
-
+                break
+        raise_error(
+            NotImplementedError,
+            "No twpa instrument found in the platform. "
+        )
+        
     def get_lo_twpa_frequency(self, qubit):
         for instrument in self.instruments:
             if "twpa" in instrument:
                 return self.instruments[instrument].frequency
+        raise_error(
+            NotImplementedError,
+            "No twpa instrument found in the platform. "
+        )
 
     def set_lo_twpa_power(self, qubit, power):
         for instrument in self.instruments:
             if "twpa" in instrument:
                 self.instruments[instrument].power = power
+                break
+        raise_error(
+            NotImplementedError,
+            "No twpa instrument found in the platform. "
+        )
 
     def get_lo_twpa_power(self, qubit):
         for instrument in self.instruments:
             if "twpa" in instrument:
                 return self.instruments[instrument].power
+        raise_error(
+            NotImplementedError,
+            "No twpa instrument found in the platform. "
+        )
 
     def set_attenuation(self, qubit, att):
         self.ro_port[qubit].attenuation = att

--- a/src/qibolab/platforms/multiqubit.py
+++ b/src/qibolab/platforms/multiqubit.py
@@ -58,6 +58,26 @@ class MultiqubitPlatform(AbstractPlatform):
     def get_lo_readout_frequency(self, qubit):
         return self.ro_port[qubit].lo_frequency
 
+    def set_lo_twpa_frequency(self, qubit, freq):
+        for instrument in self.instruments:
+            if "twpa" in instrument.name:
+                instrument.frequency = freq
+
+    def get_lo_twpa_frequency(self, qubit):
+        for instrument in self.instruments:
+            if "twpa" in instrument.name:
+                return instrument.frequency
+            
+    def set_lo_twpa_power(self, qubit, power):
+        for instrument in self.instruments:
+            if "twpa" in instrument.name:
+                instrument.power = power
+
+    def get_lo_twpa_power(self, qubit):
+        for instrument in self.instruments:
+            if "twpa" in instrument.name:
+                return instrument.power
+            
     def set_attenuation(self, qubit, att):
         self.ro_port[qubit].attenuation = att
 

--- a/src/qibolab/platforms/multiqubit.py
+++ b/src/qibolab/platforms/multiqubit.py
@@ -60,23 +60,23 @@ class MultiqubitPlatform(AbstractPlatform):
 
     def set_lo_twpa_frequency(self, qubit, freq):
         for instrument in self.instruments:
-            if "twpa" in instrument.name:
-                instrument.frequency = freq
+            if "twpa" in instrument:
+                self.instruments[instrument].frequency = freq
 
     def get_lo_twpa_frequency(self, qubit):
         for instrument in self.instruments:
-            if "twpa" in instrument.name:
-                return instrument.frequency
+            if "twpa" in instrument:
+                return self.instruments[instrument].frequency
             
     def set_lo_twpa_power(self, qubit, power):
         for instrument in self.instruments:
-            if "twpa" in instrument.name:
-                instrument.power = power
+            if "twpa" in instrument:
+                self.instruments[instrument].power = power
 
     def get_lo_twpa_power(self, qubit):
         for instrument in self.instruments:
-            if "twpa" in instrument.name:
-                return instrument.power
+            if "twpa" in instrument:
+                return self.instruments[instrument].power
             
     def set_attenuation(self, qubit, att):
         self.ro_port[qubit].attenuation = att

--- a/src/qibolab/platforms/platform.py
+++ b/src/qibolab/platforms/platform.py
@@ -56,6 +56,15 @@ class DesignPlatform(AbstractPlatform):
     def get_lo_readout_frequency(self, qubit):
         return self.qubits[qubit].readout.local_oscillator.frequency
 
+    def set_lo_twpa_frequency(self, qubit, freq):
+        self.qubits[qubit].twpa.local_oscillator.frequency = freq
+
+    def get_lo_twpa_frequency(self, qubit):
+        return self.qubits[qubit].twpa.local_oscillator.frequency
+    
+    def set_lo_twpa_power(self, qubit, power):
+        self.qubits[qubit].twpa.local_oscillator.power = power
+        
     def set_attenuation(self, qubit, att):
         raise_error(NotImplementedError, f"{self.name} does not support attenuation.")
 

--- a/src/qibolab/platforms/platform.py
+++ b/src/qibolab/platforms/platform.py
@@ -64,7 +64,10 @@ class DesignPlatform(AbstractPlatform):
     
     def set_lo_twpa_power(self, qubit, power):
         self.qubits[qubit].twpa.local_oscillator.power = power
-        
+    
+    def get_lo_twpa_power(self, qubit):
+        return self.qubits[qubit].twpa.local_oscillator.power
+    
     def set_attenuation(self, qubit, att):
         raise_error(NotImplementedError, f"{self.name} does not support attenuation.")
 

--- a/src/qibolab/platforms/platform.py
+++ b/src/qibolab/platforms/platform.py
@@ -64,10 +64,10 @@ class DesignPlatform(AbstractPlatform):
 
     def set_lo_twpa_power(self, qubit, power):
         self.qubits[qubit].twpa.local_oscillator.power = power
-    
+
     def get_lo_twpa_power(self, qubit):
         return self.qubits[qubit].twpa.local_oscillator.power
-    
+
     def set_attenuation(self, qubit, att):
         raise_error(NotImplementedError, f"{self.name} does not support attenuation.")
 


### PR DESCRIPTION
**To test:**

You can `srun -p qw5q_gold python THIS`: 
```python
from qibolab import Platform

platform = Platform("qblox", runcard="/home/users/maxime.hantute/qibolab/src/qibolab/runcards/qw5q_gold_qblox.yml")

platform.connect()
platform.setup()
platform.start()

platform.set_lo_twpa_frequency(0, 5.0e9)
platform.set_lo_twpa_power(0, -10.0)

platform.stop()
platform.disconnect()
```

**Proof that it works:**
![image](https://user-images.githubusercontent.com/52139175/234315577-73ff00e1-5897-4421-9a3f-ca8388a46a31.png)

**Comment:**
This is far from optimal because it would only work with a QPU with one feedline and one TWPA, but we should migrate multiqubit to `design` anyway so I think that it is acceptable for now anyway. 


Checklist:
- [ ] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
