### PR TITLE
Backprop placer

### DIFF
--- a/src/qibolab/transpilers/abstract.py
+++ b/src/qibolab/transpilers/abstract.py
@@ -8,8 +8,8 @@ from qibo.config import log, raise_error
 from qibo.models import Circuit
 
 
-def create_circuit_representation(circuit: Circuit):
-    """Translate qibo circuit into a list of two qubit gates to be used by the transpiler.
+def find_qubit_pairs(circuit: Circuit):
+    """Translate qibo circuit into a list of pairs of qubits to be used by the transpiler.
 
     Args:
         circuit (qibo.models.Circuit): circuit to be transpiled.

--- a/src/qibolab/transpilers/abstract.py
+++ b/src/qibolab/transpilers/abstract.py
@@ -8,7 +8,7 @@ from qibo.config import log, raise_error
 from qibo.models import Circuit
 
 
-def find_qubit_pairs(circuit: Circuit):
+def find_gates_qubits_pairs(circuit: Circuit):
     """Translate qibo circuit into a list of pairs of qubits to be used by the transpiler.
 
     Args:

--- a/src/qibolab/transpilers/abstract.py
+++ b/src/qibolab/transpilers/abstract.py
@@ -8,7 +8,7 @@ from qibo.config import log, raise_error
 from qibo.models import Circuit
 
 
-def create_circuit_repr(circuit: Circuit):
+def create_circuit_representation(circuit: Circuit):
     """Translate qibo circuit into a list of two qubit gates to be used by the transpiler.
 
     Args:

--- a/src/qibolab/transpilers/placer.py
+++ b/src/qibolab/transpilers/placer.py
@@ -243,8 +243,6 @@ class Backpropagation(Placer):
         initial_placer = Trivial(self.connectivity)
         initial_placement = initial_placer(circuit=circuit)
         new_circuit = self.assemble_circuit(circuit)
-        # print("init_circuit:\n",circuit.draw())
-        # print("circuit:\n",new_circuit.draw())
         final_placement = self.routing_step(initial_placement, new_circuit)
         return final_placement
 
@@ -261,21 +259,16 @@ class Backpropagation(Placer):
         if self.gates is None:
             return circuit.invert()
         circuit_repr = create_circuit_repr(circuit)
-        # print("circuit_repr:", circuit_repr)
         circuit_gates = len(circuit_repr)
         if circuit_gates == 0:
             raise ValueError("The circuit must contain at least a two qubit gate.")
         reps = int(self.gates / circuit_gates)
-        # print("reps:", reps)
         remainder = self.gates % circuit_gates
-        # print("resto:",remainder)
         new_circuit_repr = []
         for _ in range(reps):
             new_circuit_repr += circuit_repr[:]
-            # print(new_circuit_repr)
             circuit_repr.reverse()
         new_circuit_repr += circuit_repr[0:remainder]
-        # print("end:", new_circuit_repr)
         new_circuit = Circuit(circuit.nqubits)
         for i in range(len(new_circuit_repr)):
             # As only the connectivity is important here we can replace everithing with CZ gates

--- a/src/qibolab/transpilers/placer.py
+++ b/src/qibolab/transpilers/placer.py
@@ -131,8 +131,8 @@ class Subgraph(Placer):
         Returns:
             (dict): physical to logical qubit mapping.
         """
-        qubit_pairs = find_qubit_pairs(circuit)
-        if len(qubit_pairs) < 3:
+        gate_qubit_pairs = find_qubit_pairs(circuit)
+        if len(gate_qubit_pairs) < 3:
             raise_error(
                 ValueError, "Circuit must contain at least two two qubit gates to implement subgraph placement."
             )
@@ -140,13 +140,16 @@ class Subgraph(Placer):
         circuit_subgraph.add_nodes_from(range(self.connectivity.number_of_nodes()))
         matcher = nx.algorithms.isomorphism.GraphMatcher(self.connectivity, circuit_subgraph)
         i = 0
-        circuit_subgraph.add_edge(qubit_pairs[i][0], qubit_pairs[i][1])
+        circuit_subgraph.add_edge(gate_qubit_pairs[i][0], gate_qubit_pairs[i][1])
         while matcher.subgraph_is_monomorphic() == True:
             result = matcher
             i += 1
-            circuit_subgraph.add_edge(qubit_pairs[i][0], qubit_pairs[i][1])
+            circuit_subgraph.add_edge(gate_qubit_pairs[i][0], gate_qubit_pairs[i][1])
             matcher = nx.algorithms.isomorphism.GraphMatcher(self.connectivity, circuit_subgraph)
-            if self.connectivity.number_of_edges() == circuit_subgraph.number_of_edges() or i == len(qubit_pairs) - 1:
+            if (
+                self.connectivity.number_of_edges() == circuit_subgraph.number_of_edges()
+                or i == len(gate_qubit_pairs) - 1
+            ):
                 keys = list(result.mapping.keys())
                 keys.sort()
                 return {i: result.mapping[i] for i in keys}
@@ -176,16 +179,16 @@ class Random(Placer):
         Returns:
             (dict): physical to logical qubit mapping.
         """
