### PR TITLE
Pulses: change order, check equality

### DIFF
--- a/src/qibolab/pulses.py
+++ b/src/qibolab/pulses.py
@@ -1046,7 +1046,7 @@ class Pulse:
         )
 
     def is_equal_ignoring_start(self, item) -> bool:
-        """Check if two pulses are equal, excepto from the start time"""
+        """Check if two pulses are equal ignoring start time"""
         return (
             self.duration == item.duration
             and self.amplitude == item.amplitude

--- a/src/qibolab/pulses.py
+++ b/src/qibolab/pulses.py
@@ -369,7 +369,7 @@ class IIR(PulseShape):
     def __eq__(self, item) -> bool:
         """Overloads == operator"""
         if type(item) is IIR:
-            return self.target == item.target and self.a == item.a and self.b == item.b
+            return self.target == item.target and (self.a == item.a).all() and (self.b == item.b).all()
         return False
 
     @property
@@ -447,7 +447,7 @@ class SNZ(PulseShape):
     def __eq__(self, item) -> bool:
         """Overloads == operator"""
         if type(item) is SNZ:
-            return self.t_half_flux_pulse == item.t_half_flux_pulse
+            return self.t_half_flux_pulse == item.t_half_flux_pulse and self.b_amplitude == item.b_amplitude
         return False
 
     @property

--- a/src/qibolab/pulses.py
+++ b/src/qibolab/pulses.py
@@ -369,7 +369,7 @@ class IIR(PulseShape):
     def __eq__(self, item) -> bool:
         """Overloads == operator"""
         if type(item) is IIR:
-            return self.target == item.target and self.a == item.a and self.b == target.b
+            return self.target == item.target and self.a == item.a and self.b == item.b
         return False
 
     @property

--- a/src/qibolab/pulses.py
+++ b/src/qibolab/pulses.py
@@ -178,6 +178,10 @@ class Rectangular(PulseShape):
         self.name = "Rectangular"
         self.pulse: Pulse = None
 
+    def __eq__(self, item) -> bool:
+        """Overloads == operator"""
+        return type(item) is Rectangular
+
     @property
     def envelope_waveform_i(self) -> Waveform:
         """The envelope waveform of the i component of the pulse."""
@@ -226,6 +230,12 @@ class Gaussian(PulseShape):
         self.name = "Gaussian"
         self.pulse: Pulse = None
         self.rel_sigma: float = float(rel_sigma)
+
+    def __eq__(self, item) -> bool:
+        """Overloads == operator"""
+        if type(item) is Gaussian:
+            return self.rel_sigma == item.rel_sigma
+        return False
 
     @property
     def envelope_waveform_i(self) -> Waveform:
@@ -280,6 +290,12 @@ class Drag(PulseShape):
         self.pulse: Pulse = None
         self.rel_sigma = float(rel_sigma)
         self.beta = float(beta)
+
+    def __eq__(self, item) -> bool:
+        """Overloads == operator"""
+        if type(item) is Drag:
+            return self.rel_sigma == item.rel_sigma and self.beta == item.beta
+        return False
 
     @property
     def envelope_waveform_i(self) -> Waveform:
@@ -349,6 +365,12 @@ class IIR(PulseShape):
         self.a: np.ndarray = np.array(a)
         self.b: np.ndarray = np.array(b)
         # Check len(a) = len(b) = 2
+
+    def __eq__(self, item) -> bool:
+        """Overloads == operator"""
+        if type(item) is IIR:
+            return self.target == item.target and self.a == item.a and self.b == target.b
+        return False
 
     @property
     def pulse(self):
@@ -422,6 +444,12 @@ class SNZ(PulseShape):
         self.t_half_flux_pulse: float = t_half_flux_pulse
         self.b_amplitude: float = b_amplitude
 
+    def __eq__(self, item) -> bool:
+        """Overloads == operator"""
+        if type(item) is SNZ:
+            return self.t_half_flux_pulse == item.t_half_flux_pulse
+        return False
+
     @property
     def envelope_waveform_i(self) -> Waveform:
         """The envelope waveform of the i component of the pulse."""
@@ -484,6 +512,12 @@ class eCap(PulseShape):
         self.name = "eCap"
         self.pulse: Pulse = None
         self.alpha: float = float(alpha)
+
+    def __eq__(self, item) -> bool:
+        """Overloads == operator"""
+        if type(item) is eCap:
+            return self.alpha == item.alpha
+        return False
 
     @property
     def envelope_waveform_i(self) -> Waveform:
@@ -1011,6 +1045,19 @@ class Pulse:
             self._qubit,
         )
 
