### PR TITLE
[POC] Dictionary that infers its keys from `value.name`

### DIFF
--- a/src/qibolab/channels.py
+++ b/src/qibolab/channels.py
@@ -1,10 +1,11 @@
-from dataclasses import dataclass, field
-from typing import Dict, Optional
+from dataclasses import dataclass
+from typing import Optional
 
 from qibo.config import raise_error
 
 from qibolab.instruments.oscillator import LocalOscillator
 from qibolab.instruments.port import Port
+from qibolab.maps import NamedMap, NamedType
 
 
 def check_max_offset(offset, max_offset):
@@ -18,7 +19,7 @@ def check_max_offset(offset, max_offset):
 
 
 @dataclass
-class Channel:
+class Channel(NamedType):
     """Representation of physical wire connection (channel)."""
 
     name: str
@@ -111,54 +112,5 @@ class Channel:
         self.port.filter = value
 
 
-@dataclass
-class ChannelMap:
-    """Collection of :class:`qibolab.designs.channel.Channel` objects identified by name.
-
-    Essentially, it allows creating a mapping of names to channels just
-    specifying the names.
-
-    """
-
-    _channels: Dict[str, Channel] = field(default_factory=dict)
-
-    def add(self, *items):
-        """Add multiple items to the channel map.
-
-        If :class:`qibolab.channels.Channel` objects are given they are added to the channel map.
-        If a different type is given, a :class:`qibolab.channels.Channel` with the
-        corresponding name is created and added to the channel map.
-        """
-        for item in items:
-            if isinstance(item, Channel):
-                self[item.name] = item
-            else:
-                self[item] = Channel(item)
-        return self
-
-    def __getitem__(self, name):
-        return self._channels[name]
-
-    def __setitem__(self, name, channel):
-        if not isinstance(channel, Channel):
-            raise_error(TypeError, f"Cannot add channel of type {type(channel)} to ChannelMap.")
-        self._channels[name] = channel
-
-    def __contains__(self, name):
-        return name in self._channels
-
-    def __or__(self, channel_map):
-        channels = self._channels.copy()
-        channels.update(channel_map._channels)
-        return self.__class__(channels)
-
-    def __ior__(self, items):
-        if not isinstance(items, type(self)):
-            try:
-                if isinstance(items, str):
-                    raise TypeError
-                items = type(self)().add(*items)
-            except TypeError:
-                items = type(self)().add(items)
-        self._channels.update(items._channels)
-        return self
+class ChannelMap(NamedMap):
+    Type = Channel

--- a/src/qibolab/instruments/__init__.py
+++ b/src/qibolab/instruments/__init__.py
@@ -1,0 +1,1 @@
+from qibolab.instruments.abstract import InstrumentMap

--- a/src/qibolab/instruments/abstract.py
+++ b/src/qibolab/instruments/abstract.py
@@ -2,10 +2,12 @@ import tempfile
 from abc import ABC, abstractmethod
 from pathlib import Path
 
+from qibolab.maps import NamedMap, NamedType
+
 INSTRUMENTS_DATA_FOLDER = Path.home() / ".qibolab" / "instruments" / "data"
 
 