-        qubit_pairs = find_qubit_pairs(circuit)
+        gate_qubit_pairs = find_qubit_pairs(circuit)
         nodes = self.connectivity.number_of_nodes()
         keys = list(self.connectivity.nodes())
         final_mapping = dict(zip(keys, range(nodes)))
         final_graph = nx.relabel_nodes(self.connectivity, final_mapping)
-        final_cost = self.cost(final_graph, qubit_pairs)
+        final_cost = self.cost(final_graph, gate_qubit_pairs)
         for _ in range(self.samples):
             mapping = dict(zip(keys, random.sample(range(nodes), nodes)))
             graph = nx.relabel_nodes(self.connectivity, mapping)
-            cost = self.cost(graph, qubit_pairs)
+            cost = self.cost(graph, gate_qubit_pairs)
             if cost == 0:
                 return mapping
             if cost < final_cost:
@@ -195,21 +198,21 @@ class Random(Placer):
         return final_mapping
 
     @staticmethod
-    def cost(graph, qubit_pairs):
+    def cost(graph, gate_qubit_pairs):
         """
         Compute the cost associated to an initial layout as the lengh of the reduced circuit.
 
         Args:
             graph (networkx.Graph): current hardware qubit mapping.
-            qubit_pairs (list): circuit representation.
+            gate_qubit_pairs (list): circuit representation.
 
         Returns:
             (int): lengh of the reduced circuit.
         """
-        for allowed, gate in enumerate(qubit_pairs):
+        for allowed, gate in enumerate(gate_qubit_pairs):
             if gate not in graph.edges():
                 break
-        return len(qubit_pairs) - allowed
+        return len(gate_qubit_pairs) - allowed
 
 
 class Backpropagation(Placer):
@@ -262,20 +265,20 @@ class Backpropagation(Placer):
 
         if self.previous_gates is None:
             return circuit.invert()
-        qubit_pairs = find_qubit_pairs(circuit)
-        circuit_gates = len(qubit_pairs)
+        gate_qubit_pairs = find_qubit_pairs(circuit)
+        circuit_gates = len(gate_qubit_pairs)
         if circuit_gates == 0:
             raise ValueError("The circuit must contain at least a two qubit gate.")
         repetitions, remainder = divmod(self.previous_gates, circuit_gates)
         assembled_qubit_pairs = []
         for _ in range(repetitions):
-            assembled_qubit_pairs += qubit_pairs[:]
-            qubit_pairs.reverse()
-        assembled_qubit_pairs += qubit_pairs[0:remainder]
+            assembled_qubit_pairs += gate_qubit_pairs[:]
+            gate_qubit_pairs.reverse()
+        assembled_qubit_pairs += gate_qubit_pairs[0:remainder]
         new_circuit = Circuit(circuit.nqubits)
-        for i in range(len(assembled_qubit_pairs)):
+        for qubits in assembled_qubit_pairs:
             # As only the connectivity is important here we can replace everything with CZ gates
-            new_circuit.add(gates.CZ(assembled_qubit_pairs[i][0], assembled_qubit_pairs[i][1]))
+            new_circuit.add(gates.CZ(qubits[0], qubits[1]))
         return new_circuit.invert()
 
     def routing_step(self, layout: dict, circuit: Circuit):

--- a/src/qibolab/transpilers/placer.py
+++ b/src/qibolab/transpilers/placer.py
@@ -220,17 +220,17 @@ class Backpropagation(Placer):
     Attributes:
         connectivity (networkx.Graph): chip connectivity.
         routing_algorithm (qibolab.transpilers.routing.Transpiler): routing algorithm.
