### PR TITLE
Add attenuation to dummy platform

### DIFF
--- a/src/qibolab/designs/channels.py
+++ b/src/qibolab/designs/channels.py
@@ -105,8 +105,6 @@ class Channel:
 
     @attenuation.setter
     def attenuation(self, attenuation):
-        if not isinstance(attenuation, int):
-            raise_error(TypeError, f"Channel attenuation must be integer.")
         self._attenuation = attenuation
 
 

--- a/src/qibolab/designs/channels.py
+++ b/src/qibolab/designs/channels.py
@@ -95,6 +95,20 @@ class Channel:
             raise_error(TypeError, f"Channel filter must be dict but is {type(filter)}.")
         self._filter = filter
 
+    @property
+    def attenuation(self):
+        """Attenuation for qblox devices."""
+        """LocalOscillator object connnected to this channel."""
+        if self._attenuation is None:
+            raise_error(NotImplementedError, f"Channel {self.name} does not support attenuation.")
+        return self._attenuation
+
+    @attenuation.setter
+    def attenuation(self, attenuation):
+        if not isinstance(attenuation, int) and attenuation % 2 == 0:
+            raise_error(TypeError, f"Channel attenuation must be even integer.")
+        self._attenuation = attenuation
+
 
 @dataclass
 class ChannelMap:

--- a/src/qibolab/designs/channels.py
+++ b/src/qibolab/designs/channels.py
@@ -105,8 +105,8 @@ class Channel:
 
     @attenuation.setter
     def attenuation(self, attenuation):
-        if not isinstance(attenuation, int) and attenuation % 2 == 0:
-            raise_error(TypeError, f"Channel attenuation must be even integer.")
+        if not isinstance(attenuation, int):
+            raise_error(TypeError, f"Channel attenuation must be integer.")
         self._attenuation = attenuation
 
 

--- a/src/qibolab/designs/channels.py
+++ b/src/qibolab/designs/channels.py
@@ -98,7 +98,6 @@ class Channel:
     @property
     def attenuation(self):
         """Attenuation for qblox devices."""
-        """LocalOscillator object connnected to this channel."""
         if self._attenuation is None:
             raise_error(NotImplementedError, f"Channel {self.name} does not support attenuation.")
         return self._attenuation

--- a/src/qibolab/platforms/abstract.py
+++ b/src/qibolab/platforms/abstract.py
@@ -58,6 +58,8 @@ class Qubit:
     # parameters for single shot classification
     threshold: Optional[float] = None
     iq_angle: float = 0.0
+    # attenuation
+    attenuation: int = 0
     # required for mixers (not sure if it should be here)
     mixer_drive_g: float = 0.0
     mixer_drive_phi: float = 0.0

--- a/src/qibolab/platforms/multiqubit.py
+++ b/src/qibolab/platforms/multiqubit.py
@@ -171,8 +171,8 @@ class MultiqubitPlatform(AbstractPlatform):
                 return self.instruments[instrument].power
         raise_error(NotImplementedError, "No twpa instrument found in the platform. ")
 
-    def set_attenuation(self, qubit: Qubit, att):
-        self.ro_port[qubit.name].attenuation = att
+    def set_attenuation(self, qubit, att):
+        self.ro_port[qubit].attenuation = att
 
     def set_gain(self, qubit, gain):
         self.qd_port[qubit].gain = gain
@@ -183,8 +183,8 @@ class MultiqubitPlatform(AbstractPlatform):
         elif qubit.name in self.qfm:
             self.qf_port[qubit.name].offset = bias
 
-    def get_attenuation(self, qubit: Qubit):
-        return self.ro_port[qubit.name].attenuation
+    def get_attenuation(self, qubit):
+        return self.ro_port[qubit].attenuation
 
     def get_bias(self, qubit: Qubit):
         if qubit.name in self.qbm:
@@ -434,7 +434,7 @@ class MultiqubitPlatform(AbstractPlatform):
         if sweeper.qubits is not None:
             for qubit in sweeper.qubits:
                 if sweeper.parameter is Parameter.attenuation:
