### PR TITLE
qubit placement for transpiler

### DIFF
--- a/src/qibolab/transpilers/__init__.py
+++ b/src/qibolab/transpilers/__init__.py
@@ -1,5 +1,5 @@
 from qibolab.transpilers.fusion import Fusion, Rearrange
 from qibolab.transpilers.gate_decompositions import NativeGates
-from qibolab.transpilers.general_connectivity import GeneralConnectivity
 from qibolab.transpilers.pipeline import Pipeline
+from qibolab.transpilers.routing import GeneralConnectivity
 from qibolab.transpilers.star_connectivity import StarConnectivity

--- a/src/qibolab/transpilers/abstract.py
+++ b/src/qibolab/transpilers/abstract.py
@@ -1,10 +1,62 @@
 from abc import ABC, abstractmethod
 from typing import List, Optional, Tuple
 
+import networkx as nx
 import numpy as np
 from qibo.backends import NumpyBackend
-from qibo.config import log
+from qibo.config import log, raise_error
 from qibo.models import Circuit
+
+
+class Placer(ABC):
+    """A placer implments the initial logical-physical qubit mapping"""
+
+    @abstractmethod
+    def place(self, circuit: Circuit) -> dict:
+        """Find initial qubit mapping
+
+        Args:
+            circuit (:class:`qibo.models.Circuit`): circuit to be mapped.
+
+        Returns:
+            initial_layout (dict): dictionary containing the initial logical to physical qubit mapping
+        """
+
+    @property
+    def connectivity(self):
+        return self._connectivity
+
+    @connectivity.setter
+    def connectivity(self, connectivity):
+        """Set the hardware chip connectivity.
+        Args:
+            connectivity (networkx graph): define connectivity.
+        """
+
+        if isinstance(connectivity, nx.Graph):
+            self._connectivity = connectivity
+        else:
+            raise_error(TypeError, "Use networkx graph for custom connectivity")
+
+    def create_circuit_repr(self, circuit):
+        """Translate qibo circuit into a list of two qubit gates to be used by the transpiler.
+
+        Args:
+            circuit (:class:`qibo.models.Circuit`): circuit to be transpiled.
+
+        Returns:
+            translated_circuit (list): list containing qubits targeted by two qubit gates
+        """
+        translated_circuit = []
+        for index, gate in enumerate(circuit.queue):
+            if len(gate.qubits) == 2:
+                gate_qubits = list(gate.qubits)
+                gate_qubits.sort()
+                gate_qubits.append(index)
+                translated_circuit.append(gate_qubits)
+            if len(gate.qubits) >= 3:
+                raise_error(ValueError, "Gates targeting more than 2 qubits are not supported")
+        return translated_circuit
 
 
 class Transpiler(ABC):
@@ -48,4 +100,20 @@ class Transpiler(ABC):
             circuit (:class:`qibo.models.Circuit`): Circuit after transpilation.
             qubit_map (list): Order of qubits in the transpiled circuit.
         """
-        # TODO: Maybe use __call__?
+        # TODO: Maybe use __call__? (simone: seems a good idea)
+
+    @property
+    def connectivity(self):
+        return self._connectivity
+
+    @connectivity.setter
+    def connectivity(self, connectivity):
+        """Set the hardware chip connectivity.
+        Args:
+            connectivity (networkx graph): define connectivity.
+        """
+
+        if isinstance(connectivity, nx.Graph):
+            self._connectivity = connectivity
+        else:
+            raise_error(TypeError, "Use networkx graph for custom connectivity")

--- a/tests/test_transpilers_routing.py
+++ b/tests/test_transpilers_routing.py
@@ -5,7 +5,7 @@ from qibo import gates
 from qibo.models import Circuit
 
 from qibolab.transpilers.gate_decompositions import TwoQubitNatives
-from qibolab.transpilers.general_connectivity import GeneralConnectivity
+from qibolab.transpilers.routing import GeneralConnectivity
 
 
 def generate_random_circuit(nqubits, ngates, seed=42):


### PR DESCRIPTION
Differentiate the placer (responible of qubit initial mapping) from routing (responsible of placing swap gates to match connectivity).
This is necessary for the future implementation of sabre routing algorithm and "backpropagation" placer algorithm.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