-        num_precedent_gates (int): number of two qubit gates considered before finding initial layout.
+        previous_gates (int): number of two qubit gates considered before finding initial layout.
             if 'None' just one backward step will be implemented.
-            If gates is greater than the number of two qubit gates in the circuit, the circuit will be routed more than once.
-            Example: on a circuit with four two qubit gates A-B-C-D using num_precedent_gates = 6,
+            If previous_gates is greater than the number of two qubit gates in the circuit, the circuit will be routed more than once.
+            Example: on a circuit with four two qubit gates A-B-C-D using previous_gates = 6,
             the routing will be performed on the circuit C-D-D-C-B-A.
     """
 
-    def __init__(self, connectivity: nx.Graph, routing_algorithm: Router, num_precedent_gates=None):
+    def __init__(self, connectivity: nx.Graph, routing_algorithm: Router, previous_gates=None):
         self.connectivity = connectivity
         self.routing_algorithm = routing_algorithm
-        self.num_precedent_gates = num_precedent_gates
+        self.previous_gates = previous_gates
 
     def __call__(self, circuit: Circuit):
         """Find the initial layout of the given circuit using backpropagation placement.
@@ -249,8 +249,8 @@ class Backpropagation(Placer):
         return final_placement
 
     def assemble_circuit(self, circuit: Circuit):
-        """Assemble a single circuit to apply backpropagation placement based on num_precedent_gates.
-        Example: for a circuit with four two qubit gates A-B-C-D using num_precedent_gates = 6,
+        """Assemble a single circuit to apply backpropagation placement based on previous_gates.
+        Example: for a circuit with four two qubit gates A-B-C-D using previous_gates = 6,
         the function will return the circuit C-D-D-C-B-A.
 
         Args:
@@ -260,13 +260,13 @@ class Backpropagation(Placer):
             new_circuit (qibo.models.Circuit): assembled circuit to perform backpropagation placement.
         """
 
-        if self.num_precedent_gates is None:
+        if self.previous_gates is None:
             return circuit.invert()
         qubit_pairs = find_qubit_pairs(circuit)
         circuit_gates = len(qubit_pairs)
         if circuit_gates == 0:
             raise ValueError("The circuit must contain at least a two qubit gate.")
-        repetitions, remainder = divmod(self.num_precedent_gates, circuit_gates)
+        repetitions, remainder = divmod(self.previous_gates, circuit_gates)
         assembled_qubit_pairs = []
         for _ in range(repetitions):
             assembled_qubit_pairs += qubit_pairs[:]

--- a/src/qibolab/transpilers/placer.py
+++ b/src/qibolab/transpilers/placer.py
@@ -5,7 +5,7 @@ from qibo import gates
 from qibo.config import raise_error
 from qibo.models import Circuit
 
-from qibolab.transpilers.abstract import Placer, Router, find_qubit_pairs
+from qibolab.transpilers.abstract import Placer, Router, find_gates_qubits_pairs
 
 
 class PlacementError(Exception):
@@ -131,8 +131,8 @@ class Subgraph(Placer):
         Returns:
             (dict): physical to logical qubit mapping.
         """
-        gate_qubit_pairs = find_qubit_pairs(circuit)
-        if len(gate_qubit_pairs) < 3:
+        gates_qubis_pairs = find_gates_qubits_pairs(circuit)
+        if len(gates_qubis_pairs) < 3:
             raise_error(
                 ValueError, "Circuit must contain at least two two qubit gates to implement subgraph placement."
             )
@@ -140,15 +140,15 @@ class Subgraph(Placer):
         circuit_subgraph.add_nodes_from(range(self.connectivity.number_of_nodes()))
         matcher = nx.algorithms.isomorphism.GraphMatcher(self.connectivity, circuit_subgraph)
         i = 0
-        circuit_subgraph.add_edge(gate_qubit_pairs[i][0], gate_qubit_pairs[i][1])
+        circuit_subgraph.add_edge(gates_qubis_pairs[i][0], gates_qubis_pairs[i][1])
         while matcher.subgraph_is_monomorphic() == True:
             result = matcher
             i += 1
-            circuit_subgraph.add_edge(gate_qubit_pairs[i][0], gate_qubit_pairs[i][1])
+            circuit_subgraph.add_edge(gates_qubis_pairs[i][0], gates_qubis_pairs[i][1])
             matcher = nx.algorithms.isomorphism.GraphMatcher(self.connectivity, circuit_subgraph)
             if (
                 self.connectivity.number_of_edges() == circuit_subgraph.number_of_edges()
-                or i == len(gate_qubit_pairs) - 1
+                or i == len(gates_qubis_pairs) - 1
             ):
                 keys = list(result.mapping.keys())
                 keys.sort()
