### PR TITLE
RFSoC: receive server errors

### DIFF
--- a/src/qibolab/instruments/rfsoc.py
+++ b/src/qibolab/instruments/rfsoc.py
@@ -180,6 +180,8 @@ class TII_RFSOC4x2(AbstractInstrument):
                     break
                 received.extend(tmp)
         results = pickle.loads(received)
+        if isinstance(results, Exception):
+            raise RuntimeError(f"An error occured on the server side: {results}")
         return results["i"], results["q"]
 
     def play(


### PR DESCRIPTION
With this PR, the qibolab rfsoc driver will raise itself the errors that happen in the server.
At the moment, when the server encounters an error, the client just print "Aborted"

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
