### PR TITLE
Rfosc ExecutionParameters, New Results

### DIFF
--- a/src/qibolab/instruments/rfsoc.py
+++ b/src/qibolab/instruments/rfsoc.py
@@ -237,11 +237,10 @@ class TII_RFSOC4x2(AbstractInstrument):
 
                 if execution_parameters.acquisition_type is AcquisitionType.DISCRIMINATION:
                     shots = self.classify_shots(i_pulse, q_pulse, qubits[ro_pulse.qubit])
+                    result = execution_parameters.get_results_type(shots, execution_parameters.nshots)
                 else:
-                    shots = None
-                results[ro_pulse.qubit] = results[serial] = execution_parameters.get_results_type(
-                    i_pulse, q_pulse, shots
-                )
+                    result = execution_parameters.get_results_type(i_pulse, q_pulse, execution_parameters.nshots)
+                results[ro_pulse.qubit] = results[serial] = result
 
         return results
 
@@ -443,8 +442,6 @@ class TII_RFSOC4x2(AbstractInstrument):
         """
         sweep_results = {}
 
-        results_type = execution_parameters.get_results_type()
-
         adcs = np.unique([qubits[p.qubit].feedback.ports[0][1] for p in sequence.ro_pulses])
         for k in range(len(adcs)):
             for j in range(len(sweeper.values)):
@@ -457,9 +454,10 @@ class TII_RFSOC4x2(AbstractInstrument):
                     if execution_parameters.acquisition_type is AcquisitionType.DISCRIMINATION:
                         qubit = qubits[sequence.ro_pulses[i].qubit]
                         shots = self.classify_shots(i_pulse, q_pulse, qubit)
+                        result = execution_parameters.get_results_type(shots, execution_parameters.nshots)
                     else:
-                        shots = None
-                    results[sequence.ro_pulses[i].qubit] = results[serial] = results_type(i_pulse, q_pulse, shots)
+                        result = execution_parameters.get_results_type(i_pulse, q_pulse, execution_parameters.nshots)
+                    results[sequence.ro_pulses[i].qubit] = results[serial] = result
                 # merge new result with already saved ones
                 sweep_results = self.merge_sweep_results(sweep_results, results)
         return sweep_results

--- a/src/qibolab/instruments/rfsoc.py
+++ b/src/qibolab/instruments/rfsoc.py
@@ -237,11 +237,9 @@ class TII_RFSOC4x2(AbstractInstrument):
 
                 if execution_parameters.acquisition_type is AcquisitionType.DISCRIMINATION:
                     shots = self.classify_shots(i_pulse, q_pulse, qubits[ro_pulse.qubit])
-                    result = execution_parameters.get_results_type()(states=shots, shots=execution_parameters.nshots)
+                    result = execution_parameters.results_type(states=shots, shots=execution_parameters.nshots)
                 else:
-                    result = execution_parameters.get_results_type()(
-                        i=i_pulse, q=q_pulse, shots=execution_parameters.nshots
-                    )
+                    result = execution_parameters.results_type(i=i_pulse, q=q_pulse, shots=execution_parameters.nshots)
                 results[ro_pulse.qubit] = results[serial] = result
 
         return results
@@ -456,11 +454,9 @@ class TII_RFSOC4x2(AbstractInstrument):
                     if execution_parameters.acquisition_type is AcquisitionType.DISCRIMINATION:
                         qubit = qubits[sequence.ro_pulses[i].qubit]
                         shots = self.classify_shots(i_pulse, q_pulse, qubit)
-                        result = execution_parameters.get_results_type()(
-                            states=shots, shots=execution_parameters.nshots
-                        )
+                        result = execution_parameters.results_type(states=shots, shots=execution_parameters.nshots)
                     else:
-                        result = execution_parameters.get_results_type()(
+                        result = execution_parameters.results_type(
                             i=i_pulse, q=q_pulse, shots=execution_parameters.nshots
                         )
                     results[sequence.ro_pulses[i].qubit] = results[serial] = result

--- a/src/qibolab/instruments/rfsoc.py
+++ b/src/qibolab/instruments/rfsoc.py
@@ -237,9 +237,11 @@ class TII_RFSOC4x2(AbstractInstrument):
 
                 if execution_parameters.acquisition_type is AcquisitionType.DISCRIMINATION:
                     shots = self.classify_shots(i_pulse, q_pulse, qubits[ro_pulse.qubit])
-                    result = execution_parameters.get_results_type(shots, execution_parameters.nshots)
+                    result = execution_parameters.get_results_type()(states=shots, shots=execution_parameters.nshots)
                 else:
-                    result = execution_parameters.get_results_type(i_pulse, q_pulse, execution_parameters.nshots)
+                    result = execution_parameters.get_results_type()(
+                        i=i_pulse, q=q_pulse, shots=execution_parameters.nshots
+                    )
                 results[ro_pulse.qubit] = results[serial] = result
 
         return results
@@ -454,9 +456,13 @@ class TII_RFSOC4x2(AbstractInstrument):
                     if execution_parameters.acquisition_type is AcquisitionType.DISCRIMINATION:
                         qubit = qubits[sequence.ro_pulses[i].qubit]
                         shots = self.classify_shots(i_pulse, q_pulse, qubit)
-                        result = execution_parameters.get_results_type(shots, execution_parameters.nshots)
+                        result = execution_parameters.get_results_type()(
+                            states=shots, shots=execution_parameters.nshots
+                        )
                     else:
-                        result = execution_parameters.get_results_type(i_pulse, q_pulse, execution_parameters.nshots)
+                        result = execution_parameters.get_results_type()(
+                            i=i_pulse, q=q_pulse, shots=execution_parameters.nshots
+                        )
                     results[sequence.ro_pulses[i].qubit] = results[serial] = result
                 # merge new result with already saved ones
                 sweep_results = self.merge_sweep_results(sweep_results, results)

--- a/src/qibolab/instruments/rfsoc.py
+++ b/src/qibolab/instruments/rfsoc.py
@@ -192,8 +192,8 @@ class TII_RFSOC4x2(AbstractInstrument):
     def play(
         self,
         qubits: List[Qubit],
-        sequence: PulseSequence,
         execution_parameters: ExecutionParameters,
+        sequence: PulseSequence,
     ) -> Dict[str, Union[IntegratedResults, StateResults]]:
         """Executes the sequence of instructions and retrieves readout results.
            Each readout pulse generates a separate acquisition.