+    def is_equal(self, item: Pulse) -> bool:
+        """Check if two pulses are equal, excepto from the start time"""
+        return (
+            self.duration == item.duration
+            and self.amplitude == item.amplitude
+            and self.frequency == item.frequency
+            and self.relative_phase == item.relative_phase
+            and self.shape == item.shape
+            and self.channel == item.channel
+            and self.type == item.type
+            and self.qubit == item.qubit
+        )
+
     def plot(self, savefig_filename=None):
         """Plots the pulse envelope and modulated waveforms.
 
@@ -1495,7 +1542,7 @@ class PulseSequence:
                 ps = item
                 for pulse in ps.pulses:
                     self.pulses.append(pulse)
-        self.pulses.sort(key=lambda item: (item.channel, item.start))
+        self.pulses.sort(key=lambda item: (item.start, item.channel))
 
     def index(self, pulse):
         """Returns the index of a pulse in the sequence."""

--- a/src/qibolab/pulses.py
+++ b/src/qibolab/pulses.py
@@ -1045,7 +1045,7 @@ class Pulse:
             self._qubit,
         )
 
-    def is_equal(self, item) -> bool:
+    def is_equal_ignoring_start(self, item) -> bool:
         """Check if two pulses are equal, excepto from the start time"""
         return (
             self.duration == item.duration

--- a/src/qibolab/pulses.py
+++ b/src/qibolab/pulses.py
@@ -167,6 +167,10 @@ class PulseShape(ABC):
         modulated_waveform_q.serial = f"Modulated_Waveform_Q(num_samples = {num_samples}, amplitude = {format(pulse.amplitude, '.6f').rstrip('0').rstrip('.')}, shape = {str(pulse.shape)}, frequency = {format(pulse.frequency, '_')}, phase = {format(global_phase + pulse.relative_phase, '.6f').rstrip('0').rstrip('.')})"
         return (modulated_waveform_i, modulated_waveform_q)
 
+    def __eq__(self, item) -> bool:
+        """Overloads == operator"""
+        return type(item) is self.__class__
+
 
 class Rectangular(PulseShape):
     """
@@ -177,10 +181,6 @@ class Rectangular(PulseShape):
     def __init__(self):
         self.name = "Rectangular"
         self.pulse: Pulse = None
-
-    def __eq__(self, item) -> bool:
-        """Overloads == operator"""
-        return type(item) is Rectangular
 
     @property
     def envelope_waveform_i(self) -> Waveform:
@@ -233,7 +233,7 @@ class Gaussian(PulseShape):
 
     def __eq__(self, item) -> bool:
         """Overloads == operator"""
-        if type(item) is Gaussian:
+        if super().__eq__(item):
             return self.rel_sigma == item.rel_sigma
         return False
 
@@ -293,7 +293,7 @@ class Drag(PulseShape):
 
     def __eq__(self, item) -> bool:
         """Overloads == operator"""
-        if type(item) is Drag:
+        if super().__eq__(item):
             return self.rel_sigma == item.rel_sigma and self.beta == item.beta
         return False
 
@@ -368,7 +368,7 @@ class IIR(PulseShape):
 
     def __eq__(self, item) -> bool:
         """Overloads == operator"""
-        if type(item) is IIR:
+        if super().__eq__(item):
             return self.target == item.target and (self.a == item.a).all() and (self.b == item.b).all()
         return False
 
@@ -446,7 +446,7 @@ class SNZ(PulseShape):
 
     def __eq__(self, item) -> bool:
         """Overloads == operator"""
-        if type(item) is SNZ:
+        if super().__eq__(item):
             return self.t_half_flux_pulse == item.t_half_flux_pulse and self.b_amplitude == item.b_amplitude
         return False
 
@@ -515,7 +515,7 @@ class eCap(PulseShape):
 
     def __eq__(self, item) -> bool:
         """Overloads == operator"""
-        if type(item) is eCap:
+        if super().__eq__(item):
             return self.alpha == item.alpha
         return False
 

--- a/src/qibolab/pulses.py
+++ b/src/qibolab/pulses.py
@@ -1045,7 +1045,7 @@ class Pulse:
             self._qubit,
         )
 
