### PR TITLE
Dummy platform sweepers

### DIFF
--- a/src/qibolab/dummy.py
+++ b/src/qibolab/dummy.py
@@ -145,7 +145,7 @@ RUNCARD = {
                         "qubit": 3,
                         "relative_start": 14,
                         "type": "qf",
-                    },          
+                    },
                     {
                         "duration": 34,
                         "amplitude": 0.1,
@@ -153,7 +153,7 @@ RUNCARD = {
                         "qubit": 3,
                         "relative_start": 0,
                         "type": "qf",
-                    },                              
+                    },
                     {"type": "virtual_z", "phase": -1.5707963267948966, "qubit": 3},
                     {"type": "virtual_z", "phase": -1.5707963267948966, "qubit": 0},
                 ]

--- a/src/qibolab/dummy.py
+++ b/src/qibolab/dummy.py
@@ -1,6 +1,7 @@
 from qibolab.channels import ChannelMap
 from qibolab.instruments.dummy import DummyInstrument
 from qibolab.platform import Platform
+from qibolab.pulses import SNZ
 
 NAME = "dummy"
 RUNCARD = {
@@ -130,13 +131,29 @@ RUNCARD = {
             "0-3": {
                 "CZ": [
                     {
-                        "duration": 30,
+                        "duration": 34,
                         "amplitude": 0.055,
-                        "shape": "Rectangular()",
-                        "qubit": 0,
+                        "shape": SNZ(1),
+                        "qubit": 3,
                         "relative_start": 0,
                         "type": "qf",
                     },
+                    {
+                        "duration": 4,
+                        "amplitude": 0.055,
+                        "shape": SNZ(1),
+                        "qubit": 3,
+                        "relative_start": 14,
+                        "type": "qf",
+                    },          
+                    {
+                        "duration": 34,
+                        "amplitude": 0.1,
+                        "shape": "Rectangular()",
+                        "qubit": 3,
+                        "relative_start": 0,
+                        "type": "qf",
+                    },                              
                     {"type": "virtual_z", "phase": -1.5707963267948966, "qubit": 3},
                     {"type": "virtual_z", "phase": -1.5707963267948966, "qubit": 0},
                 ]

--- a/src/qibolab/dummy.py
+++ b/src/qibolab/dummy.py
@@ -4,15 +4,17 @@ from qibolab.platform import Platform
 
 NAME = "dummy"
 RUNCARD = {
-    "nqubits": 2,
+    "nqubits": 4,
     "description": "Dummy 2-qubits platform.",
     "qubits": [
         0,
         1,
+        2,
+        3,
     ],
     "settings": {"sampling_rate": 1000000000, "relaxation_time": 0, "nshots": 1024},
     "resonator_type": "2D",
-    "topology": [[0, 1]],
+    "topology": [[0, 1], [1, 2], [0, 3]],
     "native_gates": {
         "single_qubit": {
             0: {
@@ -55,6 +57,46 @@ RUNCARD = {
                     "phase": 0,
                 },
             },
+            2: {
+                "RX": {
+                    "duration": 40,
+                    "amplitude": 0.005,
+                    "frequency": 2700000000,
+                    "shape": "Gaussian(5)",
+                    "type": "qd",
+                    "start": 0,
+                    "phase": 0,
+                },
+                "MZ": {
+                    "duration": 1000,
+                    "amplitude": 0.0025,
+                    "frequency": 5226500000,
+                    "shape": "Rectangular()",
+                    "type": "ro",
+                    "start": 0,
+                    "phase": 0,
+                },
+            },
+            3: {
+                "RX": {
+                    "duration": 40,
+                    "amplitude": 0.0484,
+                    "frequency": 5855663000,
+                    "shape": "Drag(5, -0.02)",
+                    "type": "qd",
+                    "start": 0,
+                    "phase": 0,
+                },
+                "MZ": {
+                    "duration": 620,
+                    "amplitude": 0.003575,
+                    "frequency": 8453265000,
+                    "shape": "Rectangular()",
+                    "type": "ro",
+                    "start": 0,
+                    "phase": 0,
+                },
+            },
         },
         "two_qubit": {
             "0-1": {
@@ -71,13 +113,41 @@ RUNCARD = {
                     {"type": "virtual_z", "phase": -1.5707963267948966, "qubit": 0},
                 ]
             },
+            "1-2": {
+                "CZ": [
+                    {
+                        "duration": 30,
+                        "amplitude": 0.055,
+                        "shape": "Rectangular()",
+                        "qubit": 0,
+                        "relative_start": 0,
+                        "type": "qf",
+                    },
+                    {"type": "virtual_z", "phase": -1.5707963267948966, "qubit": 2},
+                    {"type": "virtual_z", "phase": -1.5707963267948966, "qubit": 1},
+                ]
+            },
+            "0-3": {
+                "CZ": [
+                    {
+                        "duration": 30,
+                        "amplitude": 0.055,
+                        "shape": "Rectangular()",
+                        "qubit": 0,
+                        "relative_start": 0,
+                        "type": "qf",
+                    },
+                    {"type": "virtual_z", "phase": -1.5707963267948966, "qubit": 3},
+                    {"type": "virtual_z", "phase": -1.5707963267948966, "qubit": 0},
+                ]
+            },
         },
     },
     "characterization": {
         "single_qubit": {
             0: {
                 "readout_frequency": 7226500000,
-                "drive_frequency": 0.0,
+                "drive_frequency": 4700000000,
                 "T1": 0.0,
                 "T2": 0.0,
                 "sweetspot": 0.0,
@@ -87,6 +157,24 @@ RUNCARD = {
             1: {
                 "readout_frequency": 7453265000,
                 "drive_frequency": 4855663000,
+                "T1": 0.0,
+                "T2": 0.0,
+                "sweetspot": -0.047,
+                "threshold": 0.00028502261712637096,
+                "iq_angle": 1.283105298787488,
+            },
+            2: {
+                "readout_frequency": 5226500000,
+                "drive_frequency": 2700000000,
+                "T1": 0.0,
+                "T2": 0.0,
+                "sweetspot": 0.0,
+                "threshold": 0.0,
+                "iq_angle": 0.0,
+            },
+            3: {
+                "readout_frequency": 8453265000,
+                "drive_frequency": 5855663000,
                 "T1": 0.0,
                 "T2": 0.0,
                 "sweetspot": -0.047,

--- a/src/qibolab/instruments/dummy.py
+++ b/src/qibolab/instruments/dummy.py
@@ -8,9 +8,8 @@ from qibo.config import log, raise_error
 from qibolab import AcquisitionType, AveragingMode, ExecutionParameters
 from qibolab.instruments.abstract import AbstractInstrument
 from qibolab.platform import Qubit
-from qibolab.pulses import PulseSequence, PulseType
-from qibolab.result import IntegratedResults, SampleResults
-from qibolab.sweeper import Parameter, Sweeper
+from qibolab.pulses import PulseSequence
+from qibolab.sweeper import Sweeper
 
 
 class DummyInstrument(AbstractInstrument):

--- a/src/qibolab/instruments/dummy.py
+++ b/src/qibolab/instruments/dummy.py
@@ -42,26 +42,16 @@ class DummyInstrument(AbstractInstrument):
         log.info("Disconnecting dummy instrument.")
 
     def play(self, qubits: Dict[Union[str, int], Qubit], sequence: PulseSequence, options: ExecutionParameters):
-        nshots = options.nshots
-        time.sleep(options.relaxation_time * 1e-9)
-
         ro_pulses = {pulse.qubit: pulse.serial for pulse in sequence.ro_pulses}
 
+        expts = 1 if options.averaging_mode is AveragingMode.CYCLIC else options.nshots
         results = {}
-        for qubit, serial in ro_pulses.items():
+        for ro_pulse in sequence.ro_pulses:
             if options.acquisition_type is AcquisitionType.DISCRIMINATION:
-                samples = (
-                    np.random.rand(1) if options.averaging_mode is AveragingMode.CYCLIC else np.random.rand(nshots)
-                )
-                results[qubit] = results[serial] = options.results_type(samples)
-
+                values = np.random.rand(expts)
             else:
-                i = np.random.rand(1) if options.averaging_mode is AveragingMode.CYCLIC else np.random.rand(nshots)
-                q = np.random.rand(1) if options.averaging_mode is AveragingMode.CYCLIC else np.random.rand(nshots)
-                exp_res = i + 1j * q
-                results[qubit] = results[serial] = options.results_type(data=exp_res)
-
-            # results[qubit] = results[serial] = ExecutionResults.from_components(i, q, shots)
+                values = np.random.rand(expts) * 100 + 1j * np.random.rand(expts) * 100
+            results[ro_pulse.qubit] = results[ro_pulse.serial] = options.results_type(values)
 
         return results
 
@@ -72,112 +62,19 @@ class DummyInstrument(AbstractInstrument):
         options: ExecutionParameters,
         *sweepers: List[Sweeper],
     ):
+        expts = 1
+        for sweeper in sweepers:
+            expts *= len(sweeper.values)
+        if options.averaging_mode is not AveragingMode.CYCLIC:
+            expts *= options.nshots
+
         results = {}
-        sweeper_pulses = {}
 
-        # create copy of the sequence
-        copy_sequence = copy.deepcopy(sequence)
-        # perform sweeping recursively
-        results = self._sweep_recursion(
-            qubits,
-            copy_sequence,
-            sequence,
-            options,
-            *sweepers,
-        )
-        sequence = copy_sequence
-        return results
-
-    def play_sequence_in_sweep_recursion(
-        self,
-        qubits: List[Qubit],
-        sequence: PulseSequence,
-        or_sequence: PulseSequence,
-        options: ExecutionParameters,
-    ) -> Dict[str, Union[IntegratedResults, SampleResults]]:
-        """Last recursion layer, if no sweeps are present
-
-        After playing the sequence, the resulting dictionary keys need
-        to be converted to the correct values.
-        Even indexes correspond to qubit number and are not changed.
-        Odd indexes correspond to readout pulses serials and are convert
-        to match the original sequence (of the sweep) and not the one just executed.
-        """
-        res = self.play(qubits, sequence, options)
-        newres = {}
-        serials = [pulse.serial for pulse in or_sequence.ro_pulses]
-        for idx, key in enumerate(res):
-            if idx % 2 == 1:
-                newres[serials[idx // 2]] = res[key]
+        for ro_pulse in sequence.ro_pulses:
+            if options.acquisition_type is AcquisitionType.DISCRIMINATION:
+                values = np.random.rand(expts)
             else:
-                newres[key] = res[key]
-        return newres
+                values = np.random.rand(expts) * 100 + 1j * np.random.rand(expts) * 100
+            results[ro_pulse.qubit] = results[ro_pulse.serial] = options.results_type(values)
 
-    def get_sequences_for_sweep(self, sequence, sweeper):
-        sequences = []
-        for kdx, val in enumerate(sweeper.values):
-            new_sequence = copy.deepcopy(sequence)
-            for pulse in sweeper.pulses:
-                idx = [p.serial for p in new_sequence].index(pulse.serial)
-                if sweeper.parameter in {Parameter.delay, Parameter.duration}:
-                    if sweeper.parameter is Parameter.duration:
-                        base_val = getattr(pulse, "duration")
-                        new_val = sweeper.get_values(base_val)[kdx]
-                        setattr(new_sequence[idx], "start", new_val)
-                        delta = new_val - base_val
-                    else:
-                        delta = val
-                    for seq_pulse in new_sequence[idx:]:
-                        base_val = getattr(seq_pulse, "start")
-                        setattr(seq_pulse, "start", base_val + delta)
-                else:
-                    base_val = getattr(pulse, sweeper.parameter.name)
-                    setattr(new_sequence[idx], sweeper.parameter.name, sweeper.get_values(base_val)[kdx])
-                    delta = getattr(pulse, sweeper.parameter.name)
-            sequences.append(new_sequence)
-        return sequences
-
-    def get_qubits_for_sweep(self, qubits, sweeper):
-        sweep_qubits = []
-        for kdx, val in enumerate(sweeper.values):
-            new_qubits = copy.deepcopy(qubits)
-            for idx, qubit in enumerate(sweeper.qubits):
-                base_val = getattr(qubit, sweeper.parameter.name)
-                setattr(new_qubits[idx], sweeper.parameter.name, sweeper.get_values(base_val)[kdx])
-            sweep_qubits.append(new_qubits)
-        return sweep_qubits
-
-    def _sweep_recursion(
-        self,
-        qubits,
-        sequence,
-        original_sequence,
-        options,
-        *sweepers,
-    ):
-        if len(sweepers) == 0:
-            return self.play_sequence_in_sweep_recursion(qubits, sequence, original_sequence, options)
-
-        sweeper = sweepers[0]
-
-        results = {}
-        if sweeper.pulses is not None:
-            sequences = self.get_sequences_for_sweep(original_sequence, sweeper)
-            for sequence in sequences:
-                res = self._sweep_recursion(qubits, sequence, original_sequence, options, *sweepers[1:])
-                for key in res:
-                    if key in results:
-                        results[key] = results[key] + res[key]
-                    else:
-                        results[key] = res[key]
-            return results
-        else:
-            qubits_sweep = self.get_qubits_for_sweep(qubits, sweeper)
-            for new_qubits in qubits_sweep:
-                res = self._sweep_recursion(new_qubits, sequence, original_sequence, options, *sweepers[1:])
-                for key in res:
-                    if key in results:
-                        results[key] = results[key] + res[key]
-                    else:
-                        results[key] = res[key]
-            return results
+        return results


### PR DESCRIPTION
I was trying to test a two-qubit routine with dummy platform and had some problems with the sweepers (in particular duration sweepers)...

***After*** fixing the sweepers, I realized that for a dummy platform it doesn't make sense to actually do a complex recursion... It's much more faster, shorter and reliable to just generate all the results immediately, not even looking at the sweepers/sequences actual values.
Eventually one could also add some validation at the beginning of the sweep function, to catch eventual errors.

Is there a reason why you decided to do an "actual" sweep?


Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