@@ -202,12 +202,12 @@ class TII_RFSOC4x2(AbstractInstrument):
         Args:
             qubits (list): List of `qibolab.platforms.utils.Qubit` objects
                            passed from the platform.
-            sequence (`qibolab.pulses.PulseSequence`): Pulse sequence to play.
             execution_parameters (ExecutionParameters): Parameters (nshots,
                                                         relaxation_time,
                                                         fast_reset,
                                                         acquisition_type,
                                                         averaging_mode)
+            sequence (`qibolab.pulses.PulseSequence`): Pulse sequence to play.
         Returns:
             A dictionary mapping the readout pulses serial and respective qubits to
             qibolab results objects
@@ -467,9 +467,9 @@ class TII_RFSOC4x2(AbstractInstrument):
     def sweep(
         self,
         qubits: List[Qubit],
+        execution_parameters: ExecutionParameters,
         sequence: PulseSequence,
         *sweepers: Sweeper,
-        execution_parameters: ExecutionParameters,
     ) -> Dict[str, Union[IntegratedResults, StateResults]]:
         """Executes the sweep and retrieves the readout results.
         Each readout pulse generates a separate acquisition.
@@ -478,13 +478,13 @@ class TII_RFSOC4x2(AbstractInstrument):
         Args:
             qubits (list): List of `qibolab.platforms.utils.Qubit` objects
                            passed from the platform.
-            sequence (`qibolab.pulses.PulseSequence`). Pulse sequence to play.
-            *sweepers (`qibolab.Sweeper`): Sweeper objects.
             execution_parameters (ExecutionParameters): Parameters (nshots,
                                                         relaxation_time,
                                                         fast_reset,
                                                         acquisition_type,
                                                         averaging_mode)
+            sequence (`qibolab.pulses.PulseSequence`). Pulse sequence to play.
+            *sweepers (`qibolab.Sweeper`): Sweeper objects.
         Returns:
             A dictionary mapping the readout pulses serial and respective qubits to
             results objects

--- a/src/qibolab/platforms/platform.py
+++ b/src/qibolab/platforms/platform.py
@@ -82,7 +82,6 @@ class DesignPlatform(AbstractPlatform):
             self.qubits,
             options,
             sequence,
-            options,
             *sweepers,
         )
 

--- a/src/qibolab/platforms/platform.py
+++ b/src/qibolab/platforms/platform.py
@@ -155,20 +155,21 @@ class ExecutionParameters:
     acquisition_type: AcquisitionType = AcquisitionType.DISCRIMINATION
     averaging_mode: AveragingMode = AveragingMode.SINGLESHOT
 
-    def get_results_type(self):
+    @property
+    def results_type(self):
         """Returns corresponding results class"""
+        return RESULTS_TYPE[self.averaging_mode][self.acquisition_type]
 
-        if self.averaging_mode is AveragingMode.SINGLESHOT:
-            if self.acquisition_type is AcquisitionType.INTEGRATION:
-                return IntegratedResults
-            elif self.acquisition_type is AcquisitionType.RAW:
-                return RawWaveformResults
-            else:
-                return StateResults
-        else:
-            if self.acquisition_type is AcquisitionType.INTEGRATION:
-                return AveragedIntegratedResults
-            elif self.acquisition_type is AcquisitionType.RAW:
-                return AveragedRawWaveformResults
-            else:
-                return AveragedStateResults
+
+RESULTS_TYPE = {
+    AveragingMode.CYCLIC: {
+        AcquisitionType.INTEGRATION: AveragedIntegratedResults,
+        AcquisitionType.RAW: AveragedRawWaveformResults,
+        AcquisitionType.DISCRIMINATION: AveragedStateResults,
+    },
+    AveragingMode.SINGLESHOT: {
+        AcquisitionType.INTEGRATION: IntegratedResults,
+        AcquisitionType.RAW: RawWaveformResults,
+        AcquisitionType.DISCRIMINATION: StateResults,
+    },
+}

--- a/src/qibolab/platforms/platform.py
+++ b/src/qibolab/platforms/platform.py
@@ -150,3 +150,30 @@ class ExecutionParameters:
     fast_reset: bool = False
     acquisition_type: AcquisitionType = AcquisitionType.DISCRIMINATION
     averaging_mode: AveragingMode = AveragingMode.SINGLESHOT
+
+    def get_results_type(self):
+        """Returns corresponding results class"""
+
+        from qibolab.result import (
+            AveragedIntegratedResults,
+            AveragedRawWaveformResults,
+            AveragedStateResults,
+            IntegratedResults,
+            RawWaveformResults,
+            StateResults,
+        )
+
+        if self.averaging_mode is AveragingMode.SINGLESHOT:
+            if self.acquisition_type is AcquisitionType.INTEGRATION:
+                return IntegratedResults
+            elif self.acquisition_type is AcquisitionType.RAW:
+                return RawWaveformResults
+            else:
+                return StateResults
+        else:
+            if self.acquisition_type is AcquisitionType.INTEGRATION:
+                return AveragedIntegratedResults
+            elif self.acquisition_type is AcquisitionType.RAW:
+                return AveragedRawWaveformResults
+            else:
+                return AveragedStateResults

--- a/src/qibolab/platforms/platform.py
+++ b/src/qibolab/platforms/platform.py
@@ -5,6 +5,14 @@ from typing import Optional
 from qibo.config import raise_error
 
 from qibolab.platforms.abstract import AbstractPlatform
+from qibolab.result import (
+    AveragedIntegratedResults,
+    AveragedRawWaveformResults,
+    AveragedStateResults,
+    IntegratedResults,
+    RawWaveformResults,
+    StateResults,
+)
 
 
 class DesignPlatform(AbstractPlatform):
@@ -42,11 +50,7 @@ class DesignPlatform(AbstractPlatform):
         if options.relaxation_time is None:
             options.relaxation_time = self.relaxation_time
 
-        return self.design.play(
-            self.qubits,
-            sequence,
-            options=options,
-        )
+        return self.design.play(self.qubits, options, sequence)
 
     def sweep(self, sequence, *sweepers, **kwargs):
         options = ExecutionParameters(**kwargs)
@@ -56,9 +60,9 @@ class DesignPlatform(AbstractPlatform):
 
         return self.design.sweep(
             self.qubits,
+            options,
             sequence,
             *sweepers,
-            options=options,
         )
 
     def set_lo_drive_frequency(self, qubit, freq):
@@ -153,15 +157,6 @@ class ExecutionParameters:
 
     def get_results_type(self):
         """Returns corresponding results class"""
-
-        from qibolab.result import (
-            AveragedIntegratedResults,
-            AveragedRawWaveformResults,
-            AveragedStateResults,
-            IntegratedResults,
-            RawWaveformResults,
-            StateResults,
-        )
 
         if self.averaging_mode is AveragingMode.SINGLESHOT:
             if self.acquisition_type is AcquisitionType.INTEGRATION:


### PR DESCRIPTION
I should have updated the rfsoc driver in compliance to the updated in ExecutionParameters and the new results objects.
I still didn't test anything.

Something that could be useful to others, but can also be removed if you don't like it, is the `ExecutionParameters.get_results_type()` function.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