-class Instrument(ABC):
+class Instrument(ABC, NamedType):
     """
     Parent class for all the instruments connected via TCPIP.
 
@@ -74,3 +76,7 @@ class InstrumentException(Exception):
         header = f"InstrumentException with {instrument.signature}"
         full_msg = header + ": " + message
         super().__init__(full_msg)
+
+
+class InstrumentMap(NamedMap):
+    Type = Instrument

--- a/src/qibolab/maps.py
+++ b/src/qibolab/maps.py
@@ -1,0 +1,31 @@
+NameId = str
+
+
+class NamedType:
+    """Arbitrary object that has a name."""
+
+    name: NameId
+
+
+class NamedMap(dict):
+    """Collection of ``NamedType`` objects in a dictionary where the key is their ``name``."""
+
+    Type = NamedType
+
+    def _add_items(self, *items):
+        for item in items:
+            if isinstance(item, self.Type):
+                self[item.name] = item
+            else:
+                self[item] = self.Type(item)
+        return self
+
+    def __ior__(self, items):
+        if not isinstance(items, type(self)):
+            try:
+                if isinstance(items, str):
+                    raise TypeError
+                items = type(self)()._add_items(*items)
+            except TypeError:
+                items = type(self)()._add_items(items)
+        return super().__ior__(items)

--- a/src/qibolab/platform.py
+++ b/src/qibolab/platform.py
@@ -4,14 +4,14 @@ import math
 import re
 from dataclasses import replace
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, Tuple
 
 import networkx as nx
 import yaml
 from qibo.config import log, raise_error
 
 from qibolab.channels import Channel, ChannelMap
-from qibolab.instruments.abstract import Controller, Instrument
+from qibolab.instruments.abstract import Controller, Instrument, InstrumentMap
 from qibolab.native import NativeType, SingleQubitNatives, TwoQubitNatives
 from qibolab.qubits import Qubit, QubitId, QubitPair
 
@@ -31,7 +31,7 @@ class Platform:
 
         self.name = name
         self.runcard = runcard
-        self.instruments: List[Instrument] = instruments
+        self.instruments: InstrumentMap = instruments
         self.channels: ChannelMap = channels
 
         self.qubits: Dict[QubitId, Qubit] = {}
@@ -290,7 +290,7 @@ class Platform:
     def connect(self):
         """Connect to all instruments."""
         if not self.is_connected:
-            for instrument in self.instruments:
+            for instrument in self.instruments.values():
                 try:
                     log.info(f"Connecting to instrument {instrument}.")
                     instrument.connect()
@@ -303,25 +303,25 @@ class Platform:
 
     def setup(self):
         """Prepares instruments to execute experiments."""
-        for instrument in self.instruments:
+        for instrument in self.instruments.values():
             instrument.setup()
 
     def start(self):
         """Starts all the instruments."""
         if self.is_connected:
-            for instrument in self.instruments:
+            for instrument in self.instruments.values():
                 instrument.start()
 
     def stop(self):
         """Starts all the instruments."""
         if self.is_connected:
-            for instrument in self.instruments:
+            for instrument in self.instruments.values():
                 instrument.stop()
 
     def disconnect(self):
         """Disconnects from instruments."""
         if self.is_connected:
-            for instrument in self.instruments:
+            for instrument in self.instruments.values():
                 instrument.disconnect()
         self.is_connected = False
 
@@ -343,7 +343,7 @@ class Platform:
             options = replace(options, relaxation_time=self.relaxation_time)
 
         result = {}
-        for instrument in self.instruments:
+        for instrument in self.instruments.values():
             if isinstance(instrument, Controller):
                 new_result = instrument.play(self.qubits, sequence, options)
                 if isinstance(new_result, dict):
@@ -394,7 +394,7 @@ class Platform:
             options = replace(options, relaxation_time=self.relaxation_time)
 
         result = {}
-        for instrument in self.instruments:
+        for instrument in self.instruments.values():
             if isinstance(instrument, Controller):
                 new_result = instrument.sweep(self.qubits, sequence, options, *sweepers)
                 if isinstance(new_result, dict):

--- a/src/qibolab/qubits.py
+++ b/src/qibolab/qubits.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass, field
 from typing import List, Optional, Union
 
 from qibolab.channels import Channel
+from qibolab.maps import NamedMap, NamedType
 from qibolab.native import SingleQubitNatives, TwoQubitNatives
 
 QubitId = Union[str, int]
@@ -9,7 +10,7 @@ QubitId = Union[str, int]
 
 
 @dataclass
-class Qubit:
+class Qubit(NamedType):
     """Representation of a physical qubit.
 
     Qubit objects are instantiated by :class:`qibolab.platforms.platform.Platform`
@@ -94,3 +95,7 @@ class QubitPair:
     qubit1: Qubit
     qubit2: Qubit
     native_gates: TwoQubitNatives = field(default_factory=TwoQubitNatives)
+
+
+class QubitMap(NamedMap):
+    Type = Qubit

--- a/tests/dummy_qrc/qm.py
+++ b/tests/dummy_qrc/qm.py
@@ -1,6 +1,7 @@
 import pathlib
 
 from qibolab.channels import Channel, ChannelMap
+from qibolab.instruments import InstrumentMap
 from qibolab.instruments.oscillator import LocalOscillator
 from qibolab.instruments.qmsim import QMSim
 from qibolab.platform import Platform
@@ -31,39 +32,41 @@ def create(runcard=RUNCARD):
     # TWPA
     channels |= "L4-26"
 
