### PR TITLE
Fix qpu tests for rfsoc

### DIFF
--- a/.github/workflows/selfhosted.yml
+++ b/.github/workflows/selfhosted.yml
@@ -74,13 +74,9 @@ jobs:
       with:
         name: coverage-from-self-hosted
         path: coverage/
-    - name: Notify the Pull Request
-      uses: thollander/actions-comment-pull-request@v2
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Publish Test Results
+      uses: EnricoMi/publish-unit-test-result-action@v2
+      if: always()
       with:
-        message: |
-          Run on QPU `${{ matrix.platform }}` completed! :atom:
-
-          > *You can download the coverage report as an artifact, from the workflow summary page:*
-          > ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        files: |
+          coverage/coverage.xml

--- a/.github/workflows/selfhosted.yml
+++ b/.github/workflows/selfhosted.yml
@@ -75,8 +75,8 @@ jobs:
         name: coverage-from-self-hosted
         path: coverage/
     - name: Publish Test Results
-      uses: EnricoMi/publish-unit-test-result-action@v2
+      uses:
       if: always()
       with:
-        files: |
-          coverage/coverage.xml
+        name: QPU Tests Results
+        path: coverage/coverage.xml

--- a/.github/workflows/selfhosted.yml
+++ b/.github/workflows/selfhosted.yml
@@ -74,8 +74,13 @@ jobs:
       with:
         name: coverage-from-self-hosted
         path: coverage/
-    - name: Publish Test Results
-      uses: mikepenz/action-junit-report@v3
-      if: always()
+    - name: Notify the Pull Request
+      uses: thollander/actions-comment-pull-request@v2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        report_paths: 'coverage/coverage.xml'
+        message: |
+          Run on QPU `${{ matrix.platform }}` completed! :atom:
+
+          > *You can download the coverage report as an artifact, from the workflow summary page:*
+          > ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/selfhosted.yml
+++ b/.github/workflows/selfhosted.yml
@@ -75,7 +75,7 @@ jobs:
         name: coverage-from-self-hosted
         path: coverage/
     - name: Publish Test Results
-      uses:
+      uses: dorny/test-reporter@v1
       if: always()
       with:
         name: QPU Tests Results

--- a/.github/workflows/selfhosted.yml
+++ b/.github/workflows/selfhosted.yml
@@ -75,8 +75,7 @@ jobs:
         name: coverage-from-self-hosted
         path: coverage/
     - name: Publish Test Results
-      uses: dorny/test-reporter@v1
+      uses: mikepenz/action-junit-report@v3
       if: always()
       with:
-        name: QPU Tests Results
-        path: coverage/coverage.xml
+        report_paths: 'coverage/coverage.xml'

--- a/src/qibolab/designs/channels.py
+++ b/src/qibolab/designs/channels.py
@@ -29,7 +29,7 @@ class Channel:
     """
     ports: List[tuple] = field(default_factory=list)
     """List of tuples (controller, port) connected to this channel."""
-    local_oscillator: Optional[LocalOscillator] = None
+    _local_oscillator: Optional[LocalOscillator] = None
     """Instrument object controlling the local oscillator connected to this channel.
     Not applicable for setups that do not use local oscillators because the controller
     can send sufficiently high frequencies
