### PR TITLE
Fix Dummy discrimination

### DIFF
--- a/src/qibolab/instruments/dummy.py
+++ b/src/qibolab/instruments/dummy.py
@@ -46,7 +46,10 @@ class DummyInstrument(Controller):
         results = {}
         for ro_pulse in sequence.ro_pulses:
             if options.acquisition_type is AcquisitionType.DISCRIMINATION:
-                values = np.random.rand(expts)
+                if options.averaging_mode is AveragingMode.SINGLESHOT:
+                    values = np.random.randint(2, size=expts)
+                elif options.averaging_mode is AveragingMode.CYCLIC:
+                    values = np.random.rand(expts)
             elif options.acquisition_type is AcquisitionType.RAW:
                 samples = int(ro_pulse.duration * self.sampling_rate)
                 values = np.random.rand(samples * expts) * 100 + 1j * np.random.rand(samples * expts) * 100
@@ -73,7 +76,10 @@ class DummyInstrument(Controller):
 
         for ro_pulse in sequence.ro_pulses:
             if options.acquisition_type is AcquisitionType.DISCRIMINATION:
-                values = np.random.rand(expts)
+                if options.averaging_mode is AveragingMode.SINGLESHOT:
+                    values = np.random.randint(2, size=expts)
+                elif options.averaging_mode is AveragingMode.CYCLIC:
+                    values = np.random.rand(expts)
             elif options.acquisition_type is AcquisitionType.RAW:
                 samples = int(ro_pulse.duration * self.sampling_rate)
                 values = np.random.rand(samples * expts) * 100 + 1j * np.random.rand(samples * expts) * 100

--- a/src/qibolab/instruments/dummy.py
+++ b/src/qibolab/instruments/dummy.py
@@ -40,24 +40,26 @@ class DummyInstrument(Controller):
     def disconnect(self):
         log.info("Disconnecting dummy instrument.")
 
-    def play(self, qubits: Dict[Union[str, int], Qubit], sequence: PulseSequence, options: ExecutionParameters):
-        expts = 1 if options.averaging_mode is AveragingMode.CYCLIC else options.nshots
-
+    def get_values(self, options, sequence, exp_points):
         results = {}
         for ro_pulse in sequence.ro_pulses:
             if options.acquisition_type is AcquisitionType.DISCRIMINATION:
                 if options.averaging_mode is AveragingMode.SINGLESHOT:
-                    values = np.random.randint(2, size=expts)
+                    values = np.random.randint(2, size=exp_points)
                 elif options.averaging_mode is AveragingMode.CYCLIC:
-                    values = np.random.rand(expts)
+                    values = np.random.rand(exp_points)
             elif options.acquisition_type is AcquisitionType.RAW:
                 samples = int(ro_pulse.duration * self.sampling_rate)
-                values = np.random.rand(samples * expts) * 100 + 1j * np.random.rand(samples * expts) * 100
+                values = np.random.rand(samples * exp_points) * 100 + 1j * np.random.rand(samples * exp_points) * 100
             elif options.acquisition_type is AcquisitionType.INTEGRATION:
-                values = np.random.rand(expts) * 100 + 1j * np.random.rand(expts) * 100
+                values = np.random.rand(exp_points) * 100 + 1j * np.random.rand(exp_points) * 100
             results[ro_pulse.qubit] = results[ro_pulse.serial] = options.results_type(values)
-
         return results
+
+    def play(self, qubits: Dict[Union[str, int], Qubit], sequence: PulseSequence, options: ExecutionParameters):
+        exp_points = 1 if options.averaging_mode is AveragingMode.CYCLIC else options.nshots
+
+        return self.get_values(options, sequence, exp_points)
 
     def sweep(
         self,
@@ -66,25 +68,10 @@ class DummyInstrument(Controller):
         options: ExecutionParameters,
         *sweepers: List[Sweeper],
     ):
-        expts = 1
+        exp_points = 1
         for sweeper in sweepers:
-            expts *= len(sweeper.values)
+            exp_points *= len(sweeper.values)
         if options.averaging_mode is not AveragingMode.CYCLIC:
-            expts *= options.nshots
+            exp_points *= options.nshots
 
-        results = {}
-
-        for ro_pulse in sequence.ro_pulses:
-            if options.acquisition_type is AcquisitionType.DISCRIMINATION:
-                if options.averaging_mode is AveragingMode.SINGLESHOT:
-                    values = np.random.randint(2, size=expts)
-                elif options.averaging_mode is AveragingMode.CYCLIC:
-                    values = np.random.rand(expts)
-            elif options.acquisition_type is AcquisitionType.RAW:
-                samples = int(ro_pulse.duration * self.sampling_rate)
-                values = np.random.rand(samples * expts) * 100 + 1j * np.random.rand(samples * expts) * 100
-            elif options.acquisition_type is AcquisitionType.INTEGRATION:
-                values = np.random.rand(expts) * 100 + 1j * np.random.rand(expts) * 100
-            results[ro_pulse.qubit] = results[ro_pulse.serial] = options.results_type(values)
-
-        return results
+        return self.get_values(options, sequence, exp_points)


### PR DESCRIPTION
Fix the way the dummy generates random numbers for Discrimination.

When Singleshot it gets either gets 0 or 1 and when Cylic a float in [0,1].

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