-    # Instantiate local oscillators (HARDCODED)
-    local_oscillators = [
+    local_oscillators = InstrumentMap()
+    local_oscillators |= (
         LocalOscillator("lo_readout_a", "192.168.0.39"),
         LocalOscillator("lo_readout_b", "192.168.0.31"),
         LocalOscillator("lo_drive_low", "192.168.0.32"),
         LocalOscillator("lo_drive_mid", "192.168.0.33"),
         LocalOscillator("lo_drive_high", "192.168.0.34"),
         LocalOscillator("twpa_a", "192.168.0.35"),
-    ]
+    )
     # Set LO parameters
-    local_oscillators[0].frequency = 7_300_000_000
-    local_oscillators[1].frequency = 7_900_000_000
-    local_oscillators[2].frequency = 4_700_000_000
-    local_oscillators[3].frequency = 5_600_000_000
-    local_oscillators[4].frequency = 6_500_000_000
-    local_oscillators[0].power = 18.0
-    local_oscillators[1].power = 15.0
-    for i in range(2, 5):
-        local_oscillators[i].power = 16.0
+    local_oscillators["lo_readout_a"].frequency = 7_300_000_000
+    local_oscillators["lo_readout_b"].frequency = 7_900_000_000
+    local_oscillators["lo_drive_low"].frequency = 4_700_000_000
+    local_oscillators["lo_drive_mid"].frequency = 5_600_000_000
+    local_oscillators["lo_drive_high"].frequency = 6_500_000_000
+    local_oscillators["lo_readout_a"].power = 18.0
+    local_oscillators["lo_readout_b"].power = 15.0
+    for name in ["lo_drive_low", "lo_drive_mid", "lo_drive_high"]:
+        local_oscillators[name].power = 16.0
     # Set TWPA parameters
-    local_oscillators[5].frequency = 6_511_000_000
-    local_oscillators[5].power = 4.5
+    local_oscillators["twpa_a"].frequency = 6_511_000_000
+    local_oscillators["twpa_a"].power = 4.5
     # Map LOs to channels
-    channels["L3-25_a"].local_oscillator = local_oscillators[0]
-    channels["L3-25_b"].local_oscillator = local_oscillators[1]
-    channels["L3-15"].local_oscillator = local_oscillators[2]
-    channels["L3-11"].local_oscillator = local_oscillators[2]
-    channels["L3-12"].local_oscillator = local_oscillators[3]
-    channels["L3-13"].local_oscillator = local_oscillators[4]
-    channels["L3-14"].local_oscillator = local_oscillators[4]
-    channels["L4-26"].local_oscillator = local_oscillators[5]
+    channels["L3-25_a"].local_oscillator = local_oscillators["lo_readout_a"]
+    channels["L3-25_b"].local_oscillator = local_oscillators["lo_readout_b"]
+    channels["L3-15"].local_oscillator = local_oscillators["lo_drive_low"]
+    channels["L3-11"].local_oscillator = local_oscillators["lo_drive_low"]
+    channels["L3-12"].local_oscillator = local_oscillators["lo_drive_mid"]
+    channels["L3-13"].local_oscillator = local_oscillators["lo_drive_high"]
+    channels["L3-14"].local_oscillator = local_oscillators["lo_drive_high"]
+    channels["L4-26"].local_oscillator = local_oscillators["twpa_a"]
 
-    instruments = [controller] + local_oscillators
+    instruments = InstrumentMap()
+    instruments |= controller
+    instruments |= local_oscillators
     platform = Platform("qw5q_gold", runcard, instruments, channels)
 
     # assign channels to qubits


### PR DESCRIPTION
Following https://github.com/qiboteam/qibolab/pull/469#discussion_r1225264093, I realized that several parts of the platform `create` function involve adding elements in a dictionary using their `.name` as the key. If we also pass the `instruments` to the `Platform` as a dictionary as we discussed in the past (currently we are using a list), this will be another example of such a dictionary.

It could be useful to have a helper dict that performs this operation automatically. Here I implemented an abstract `NamedMap` class to do this and for each collection of objects that the `Platform` needs we have the corresponding specialization: `Qubit` -> `QubitMap`, `Channel` -> `ChannelMap`, `Instrument` -> `InstrumentMap`.

This is not very important and I am not sure if it will be useful in the end, so I would not consider merging it yet but we can keep it open in case the idea is useful at some point.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.