@@ -179,16 +179,16 @@ class Random(Placer):
         Returns:
             (dict): physical to logical qubit mapping.
         """
-        gate_qubit_pairs = find_qubit_pairs(circuit)
+        gates_qubis_pairs = find_gates_qubits_pairs(circuit)
         nodes = self.connectivity.number_of_nodes()
         keys = list(self.connectivity.nodes())
         final_mapping = dict(zip(keys, range(nodes)))
         final_graph = nx.relabel_nodes(self.connectivity, final_mapping)
-        final_cost = self.cost(final_graph, gate_qubit_pairs)
+        final_cost = self.cost(final_graph, gates_qubis_pairs)
         for _ in range(self.samples):
             mapping = dict(zip(keys, random.sample(range(nodes), nodes)))
             graph = nx.relabel_nodes(self.connectivity, mapping)
-            cost = self.cost(graph, gate_qubit_pairs)
+            cost = self.cost(graph, gates_qubis_pairs)
             if cost == 0:
                 return mapping
             if cost < final_cost:
@@ -198,21 +198,21 @@ class Random(Placer):
         return final_mapping
 
     @staticmethod
-    def cost(graph, gate_qubit_pairs):
+    def cost(graph, gates_qubis_pairs):
         """
         Compute the cost associated to an initial layout as the lengh of the reduced circuit.
 
         Args:
             graph (networkx.Graph): current hardware qubit mapping.
-            gate_qubit_pairs (list): circuit representation.
+            gates_qubis_pairs (list): circuit representation.
 
         Returns:
             (int): lengh of the reduced circuit.
         """
-        for allowed, gate in enumerate(gate_qubit_pairs):
+        for allowed, gate in enumerate(gates_qubis_pairs):
             if gate not in graph.edges():
                 break
-        return len(gate_qubit_pairs) - allowed
+        return len(gates_qubis_pairs) - allowed
 
 
 class Backpropagation(Placer):
@@ -265,18 +265,18 @@ class Backpropagation(Placer):
 
         if self.depth is None:
             return circuit.invert()
-        gate_qubit_pairs = find_qubit_pairs(circuit)
-        circuit_gates = len(gate_qubit_pairs)
+        gates_qubis_pairs = find_gates_qubits_pairs(circuit)
+        circuit_gates = len(gates_qubis_pairs)
         if circuit_gates == 0:
             raise ValueError("The circuit must contain at least a two qubit gate.")
         repetitions, remainder = divmod(self.depth, circuit_gates)
-        assembled_qubit_pairs = []
+        assembled_gates_qubits_pairs = []
         for _ in range(repetitions):
-            assembled_qubit_pairs += gate_qubit_pairs[:]
-            gate_qubit_pairs.reverse()
-        assembled_qubit_pairs += gate_qubit_pairs[0:remainder]
+            assembled_gates_qubits_pairs += gates_qubis_pairs[:]
+            gates_qubis_pairs.reverse()
+        assembled_gates_qubits_pairs += gates_qubis_pairs[0:remainder]
         new_circuit = Circuit(circuit.nqubits)
-        for qubits in assembled_qubit_pairs:
+        for qubits in assembled_gates_qubits_pairs:
             # As only the connectivity is important here we can replace everything with CZ gates
             new_circuit.add(gates.CZ(qubits[0], qubits[1]))
         return new_circuit.invert()

--- a/src/qibolab/transpilers/placer.py
+++ b/src/qibolab/transpilers/placer.py
@@ -223,17 +223,17 @@ class Backpropagation(Placer):
     Attributes:
         connectivity (networkx.Graph): chip connectivity.
         routing_algorithm (qibolab.transpilers.routing.Transpiler): routing algorithm.
-        previous_gates (int): number of two qubit gates considered before finding initial layout.
+        depth (int): number of two qubit gates considered before finding initial layout.
             if 'None' just one backward step will be implemented.
-            If previous_gates is greater than the number of two qubit gates in the circuit, the circuit will be routed more than once.
-            Example: on a circuit with four two qubit gates A-B-C-D using previous_gates = 6,
+            If depth is greater than the number of two qubit gates in the circuit, the circuit will be routed more than once.
+            Example: on a circuit with four two qubit gates A-B-C-D using depth = 6,
             the routing will be performed on the circuit C-D-D-C-B-A.
     """
 