-    def is_equal(self, item: Pulse) -> bool:
+    def is_equal(self, item) -> bool:
         """Check if two pulses are equal, excepto from the start time"""
         return (
             self.duration == item.duration

--- a/tests/test_pulses.py
+++ b/tests/test_pulses.py
@@ -401,9 +401,9 @@ def test_pulses_pulse_split_pulse():
 
 
 def test_pulses_pulsesequence_init():
-    p1 = Pulse(600, 40, 0.9, 100e6, 0, Drag(5, 1), 1, PulseType.DRIVE)
+    p1 = Pulse(400, 40, 0.9, 100e6, 0, Drag(5, 1), 3, PulseType.DRIVE)
     p2 = Pulse(500, 40, 0.9, 100e6, 0, Drag(5, 1), 2, PulseType.DRIVE)
-    p3 = Pulse(400, 40, 0.9, 100e6, 0, Drag(5, 1), 3, PulseType.DRIVE)
+    p3 = Pulse(600, 40, 0.9, 100e6, 0, Drag(5, 1), 1, PulseType.DRIVE)
 
     ps = PulseSequence()
     assert type(ps) == PulseSequence
@@ -433,9 +433,9 @@ def test_pulses_pulsesequence_operators():
     ps = ps + ReadoutPulse(800, 200, 0.9, 20e6, 0, Rectangular(), 2)
     ps = ReadoutPulse(800, 200, 0.9, 20e6, 0, Rectangular(), 3) + ps
 
-    p4 = Pulse(300, 40, 0.9, 50e6, 0, Gaussian(5), 1, PulseType.DRIVE)
+    p4 = Pulse(100, 40, 0.9, 50e6, 0, Gaussian(5), 3, PulseType.DRIVE)
     p5 = Pulse(200, 40, 0.9, 50e6, 0, Gaussian(5), 2, PulseType.DRIVE)
-    p6 = Pulse(100, 40, 0.9, 50e6, 0, Gaussian(5), 3, PulseType.DRIVE)
+    p6 = Pulse(300, 40, 0.9, 50e6, 0, Gaussian(5), 1, PulseType.DRIVE)
 
     another_ps = PulseSequence()
     another_ps.add(p4)

--- a/tests/test_pulses.py
+++ b/tests/test_pulses.py
@@ -275,24 +275,24 @@ def test_pulses_pulse_attributes():
     assert p0.finish == 100
 
 
-def test_pulses_is_equal():
+def test_pulses_is_equal_ignoring_start():
     """Checks if two pulses are equal, not looking at start time"""
 
     p1 = Pulse(0, 40, 0.9, 0, 0, Rectangular(), 0, PulseType.FLUX, 0)
     p2 = Pulse(100, 40, 0.9, 0, 0, Rectangular(), 0, PulseType.FLUX, 0)
     p3 = Pulse(0, 40, 0.9, 0, 0, Rectangular(), 0, PulseType.FLUX, 0)
     p4 = Pulse(200, 40, 0.9, 0, 0, Rectangular(), 2, PulseType.FLUX, 0)
-    assert p1.is_equal(p2)
-    assert p1.is_equal(p3)
-    assert not p1.is_equal(p4)
+    assert p1.is_equal_ignoring_start(p2)
+    assert p1.is_equal_ignoring_start(p3)
+    assert not p1.is_equal_ignoring_start(p4)
 
     p1 = Pulse(0, 40, 0.9, 50e6, 0, Gaussian(5), 0, PulseType.DRIVE, 2)
     p2 = Pulse(10, 40, 0.9, 50e6, 0, Gaussian(5), 0, PulseType.DRIVE, 2)
     p3 = Pulse(20, 50, 0.8, 50e6, 0, Gaussian(5), 0, PulseType.DRIVE, 2)
     p4 = Pulse(30, 40, 0.9, 50e6, 0, Gaussian(4), 0, PulseType.DRIVE, 2)
-    assert p1.is_equal(p2)
-    assert not p1.is_equal(p3)
-    assert not p1.is_equal(p4)
+    assert p1.is_equal_ignoring_start(p2)
+    assert not p1.is_equal_ignoring_start(p3)
+    assert not p1.is_equal_ignoring_start(p4)
 
 
 def test_pulses_pulse_serial():

--- a/tests/test_pulses.py
+++ b/tests/test_pulses.py
@@ -275,6 +275,26 @@ def test_pulses_pulse_attributes():
     assert p0.finish == 100
 
 
+def test_pulses_is_equal():
+    """Checks if two pulses are equal, not looking at start time"""
+
+    p1 = Pulse(0, 40, 0.9, 0, 0, Rectangular(), 0, PulseType.FLUX, 0)
+    p2 = Pulse(100, 40, 0.9, 0, 0, Rectangular(), 0, PulseType.FLUX, 0)
+    p3 = Pulse(0, 40, 0.9, 0, 0, Rectangular(), 0, PulseType.FLUX, 0)
+    p4 = Pulse(200, 40, 0.9, 0, 0, Rectangular(), 2, PulseType.FLUX, 0)
+    assert p1.is_equal(p2)
+    assert p1.is_equal(p3)
+    assert not p1.is_equal(p4)
+
+    p1 = Pulse(0, 40, 0.9, 50e6, 0, Gaussian(5), 0, PulseType.DRIVE, 2)
+    p2 = Pulse(10, 40, 0.9, 50e6, 0, Gaussian(5), 0, PulseType.DRIVE, 2)
+    p3 = Pulse(20, 50, 0.8, 50e6, 0, Gaussian(5), 0, PulseType.DRIVE, 2)
+    p4 = Pulse(30, 40, 0.9, 50e6, 0, Gaussian(4), 0, PulseType.DRIVE, 2)
+    assert p1.is_equal(p2)
+    assert not p1.is_equal(p3)
+    assert not p1.is_equal(p4)
+
+
 def test_pulses_pulse_serial():
     p11 = Pulse(0, 40, 0.9, 50_000_000, 0, Gaussian(5), 0, PulseType.DRIVE)
     assert p11.serial == "Pulse(0, 40, 0.9, 50_000_000, 0, Gaussian(5), 0, PulseType.DRIVE, 0)"
@@ -808,6 +828,60 @@ def test_pulses_pulseshape_drag():
         pulse.shape.modulated_waveform_q.serial
         == f"Modulated_Waveform_Q(num_samples = {num_samples}, amplitude = {format(pulse.amplitude, '.6f').rstrip('0').rstrip('.')}, shape = {str(pulse.shape)}, frequency = {format(pulse.frequency, '_')}, phase = {format(global_phase + pulse.relative_phase, '.6f').rstrip('0').rstrip('.')})"
     )