-                    original_value[qubit.name] = self.get_attenuation(qubit)
+                    original_value[qubit.name] = self.get_attenuation(qubit.name)
                 elif sweeper.parameter is Parameter.gain:
                     original_value[qubit.name] = self.get_gain(qubit)
                 elif sweeper.parameter is Parameter.bias:
@@ -452,7 +452,7 @@ class MultiqubitPlatform(AbstractPlatform):
         if sweeper.qubits is not None:
             for qubit in sweeper.qubits:
                 if sweeper.parameter is Parameter.attenuation:
-                    self.set_attenuation(qubit, original_value[qubit.name])
+                    self.set_attenuation(qubit.name, original_value[qubit.name])
                 elif sweeper.parameter is Parameter.gain:
                     self.set_gain(qubit, original_value[qubit.name])
                 elif sweeper.parameter is Parameter.bias:
@@ -488,7 +488,7 @@ class MultiqubitPlatform(AbstractPlatform):
         if sweeper.qubits is not None:
             for qubit in sweeper.qubits:
                 if sweeper.parameter is Parameter.attenuation:
-                    self.set_attenuation(qubit, value)
+                    self.set_attenuation(qubit.name, value)
                 elif sweeper.parameter is Parameter.gain:
                     self.set_gain(qubit, value)
                 elif sweeper.parameter is Parameter.bias:

--- a/src/qibolab/platforms/platform.py
+++ b/src/qibolab/platforms/platform.py
@@ -1,6 +1,6 @@
 from qibo.config import raise_error
 
-from qibolab.platforms.abstract import AbstractPlatform
+from qibolab.platforms.abstract import AbstractPlatform, Qubit
 
 
 class DesignPlatform(AbstractPlatform):
@@ -68,11 +68,11 @@ class DesignPlatform(AbstractPlatform):
     def get_lo_twpa_power(self, qubit):
         return self.qubits[qubit].twpa.local_oscillator.power
 
-    def set_attenuation(self, qubit, att):
-        raise_error(NotImplementedError, f"{self.name} does not support attenuation.")
+    def set_attenuation(self, qubit: Qubit, att):
+        self.qubits[qubit.name].attenuation = att
 
-    def get_attenuation(self, qubit):
-        raise_error(NotImplementedError, f"{self.name} does not support attenuation.")
+    def get_attenuation(self, qubit: Qubit):
+        return self.qubits[qubit.name].attenuation
 
     def set_gain(self, qubit, gain):
         raise_error(NotImplementedError, f"{self.name} does not support gain.")

--- a/tests/test_platforms_design.py
+++ b/tests/test_platforms_design.py
@@ -25,8 +25,8 @@ def test_platform_lo_readout_frequency(platform):
 
 
 def test_platform_attenuation(platform):
-    platform.set_lo_readout_frequency(qubit, 10)
-    assert platform.get_lo_readout_frequency(qubit) == 10
+    platform.set_attenuation(qubit, 10)
+    assert platform.get_attenuation(qubit) == 10
 
 
 def test_platform_gain(platform):

--- a/tests/test_platforms_design.py
+++ b/tests/test_platforms_design.py
@@ -25,10 +25,8 @@ def test_platform_lo_readout_frequency(platform):
 
 
 def test_platform_attenuation(platform):
-    with pytest.raises(NotImplementedError):
-        platform.set_attenuation(qubit, 0)
-    with pytest.raises(NotImplementedError):
-        platform.get_attenuation(qubit)
+    platform.set_lo_readout_frequency(qubit, 10)
+    assert platform.get_lo_readout_frequency(qubit) == 10
 
 
 def test_platform_gain(platform):


### PR DESCRIPTION
This PR adds attenuation to the `dummy` platform to be able to tests qibocal protocols which involve attenuation without raising errors. 
@stavros11 maybe there is an easier way to do it. This one seems to work without breaking the other platforms.
 
Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