-    def __init__(self, connectivity: nx.Graph, routing_algorithm: Router, previous_gates=None):
+    def __init__(self, connectivity: nx.Graph, routing_algorithm: Router, depth=None):
         self.connectivity = connectivity
         self.routing_algorithm = routing_algorithm
-        self.previous_gates = previous_gates
+        self.depth = depth
 
     def __call__(self, circuit: Circuit):
         """Find the initial layout of the given circuit using backpropagation placement.
@@ -252,8 +252,8 @@ class Backpropagation(Placer):
         return final_placement
 
     def assemble_circuit(self, circuit: Circuit):
-        """Assemble a single circuit to apply backpropagation placement based on previous_gates.
-        Example: for a circuit with four two qubit gates A-B-C-D using previous_gates = 6,
+        """Assemble a single circuit to apply backpropagation placement based on depth.
+        Example: for a circuit with four two qubit gates A-B-C-D using depth = 6,
         the function will return the circuit C-D-D-C-B-A.
 
         Args:
@@ -263,13 +263,13 @@ class Backpropagation(Placer):
             new_circuit (qibo.models.Circuit): assembled circuit to perform backpropagation placement.
         """
 
-        if self.previous_gates is None:
+        if self.depth is None:
             return circuit.invert()
         gate_qubit_pairs = find_qubit_pairs(circuit)
         circuit_gates = len(gate_qubit_pairs)
         if circuit_gates == 0:
             raise ValueError("The circuit must contain at least a two qubit gate.")
-        repetitions, remainder = divmod(self.previous_gates, circuit_gates)
+        repetitions, remainder = divmod(self.depth, circuit_gates)
         assembled_qubit_pairs = []
         for _ in range(repetitions):
             assembled_qubit_pairs += gate_qubit_pairs[:]

--- a/src/qibolab/transpilers/routing.py
+++ b/src/qibolab/transpilers/routing.py
@@ -6,7 +6,7 @@ from qibo import gates
 from qibo.config import log, raise_error
 from qibo.models import Circuit
 
-from qibolab.transpilers.abstract import Router, create_circuit_repr
+from qibolab.transpilers.abstract import Router, create_circuit_representation
 from qibolab.transpilers.placer import assert_placement
 
 
@@ -14,7 +14,7 @@ class ConnectivityError(Exception):
     """Raise for an error in the connectivity"""
 
 
-def assert_connectivity(connectivity, circuit):
+def assert_connectivity(connectivity: nx.Graph, circuit: Circuit):
     """Assert if a circuit can be executed on Hardware.
     No gates acting on more than two qubits.
     All two qubit operations can be performed on hardware
@@ -32,7 +32,7 @@ def assert_connectivity(connectivity, circuit):
                 raise ConnectivityError("Circuit does not respect connectivity. " f"{gate.name} acts on {gate.qubits}.")
 
 
-def remap_circuit(circuit, qubit_map):
+def remap_circuit(circuit: Circuit, qubit_map):
     """Map logical to physical qubits in a circuit.
 
     Args:
@@ -95,7 +95,7 @@ class ShortestPaths(Router):
         self._mapping = initial_layout
         init_qubit_map = np.asarray(list(initial_layout.values()))
         self.initial_checks(circuit.nqubits)
-        self._circuit_repr = create_circuit_repr(circuit)
+        self._circuit_repr = create_circuit_representation(circuit)
         self._graph = nx.relabel_nodes(self.connectivity, self._mapping)
         self._qubit_map = np.sort(init_qubit_map)
         self.first_transpiler_step(circuit)

--- a/src/qibolab/transpilers/routing.py
+++ b/src/qibolab/transpilers/routing.py
@@ -6,7 +6,7 @@ from qibo import gates
 from qibo.config import log, raise_error
 from qibo.models import Circuit
 
-from qibolab.transpilers.abstract import Router, find_qubit_pairs
+from qibolab.transpilers.abstract import Router, find_gates_qubits_pairs
 from qibolab.transpilers.placer import assert_placement
 
 
@@ -95,7 +95,7 @@ class ShortestPaths(Router):
         self._mapping = initial_layout
         init_qubit_map = np.asarray(list(initial_layout.values()))
         self.initial_checks(circuit.nqubits)