@@ -52,9 +52,24 @@ class Channel:
     """
 
     @property
+    def local_oscillator(self):
+        """LocalOscillator object connnected to this channel."""
+        if self._local_oscillator is None:
+            raise_error(NotImplementedError, f"Channel {name} does not have a local oscillator")
+        return self._local_oscillator
+
+    @local_oscillator.setter
+    def local_oscillator(self, local_oscillator):
+        if not isinstance(local_oscillator, LocalOscillator):
+            raise_error(TypeError, "Attempting to set LocalOscillator failed.")
+        self._local_oscillator = local_oscillator
+
+    @property
     def bias(self):
         """Bias offset for flux channels."""
         if self._bias is None:
+            if self.qubit.flux is None:
+                raise_error(NotImplementedError, f"Channel {name} is not connected to a flux qubit")
             # operate qubits at their sweetspot unless otherwise stated
             check_max_bias(self.qubit.sweetspot, self.max_bias)
             return self.qubit.sweetspot

--- a/src/qibolab/designs/channels.py
+++ b/src/qibolab/designs/channels.py
@@ -55,7 +55,7 @@ class Channel:
     def local_oscillator(self):
         """LocalOscillator object connnected to this channel."""
         if self._local_oscillator is None:
-            raise_error(NotImplementedError, f"Channel {name} does not have a local oscillator")
+            raise_error(NotImplementedError, f"Channel {self.name} does not have a local oscillator")
         return self._local_oscillator
 
     @local_oscillator.setter
@@ -69,7 +69,7 @@ class Channel:
         """Bias offset for flux channels."""
         if self._bias is None:
             if self.qubit.flux is None:
-                raise_error(NotImplementedError, f"Channel {name} is not connected to a flux qubit")
+                raise_error(NotImplementedError, f"Channel {self.name} is not connected to a flux qubit")
             # operate qubits at their sweetspot unless otherwise stated
             check_max_bias(self.qubit.sweetspot, self.max_bias)
             return self.qubit.sweetspot

--- a/src/qibolab/platforms/platform.py
+++ b/src/qibolab/platforms/platform.py
@@ -45,23 +45,15 @@ class DesignPlatform(AbstractPlatform):
         )
 
     def set_lo_drive_frequency(self, qubit, freq):
-        if self.qubits[qubit].drive.local_oscillator is None:
-            raise_error(NotImplementedError, f"Qubit {qubit} drive does not have a local oscillator")
         self.qubits[qubit].drive.local_oscillator.frequency = freq
 
     def get_lo_drive_frequency(self, qubit):
-        if self.qubits[qubit].drive.local_oscillator is None:
-            raise_error(NotImplementedError, f"Qubit {qubit} drive does not have a local oscillator")
         return self.qubits[qubit].drive.local_oscillator.frequency
 
     def set_lo_readout_frequency(self, qubit, freq):
-        if self.qubits[qubit].readout.local_oscillator is None:
-            raise_error(NotImplementedError, f"Qubit {qubit} readout does not have a local oscillator")
         self.qubits[qubit].readout.local_oscillator.frequency = freq
 
     def get_lo_readout_frequency(self, qubit):
-        if self.qubits[qubit].readout.local_oscillator is None:
-            raise_error(NotImplementedError, f"Qubit {qubit} readout does not have a local oscillator")
         return self.qubits[qubit].readout.local_oscillator.frequency
 
     def set_lo_twpa_frequency(self, qubit, freq):
@@ -89,11 +81,7 @@ class DesignPlatform(AbstractPlatform):
         raise_error(NotImplementedError, f"{self.name} does not support gain.")
 
     def set_bias(self, qubit, bias):
-        if self.qubits[qubit].flux is None:
-            raise_error(NotImplementedError, f"Qubit {qubit} does not support flux")
         self.qubits[qubit].flux.bias = bias
 
     def get_bias(self, qubit):
-        if self.qubits[qubit].flux is None:
-            raise_error(NotImplementedError, f"Qubit {qubit} does not support flux")
         return self.qubits[qubit].flux.bias

--- a/src/qibolab/platforms/platform.py
+++ b/src/qibolab/platforms/platform.py
@@ -45,15 +45,23 @@ class DesignPlatform(AbstractPlatform):
         )
 
     def set_lo_drive_frequency(self, qubit, freq):
+        if self.qubits[qubit].drive.local_oscillator is None:
+            raise_error(NotImplementedError, f"Qubit {qubit} drive does not have a local oscillator")
         self.qubits[qubit].drive.local_oscillator.frequency = freq
 
     def get_lo_drive_frequency(self, qubit):
+        if self.qubits[qubit].drive.local_oscillator is None:
+            raise_error(NotImplementedError, f"Qubit {qubit} drive does not have a local oscillator")
         return self.qubits[qubit].drive.local_oscillator.frequency
 
     def set_lo_readout_frequency(self, qubit, freq):
+        if self.qubits[qubit].readout.local_oscillator is None:
+            raise_error(NotImplementedError, f"Qubit {qubit} readout does not have a local oscillator")
         self.qubits[qubit].readout.local_oscillator.frequency = freq
 
     def get_lo_readout_frequency(self, qubit):
+        if self.qubits[qubit].readout.local_oscillator is None:
+            raise_error(NotImplementedError, f"Qubit {qubit} readout does not have a local oscillator")
         return self.qubits[qubit].readout.local_oscillator.frequency
 
     def set_lo_twpa_frequency(self, qubit, freq):
@@ -81,7 +89,11 @@ class DesignPlatform(AbstractPlatform):
         raise_error(NotImplementedError, f"{self.name} does not support gain.")
 
     def set_bias(self, qubit, bias):
+        if self.qubits[qubit].flux is None:
+            raise_error(NotImplementedError, f"Qubit {qubit} does not support flux")
         self.qubits[qubit].flux.bias = bias
 
     def get_bias(self, qubit):
+        if self.qubits[qubit].flux is None:
+            raise_error(NotImplementedError, f"Qubit {qubit} does not support flux")
         return self.qubits[qubit].flux.bias

--- a/src/qibolab/platforms/platform.py
+++ b/src/qibolab/platforms/platform.py
@@ -81,6 +81,8 @@ class DesignPlatform(AbstractPlatform):
         raise_error(NotImplementedError, f"{self.name} does not support gain.")
 
     def set_bias(self, qubit, bias):
+        if self.qubits[qubit].flux is None:
+            raise_error(NotImplementedError, f"{self.name} does not have flux.")
         self.qubits[qubit].flux.bias = bias
 
     def get_bias(self, qubit):

--- a/tests/test_designs_channels.py
+++ b/tests/test_designs_channels.py
@@ -7,7 +7,8 @@ def test_channel_init():
     channel = Channel("L1-test")
     channel.ports = [("c1", 0), ("c2", 1)]
     assert channel.name == "L1-test"
-    assert channel.local_oscillator is None
+    with pytest.raises(NotImplementedError):
+        _ = channel.local_oscillator
 
 
 def test_channel_errors():

--- a/tests/test_instruments_erasynth.py
+++ b/tests/test_instruments_erasynth.py
@@ -8,7 +8,7 @@ from .conftest import load_from_platform
 
 
 @pytest.mark.qpu
-def test_instruments_erasynth_init(instrument):
+def test_instruments_erasynth_init(instrument, platform_name):
     assert instrument.is_connected == True
     assert instrument.device
     assert instrument.data_folder == user_folder / "instruments" / "data" / instrument.tmp_folder.name.split("/")[-1]
@@ -34,7 +34,7 @@ def instrument_set_and_test_parameter_values(instrument, parameter, values):
 
 
 @pytest.mark.qpu
-def test_instruments_erasynth_set_device_paramter(instrument):
+def test_instruments_erasynth_set_device_paramter(instrument, platform_name):
     instrument_set_and_test_parameter_values(
         instrument, f"power", np.arange(-60, 0, 10)
     )  # Max power is 25dBm but to be safe testing only until 0dBm
@@ -42,7 +42,7 @@ def test_instruments_erasynth_set_device_paramter(instrument):
 
 
 @pytest.mark.qpu
-def test_instruments_erasynth_start_stop_disconnect(instrument):
+def test_instruments_erasynth_start_stop_disconnect(instrument, platform_name):
     instrument.start()
     instrument.stop()
     instrument.disconnect()

--- a/tests/test_platforms.py
+++ b/tests/test_platforms.py
@@ -83,14 +83,16 @@ def test_abstractplatform_setup_start_stop(platform):
 
 @pytest.mark.qpu
 def test_platform_lo_drive_frequency(platform):
-    platform.set_lo_drive_frequency(qubit, 1e9)
-    assert platform.get_lo_drive_frequency(qubit) == 1e9
+    with pytest.raises(NotImplementedError):
+        platform.set_lo_drive_frequency(qubit, 1e9)
+        assert platform.get_lo_drive_frequency(qubit) == 1e9
 
 
 @pytest.mark.qpu
 def test_platform_lo_readout_frequency(platform):
-    platform.set_lo_readout_frequency(qubit, 1e9)
-    assert platform.get_lo_readout_frequency(qubit) == 1e9
+    with pytest.raises(NotImplementedError):
+        platform.set_lo_readout_frequency(qubit, 1e9)
+        assert platform.get_lo_readout_frequency(qubit) == 1e9
 
 
 @pytest.mark.qpu
@@ -119,8 +121,9 @@ def test_platform_gain(platform):
 
 @pytest.mark.qpu
 def test_platform_bias(platform):
-    platform.set_bias(qubit, 0)
-    assert platform.get_bias(qubit) == 0
+    with pytest.raises(NotImplementedError):
+        platform.set_bias(qubit, 0)
+        assert platform.get_bias(qubit) == 0
 
 
 @pytest.mark.qpu


### PR DESCRIPTION
Some of the qpu tests were failing were run with the rfsoc because local oscillators and flux biases were not present.
I tried to fix them.


Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