+
+
+def test_pulses_pulseshape_eq():
+    """Checks == operator for pulse shapes"""
+
+    shape1 = Rectangular()
+    shape2 = Rectangular()
+    shape3 = Gaussian(5)
+    assert shape1 == shape2
+    assert not shape1 == shape3
+
+    shape1 = Gaussian(4)
+    shape2 = Gaussian(4)
+    shape3 = Gaussian(5)
+    assert shape1 == shape2
+    assert not shape1 == shape3
+
+    shape1 = Drag(4, 0.01)
+    shape2 = Drag(4, 0.01)
+    shape3 = Drag(5, 0.01)
+    shape4 = Drag(4, 0.05)
+    shape5 = Drag(5, 0.05)
+    assert shape1 == shape2
+    assert not shape1 == shape3
+    assert not shape1 == shape4
+    assert not shape1 == shape5
+
+    shape1 = IIR([-0.5, 2], [1], Rectangular())
+    shape2 = IIR([-0.5, 2], [1], Rectangular())
+    shape3 = IIR([-0.5, 4], [1], Rectangular())
+    shape4 = IIR([-0.4, 2], [1], Rectangular())
+    shape5 = IIR([-0.5, 2], [2], Rectangular())
+    shape6 = IIR([-0.5, 2], [2], Gaussian(5))
+    assert shape1 == shape2
+    assert not shape1 == shape3
+    assert not shape1 == shape4
+    assert not shape1 == shape5
+    assert not shape1 == shape6
+
+    shape1 = SNZ(17, 0.8)
+    shape2 = SNZ(17, 0.8)
+    shape3 = SNZ(18, 0.8)
+    shape4 = SNZ(17, 0.9)
+    shape5 = SNZ(18, 0.9)
+    assert shape1 == shape2
+    assert not shape1 == shape3
+    assert not shape1 == shape4
+    assert not shape1 == shape5
+
+    shape1 = eCap(4)
+    shape2 = eCap(4)
+    shape3 = eCap(5)
+    assert shape1 == shape2
+    assert not shape1 == shape3
 
 
 def test_pulse():


### PR DESCRIPTION
This PR would help me in the development of the new version of the rfsoc driver, these are changes that I could do in the driver itself, but it makes sense to have them in main qibolab.

List of changes:
* currently, in a `PulseSequence` the pulses are ordered by channel and then by start time, I need them ordered by start time so I propose to have them ordered by start time and then channel
* I added a new function called `is_equal` that checks if two pulses are equal but without looking at the start time. This could be useful also for other driver, I think, to avoid to register in memory multiple times the same wavefunction. (Maybe there is a better way to name the function, suggestions are welcomed.)
*  I re-defined the equality operator `==` for all `PulseShape` objects (this is kinda needed for the `is_equal` function. I am not completely sure I did it correctly for `IIR` 


Checklist:
- [x] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