-        self._gates_qubits_pairs = find_qubit_pairs(circuit)
+        self._gates_qubits_pairs = find_gates_qubits_pairs(circuit)
         self._graph = nx.relabel_nodes(self.connectivity, self._mapping)
         self._qubit_map = np.sort(init_qubit_map)
         self.first_transpiler_step(circuit)

--- a/src/qibolab/transpilers/routing.py
+++ b/src/qibolab/transpilers/routing.py
@@ -59,7 +59,7 @@ class ShortestPaths(Router):
         verbose (bool): print info messages.
         initial_layout (dict): initial physical to logical qubit mapping
         added_swaps (int): number of swaps added to the circuit to match connectivity.
-        _qubit_pairs (list): quantum circuit represented as a list (only 2 qubit gates).
+        _gates_qubits_pairs (list): quantum circuit represented as a list (only 2 qubit gates).
         _mapping (dict): circuit to physical qubit mapping during transpiling.
         _graph (networkx.graph): qubit mapped as nodes of the connectivity graph.
         _qubit_map (np.array): circuit to physical qubit mapping during transpiling as vector.
@@ -74,7 +74,7 @@ class ShortestPaths(Router):
         self.initial_layout = None
         self.added_swaps = 0
         self.final_map = None
-        self._qubit_pairs = None
+        self._gates_qubits_pairs = None
         self._mapping = None
         self._graph = None
         self._qubit_map = None
@@ -95,11 +95,11 @@ class ShortestPaths(Router):
         self._mapping = initial_layout
         init_qubit_map = np.asarray(list(initial_layout.values()))
         self.initial_checks(circuit.nqubits)
-        self._qubit_pairs = find_qubit_pairs(circuit)
+        self._gates_qubits_pairs = find_qubit_pairs(circuit)
         self._graph = nx.relabel_nodes(self.connectivity, self._mapping)
         self._qubit_map = np.sort(init_qubit_map)
         self.first_transpiler_step(circuit)
-        while len(self._qubit_pairs) != 0:
+        while len(self._gates_qubits_pairs) != 0:
             self.transpiler_step(circuit)
         final_mapping = {
             key: self._qubit_map[init_qubit_map[i]] for i, key in enumerate(list(self.connectivity.nodes()))
@@ -113,11 +113,11 @@ class ShortestPaths(Router):
         Args:
             qibo_circuit (qibo.models.Circuit): circuit to be transpiled.
         """
-        len_before_step = len(self._qubit_pairs)
+        len_before_step = len(self._gates_qubits_pairs)
         path, meeting_point = self.relocate()
         self.add_swaps(path, meeting_point)
         self.update_qubit_map()
-        self.add_gates(qibo_circuit, len_before_step - len(self._qubit_pairs))
+        self.add_gates(qibo_circuit, len_before_step - len(self._gates_qubits_pairs))
 
     def first_transpiler_step(self, qibo_circuit):
         """First transpilation step. Apply gates that can be run with the initial qubit mapping.
@@ -127,9 +127,9 @@ class ShortestPaths(Router):
         """
         self._circuit_position = 0
         self.added_swaps = 0
-        len_2q_circuit = len(self._qubit_pairs)
-        self._qubit_pairs = self.reduce(self._graph)
-        self.add_gates(qibo_circuit, len_2q_circuit - len(self._qubit_pairs))
+        len_2q_circuit = len(self._gates_qubits_pairs)
+        self._gates_qubits_pairs = self.reduce(self._graph)
+        self.add_gates(qibo_circuit, len_2q_circuit - len(self._gates_qubits_pairs))
 
     @property
     def sampling_split(self):
@@ -163,7 +163,7 @@ class ShortestPaths(Router):
         Returns:
             new_circuit (list): reduced circuit.
         """
-        new_circuit = self._qubit_pairs.copy()
+        new_circuit = self._gates_qubits_pairs.copy()
         while new_circuit != [] and (new_circuit[0][0], new_circuit[0][1]) in graph.edges():
             del new_circuit[0]
         return new_circuit
@@ -226,7 +226,7 @@ class ShortestPaths(Router):
                     meeting_point = meeting_point_list[j]
         self._graph = final_graph
         self._mapping = final_mapping
-        self._qubit_pairs = final_circuit
+        self._gates_qubits_pairs = final_circuit
         return final_path, meeting_point
 
     def initial_checks(self, qubits):

--- a/tests/test_transpilers_abstract.py
+++ b/tests/test_transpilers_abstract.py
@@ -2,7 +2,7 @@ import pytest
 from qibo import gates
 from qibo.models import Circuit
 
-from qibolab.transpilers.abstract import find_qubit_pairs
+from qibolab.transpilers.abstract import find_gates_qubits_pairs
 
 
 def test_circuit_representation():
@@ -12,7 +12,7 @@ def test_circuit_representation():
     circuit.add(gates.X(1))
     circuit.add(gates.CZ(3, 0))
     circuit.add(gates.CNOT(4, 0))
-    repr = find_qubit_pairs(circuit)
+    repr = find_gates_qubits_pairs(circuit)
     assert repr == [[0, i + 1] for i in range(4)]
 
 
@@ -20,4 +20,4 @@ def test_circuit_representation_fail():
     circuit = Circuit(5)
     circuit.add(gates.TOFFOLI(0, 1, 2))
     with pytest.raises(ValueError):
-        repr = find_qubit_pairs(circuit)
+        repr = find_gates_qubits_pairs(circuit)

--- a/tests/test_transpilers_abstract.py
+++ b/tests/test_transpilers_abstract.py
@@ -2,7 +2,7 @@ import pytest
 from qibo import gates
 from qibo.models import Circuit
 
-from qibolab.transpilers.abstract import create_circuit_representation
+from qibolab.transpilers.abstract import find_qubit_pairs
 
 
 def test_circuit_representation():
@@ -12,7 +12,7 @@ def test_circuit_representation():
     circuit.add(gates.X(1))
     circuit.add(gates.CZ(3, 0))
     circuit.add(gates.CNOT(4, 0))
-    repr = create_circuit_representation(circuit)
+    repr = find_qubit_pairs(circuit)
     assert repr == [[0, i + 1] for i in range(4)]
 
 
@@ -20,4 +20,4 @@ def test_circuit_representation_fail():
     circuit = Circuit(5)
     circuit.add(gates.TOFFOLI(0, 1, 2))
     with pytest.raises(ValueError):
-        repr = create_circuit_representation(circuit)
+        repr = find_qubit_pairs(circuit)

--- a/tests/test_transpilers_abstract.py
+++ b/tests/test_transpilers_abstract.py
@@ -2,7 +2,7 @@ import pytest
 from qibo import gates
 from qibo.models import Circuit
 
-from qibolab.transpilers.abstract import create_circuit_repr
+from qibolab.transpilers.abstract import create_circuit_representation
 
 
 def test_circuit_representation():
@@ -12,7 +12,7 @@ def test_circuit_representation():
     circuit.add(gates.X(1))
     circuit.add(gates.CZ(3, 0))
     circuit.add(gates.CNOT(4, 0))
-    repr = create_circuit_repr(circuit)
+    repr = create_circuit_representation(circuit)
     assert repr == [[0, i + 1] for i in range(4)]
 
 
@@ -20,4 +20,4 @@ def test_circuit_representation_fail():
     circuit = Circuit(5)
     circuit.add(gates.TOFFOLI(0, 1, 2))
     with pytest.raises(ValueError):
-        repr = create_circuit_repr(circuit)
+        repr = create_circuit_representation(circuit)

--- a/tests/test_transpilers_placer.py
+++ b/tests/test_transpilers_placer.py
@@ -162,7 +162,7 @@ def test_backpropagation(gates):
     circuit = star_circuit()
     connectivity = star_connectivity()
     routing = ShortestPaths(connectivity=connectivity)
-    placer = Backpropagation(connectivity, routing, num_precedent_gates=gates)
+    placer = Backpropagation(connectivity, routing, previous_gates=gates)
     layout = placer(circuit)
     assert_placement(circuit, layout)
 
@@ -170,7 +170,7 @@ def test_backpropagation(gates):
 def test_backpropagation_no_gates():
     connectivity = star_connectivity()
     routing = ShortestPaths(connectivity=connectivity)
-    placer = Backpropagation(connectivity, routing, num_precedent_gates=10)
+    placer = Backpropagation(connectivity, routing, previous_gates=10)
     circuit = Circuit(5)
     with pytest.raises(ValueError):
         layout = placer(circuit)

--- a/tests/test_transpilers_placer.py
+++ b/tests/test_transpilers_placer.py
@@ -162,7 +162,7 @@ def test_backpropagation(gates):
     circuit = star_circuit()
     connectivity = star_connectivity()
     routing = ShortestPaths(connectivity=connectivity)
-    placer = Backpropagation(connectivity, routing, gates=gates)
+    placer = Backpropagation(connectivity, routing, num_precedent_gates=gates)
     layout = placer(circuit)
     assert_placement(circuit, layout)
 
@@ -170,7 +170,7 @@ def test_backpropagation(gates):
 def test_backpropagation_no_gates():
     connectivity = star_connectivity()
     routing = ShortestPaths(connectivity=connectivity)
-    placer = Backpropagation(connectivity, routing, gates=10)
+    placer = Backpropagation(connectivity, routing, num_precedent_gates=10)
     circuit = Circuit(5)
     with pytest.raises(ValueError):
         layout = placer(circuit)

--- a/tests/test_transpilers_placer.py
+++ b/tests/test_transpilers_placer.py
@@ -162,7 +162,7 @@ def test_backpropagation(gates):
     circuit = star_circuit()
     connectivity = star_connectivity()
     routing = ShortestPaths(connectivity=connectivity)
-    placer = Backpropagation(connectivity, routing, previous_gates=gates)
+    placer = Backpropagation(connectivity, routing, depth=gates)
     layout = placer(circuit)
     assert_placement(circuit, layout)
 
@@ -170,7 +170,7 @@ def test_backpropagation(gates):
 def test_backpropagation_no_gates():
     connectivity = star_connectivity()
     routing = ShortestPaths(connectivity=connectivity)
-    placer = Backpropagation(connectivity, routing, previous_gates=10)
+    placer = Backpropagation(connectivity, routing, depth=10)
     circuit = Circuit(5)
     with pytest.raises(ValueError):
         layout = placer(circuit)

--- a/tests/test_transpilers_placer.py
+++ b/tests/test_transpilers_placer.py
@@ -120,9 +120,7 @@ def test_subgraph_perfect():
     assert_placement(star_circuit(), layout)
 
 
-def test_subgraph_non_perfect():
-    connectivity = star_connectivity()
-    placer = Subgraph(connectivity=connectivity)
+def imperfect_circuit():
     circuit = Circuit(5)
     circuit.add(gates.CNOT(1, 3))
     circuit.add(gates.CNOT(2, 4))
@@ -133,8 +131,14 @@ def test_subgraph_non_perfect():
     circuit.add(gates.CNOT(4, 3))
     circuit.add(gates.CNOT(1, 2))
     circuit.add(gates.CNOT(3, 1))
-    layout = placer(circuit)
-    assert_placement(circuit, layout)
+    return circuit
+
+
+def test_subgraph_non_perfect():
+    connectivity = star_connectivity()
+    placer = Subgraph(connectivity=connectivity)
+    layout = placer(imperfect_circuit())
+    assert_placement(imperfect_circuit(), layout)
 
 
 def test_subgraph_error():
@@ -153,9 +157,20 @@ def test_random(reps):
     assert_placement(star_circuit(), layout)
 
 
-def test_backpropagation():
+@pytest.mark.parametrize("gates", [None, 5, 13])
+def test_backpropagation(gates):
+    circuit = star_circuit()
     connectivity = star_connectivity()
     routing = ShortestPaths(connectivity=connectivity)
-    placer = Backpropagation(connectivity, routing)
-    layout = placer(star_circuit())
-    assert_placement(star_circuit(), layout)
+    placer = Backpropagation(connectivity, routing, gates=gates)
+    layout = placer(circuit)
+    assert_placement(circuit, layout)
+
+
+def test_backpropagation_no_gates():
+    connectivity = star_connectivity()
+    routing = ShortestPaths(connectivity=connectivity)
+    placer = Backpropagation(connectivity, routing, gates=10)
+    circuit = Circuit(5)
+    with pytest.raises(ValueError):
+        layout = placer(circuit)


### PR DESCRIPTION
Backpropagation placement defining the number previous gates to be considered
@AleCandido here the parameter is ngates, i you want to use just the first part of a long circuit you can just pass the initial part of the circuit to the placer. In this way the function is general and easy to use.

Checklist:
- [x] Reviewers confirm new code works as expected.
- [X] Tests are passing.
- [X] Coverage does not decrease.
- [X] Documentation is updated.
