### PR TITLE
Add sequence unrolling for the dummy

### DIFF
--- a/src/qibolab/__init__.py
+++ b/src/qibolab/__init__.py
@@ -8,7 +8,6 @@ from typing import Optional
 
 from qibo.config import raise_error
 
-from qibolab.platform import Platform
 from qibolab.result import (
     AveragedIntegratedResults,
     AveragedRawWaveformResults,

--- a/src/qibolab/instruments/abstract.py
+++ b/src/qibolab/instruments/abstract.py
@@ -52,15 +52,18 @@ class Controller(Instrument):
 
     @abstractmethod
     def play(self, *args, **kwargs):
-        """If the sequence is a PulseSequence play a pulse sequence and retrieve feedback.
-        If the sequence is a List play a pulses sequences by unrolling and retrieve feedback
+        """The sequence is a PulseSequence play a pulse sequence and retrieve feedback.
 
         Returns:
-            If the sequence is a PulseSequence:
             (Dict[ResultType]) mapping the serial of the readout pulses used to
             the acquired :class:`qibolab.result.ExecutionResults` object.
+        """
 
-            If the sequence is a List:
+    @abstractmethod
+    def play_sequences(self, *args, **kwargs):
+        """The sequence is a List play a pulses sequences by unrolling and retrieve feedback.
+
+        Returns:
             (Dict[List[ResultType]) mapping the serial of the readout pulses used to a list of
             the acquired :class:`qibolab.result.ExecutionResults` object.
         """

--- a/src/qibolab/instruments/abstract.py
+++ b/src/qibolab/instruments/abstract.py
@@ -52,10 +52,16 @@ class Controller(Instrument):
 
     @abstractmethod
     def play(self, *args, **kwargs):
-        """Play a pulse sequence and retrieve feedback.
+        """If the sequence is a PulseSequence play a pulse sequence and retrieve feedback.
+        If the sequence is a List play a pulses sequences by unrolling and retrieve feedback
 
         Returns:
-            (dict) mapping the serial of the readout pulses used to
+            If the sequence is a PulseSequence:
+            (Dict[ResultType]) mapping the serial of the readout pulses used to
+            the acquired :class:`qibolab.result.ExecutionResults` object.
+
+            If the sequence is a List:
+            (Dict[List[ResultType]) mapping the serial of the readout pulses used to a list of
             the acquired :class:`qibolab.result.ExecutionResults` object.
         """
 

--- a/src/qibolab/instruments/abstract.py
+++ b/src/qibolab/instruments/abstract.py
@@ -83,7 +83,7 @@ class Controller(Instrument):
 
     @abstractmethod
     def play(self, *args, **kwargs):
-        """The sequence is a PulseSequence play a pulse sequence and retrieve feedback.
+        """Play a pulse sequence and retrieve feedback.
 
         Returns:
             (Dict[ResultType]) mapping the serial of the readout pulses used to
@@ -92,7 +92,7 @@ class Controller(Instrument):
 
     @abstractmethod
     def play_sequences(self, *args, **kwargs):
-        """The sequence is a List play a pulses sequences by unrolling and retrieve feedback.
+        """Play pulses sequences by unrolling and retrieve feedback.
 
         Returns:
             (Dict[List[ResultType]) mapping the serial of the readout pulses used to a list of

--- a/src/qibolab/instruments/dummy.py
+++ b/src/qibolab/instruments/dummy.py
@@ -55,7 +55,12 @@ class DummyInstrument(Controller):
                 values = np.random.rand(exp_points) * 100 + 1j * np.random.rand(exp_points) * 100
         return values
 
-    def play(self, qubits: Dict[Union[str, int], Qubit], sequence: PulseSequence, options: ExecutionParameters):
+    def play(
+        self,
+        qubits: Dict[Union[str, int], Qubit],
+        sequence: Union[PulseSequence, List[PulseSequence]],
+        options: ExecutionParameters,
+    ):
         exp_points = 1 if options.averaging_mode is AveragingMode.CYCLIC else options.nshots
         results = {}
 
@@ -87,4 +92,9 @@ class DummyInstrument(Controller):
         if options.averaging_mode is not AveragingMode.CYCLIC:
             exp_points *= options.nshots
 
-        return self.get_values(options, sequence, exp_points)
+        results = {}
+        for ro_pulse in sequence.ro_pulses:
+            values = self.get_values(options, sequence, exp_points)
+            results[ro_pulse.qubit] = results[ro_pulse.serial] = options.results_type(values)
+
+        return results

--- a/src/qibolab/instruments/dummy.py
+++ b/src/qibolab/instruments/dummy.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from typing import Dict, List, Union
 
 import numpy as np
@@ -64,14 +65,13 @@ class DummyInstrument(Controller):
                 results[ro_pulse.qubit] = results[ro_pulse.serial] = options.results_type(values)
 
         if isinstance(sequence, List):
-            values_sequence = []
+            results = defaultdict(list)
             for small_sequence in sequence:
                 for ro_pulse in small_sequence.ro_pulses:
                     values = self.get_values(options, small_sequence, exp_points)
-                    values_sequence.append(options.results_type(values))
-            results[ro_pulse.qubit] = results[ro_pulse.serial] = values_sequence
+                    results[ro_pulse.serial].append(options.results_type(values))
+                    results[ro_pulse.qubit].append(options.results_type(values))
 
-        # return self.get_values(options, sequence, exp_points)
         return results
 
     def sweep(

--- a/src/qibolab/instruments/dummy.py
+++ b/src/qibolab/instruments/dummy.py
@@ -58,24 +58,31 @@ class DummyInstrument(Controller):
     def play(
         self,
         qubits: Dict[Union[str, int], Qubit],
-        sequence: Union[PulseSequence, List[PulseSequence]],
+        sequence: PulseSequence,
         options: ExecutionParameters,
     ):
         exp_points = 1 if options.averaging_mode is AveragingMode.CYCLIC else options.nshots
         results = {}
 
-        if isinstance(sequence, PulseSequence):
-            for ro_pulse in sequence.ro_pulses:
-                values = self.get_values(options, sequence, exp_points)
-                results[ro_pulse.qubit] = results[ro_pulse.serial] = options.results_type(values)
+        for ro_pulse in sequence.ro_pulses:
+            values = self.get_values(options, sequence, exp_points)
+            results[ro_pulse.qubit] = results[ro_pulse.serial] = options.results_type(values)
 
-        if isinstance(sequence, List):
-            results = defaultdict(list)
-            for small_sequence in sequence:
-                for ro_pulse in small_sequence.ro_pulses:
-                    values = self.get_values(options, small_sequence, exp_points)
-                    results[ro_pulse.serial].append(options.results_type(values))
-                    results[ro_pulse.qubit].append(options.results_type(values))
+        return results
+
+    def play_sequences(
+        self,
+        qubits: Dict[Union[str, int], Qubit],
+        sequence: List[PulseSequence],
+        options: ExecutionParameters,
+    ):
+        exp_points = 1 if options.averaging_mode is AveragingMode.CYCLIC else options.nshots
+        results = defaultdict(list)
+        for small_sequence in sequence:
+            for ro_pulse in small_sequence.ro_pulses:
+                values = self.get_values(options, small_sequence, exp_points)
+                results[ro_pulse.serial].append(options.results_type(values))
+                results[ro_pulse.qubit].append(options.results_type(values))
 
         return results
 

--- a/src/qibolab/instruments/dummy.py
+++ b/src/qibolab/instruments/dummy.py
@@ -91,16 +91,16 @@ class DummyInstrument(Controller):
     def play_sequences(
         self,
         qubits: Dict[QubitId, Qubit],
-        sequence: List[PulseSequence],
+        sequences: List[PulseSequence],
         options: ExecutionParameters,
     ):
         exp_points = 1 if options.averaging_mode is AveragingMode.CYCLIC else options.nshots
         shape = (exp_points,)
 
         results = defaultdict(list)
-        for small_sequence in sequence:
-            for ro_pulse in small_sequence.ro_pulses:
-                values = self.get_values(options, small_sequence, shape)
+        for sequence in sequences:
+            for ro_pulse in sequence.ro_pulses:
+                values = self.get_values(options, sequence, shape)
                 results[ro_pulse.serial].append(options.results_type(values))
                 results[ro_pulse.qubit].append(options.results_type(values))
 

--- a/src/qibolab/instruments/qm.py
+++ b/src/qibolab/instruments/qm.py
@@ -1004,3 +1004,6 @@ class QMOPX(Controller):
 
         result = self.execute_program(experiment)
         return self.fetch_results(result, qmsequence.ro_pulses)
+
+    def play_sequences(self, qubits, sequence, options):
+        pass

--- a/src/qibolab/instruments/qm.py
+++ b/src/qibolab/instruments/qm.py
@@ -1017,4 +1017,4 @@ class QMOPX(Controller):
         return self.fetch_results(result, qmsequence.ro_pulses)
 
     def play_sequences(self, qubits, sequence, options):
-        pass
+        raise NotImplementedError

--- a/src/qibolab/instruments/rfsoc.py
+++ b/src/qibolab/instruments/rfsoc.py
@@ -326,7 +326,7 @@ class RFSoC(Controller):
         return results
 
     def play_sequences(self, qubits, sequence, options):
-        pass
+        raise NotImplementedError
 
     @staticmethod
     def validate_input_command(sequence: PulseSequence, execution_parameters: ExecutionParameters, sweep: bool):

--- a/src/qibolab/instruments/rfsoc.py
+++ b/src/qibolab/instruments/rfsoc.py
@@ -316,6 +316,9 @@ class RFSoC(Controller):
 
         return results
 
+    def play_sequences(self, qubits, sequence, options):
+        pass
+
     @staticmethod
     def validate_input_command(sequence: PulseSequence, execution_parameters: ExecutionParameters, sweep: bool):
         """Check if sequence and execution_parameters are supported."""

--- a/src/qibolab/instruments/zhinst.py
+++ b/src/qibolab/instruments/zhinst.py
@@ -1057,6 +1057,9 @@ class Zurich(Controller):
             else:
                 self.define_exp(qubits, options, exp, exp_calib)
 
+    def play_sequences(self, qubits, sequence, options):
+        pass
+
     # -----------------------------------------------------------------------------
 
     def play_sim(self, qubits, sequence, options, sim_time):

--- a/src/qibolab/platform.py
+++ b/src/qibolab/platform.py
@@ -358,7 +358,7 @@ class Platform:
             **kwargs: May need them for something
         Returns:
             Readout results acquired by after execution.
-        
+
         """
         return self._execute("play", sequences, options, **kwargs)
 
@@ -370,7 +370,7 @@ class Platform:
             **kwargs: May need them for something
         Returns:
             Readout results acquired by after execution.
-        
+
         """
         return self._execute("play_sequences", sequences, options, **kwargs)
 

--- a/src/qibolab/platform.py
+++ b/src/qibolab/platform.py
@@ -353,6 +353,34 @@ class Platform:
                     result = new_result
         return result
 
+    def execute_pulse_sequences(self, sequence, options, **kwargs):
+        """Executes a List of PulseSequence.
+
+        Args:
+            sequence (List[:class:`qibolab.pulses.PulseSequence`]): Pulse sequences to execute.
+            options (:class:`qibolab.platforms.platform.ExecutionParameters`): Object holding the execution options.
+            **kwargs: May need them for something
+
+        Returns:
+            Readout results acquired by after execution.
+        """
+        if options.nshots is None:
+            options = replace(options, nshots=self.nshots)
+
+        if options.relaxation_time is None:
+            options = replace(options, relaxation_time=self.relaxation_time)
+
+        result = {}
+        for instrument in self.instruments:
+            if isinstance(instrument, Controller):
+                new_result = instrument.play_sequences(self.qubits, sequence, options)
+                if isinstance(new_result, dict):
+                    result.update(new_result)
+                elif new_result is not None:
+                    # currently the result of QMSim is not a dict
+                    result = new_result
+        return result
+
     def sweep(self, sequence, options, *sweepers):
         """Executes a pulse sequence for different values of sweeped parameters.
 

--- a/src/qibolab/platform.py
+++ b/src/qibolab/platform.py
@@ -10,7 +10,6 @@ import networkx as nx
 import yaml
 from qibo.config import log, raise_error
 
-from qibolab import ExecutionParameters
 from qibolab.channels import Channel, ChannelMap
 from qibolab.execution_parameters import ExecutionParameters
 from qibolab.instruments.abstract import Controller, Instrument

--- a/src/qibolab/platform.py
+++ b/src/qibolab/platform.py
@@ -332,6 +332,7 @@ class Platform:
         self.is_connected = False
 
     def _execute(self, method, sequences, options, **kwargs):
+        """Executes the sequences on the controllers"""
         if options.nshots is None:
             options = replace(options, nshots=self.nshots)
 
@@ -350,9 +351,27 @@ class Platform:
         return result
 
     def execute_pulse_sequence(self, sequences: PulseSequence, options: ExecutionParameters, **kwargs):
+        """
+        Args:
+            sequence (:class:`qibolab.pulses.PulseSequence`): Pulse sequences to execute.
+            options (:class:`qibolab.platforms.platform.ExecutionParameters`): Object holding the execution options.
+            **kwargs: May need them for something
+        Returns:
+            Readout results acquired by after execution.
+        
+        """
         return self._execute("play", sequences, options, **kwargs)
 
     def execute_pulse_sequences(self, sequences: List[PulseSequence], options: ExecutionParameters, **kwargs):
+        """
+        Args:
+            sequence (List[:class:`qibolab.pulses.PulseSequence`]): Pulse sequences to execute.
+            options (:class:`qibolab.platforms.platform.ExecutionParameters`): Object holding the execution options.
+            **kwargs: May need them for something
+        Returns:
+            Readout results acquired by after execution.
+        
+        """
         return self._execute("play_sequences", sequences, options, **kwargs)
 
     def sweep(self, sequence: PulseSequence, options: ExecutionParameters, *sweepers: Sweeper):

--- a/src/qibolab/platform.py
+++ b/src/qibolab/platform.py
@@ -13,7 +13,9 @@ from qibo.config import log, raise_error
 from qibolab.channels import Channel, ChannelMap
 from qibolab.instruments.abstract import Controller, Instrument
 from qibolab.native import NativeType, SingleQubitNatives, TwoQubitNatives
+from qibolab.pulses import PulseSequence
 from qibolab.qubits import Qubit, QubitId, QubitPair
+from qibolab.sweeper import Sweeper
 
 
 class Platform:
@@ -328,13 +330,8 @@ class Platform:
                 instrument.disconnect()
         self.is_connected = False
 
-    def execute_pulse_sequence(self, sequence, options, **kwargs):
+    def execute_pulse_sequence(self, sequence: PulseSequence, options, **kwargs):
         """Executes a pulse sequence.
-
-        Args:
-            sequence (:class:`qibolab.pulses.PulseSequence`): Pulse sequence to execute.
-            options (:class:`qibolab.platforms.platform.ExecutionParameters`): Object holding the execution options.
-            **kwargs: May need them for something
 
         Returns:
             Readout results acquired by after execution.
@@ -356,13 +353,8 @@ class Platform:
                     result = new_result
         return result
 
-    def execute_pulse_sequences(self, sequence, options, **kwargs):
+    def execute_pulse_sequences(self, sequences: List[PulseSequence], options, **kwargs):
         """Executes a List of PulseSequence.
-
-        Args:
-            sequence (List[:class:`qibolab.pulses.PulseSequence`]): Pulse sequences to execute.
-            options (:class:`qibolab.platforms.platform.ExecutionParameters`): Object holding the execution options.
-            **kwargs: May need them for something
 
         Returns:
             Readout results acquired by after execution.
@@ -376,7 +368,7 @@ class Platform:
         result = {}
         for instrument in self.instruments:
             if isinstance(instrument, Controller):
-                new_result = instrument.play_sequences(self.qubits, sequence, options)
+                new_result = instrument.play_sequences(self.qubits, sequences, options)
                 if isinstance(new_result, dict):
                     result.update(new_result)
                 elif new_result is not None:
@@ -384,7 +376,7 @@ class Platform:
                     result = new_result
         return result
 
-    def sweep(self, sequence, options, *sweepers):
+    def sweep(self, sequence: PulseSequence, options, *sweepers: Sweeper):
         """Executes a pulse sequence for different values of sweeped parameters.
 
         Useful for performing chip characterization.
@@ -407,13 +399,6 @@ class Platform:
                 parameter_range = np.random.randint(10, size=10)
                 sweeper = Sweeper(parameter, parameter_range, [pulse])
                 platform.sweep(sequence, ExecutionParameters(), sweeper)
-
-        Args:
-            sequence (:class:`qibolab.pulses.PulseSequence`): Pulse sequence to execute.
-            options (:class:`qibolab.platforms.platform.ExecutionParameters`): Object holding the execution options.
-            *sweepers (:class:`qibolab.sweeper.Sweeper`): Sweeper objects that specify which
-                parameters are being sweeped.
-            **kwargs: May need them for something
 
         Returns:
             Readout results acquired by after execution.

--- a/src/qibolab/platform.py
+++ b/src/qibolab/platform.py
@@ -10,6 +10,7 @@ import networkx as nx
 import yaml
 from qibo.config import log, raise_error
 
+from qibolab import ExecutionParameters
 from qibolab.channels import Channel, ChannelMap
 from qibolab.instruments.abstract import Controller, Instrument
 from qibolab.native import NativeType, SingleQubitNatives, TwoQubitNatives
@@ -330,7 +331,7 @@ class Platform:
                 instrument.disconnect()
         self.is_connected = False
 
-    def execute_pulse_sequence(self, sequence: PulseSequence, options, **kwargs):
+    def execute_pulse_sequence(self, sequence: PulseSequence, options: ExecutionParameters, **kwargs):
         """Executes a pulse sequence.
 
         Returns:
@@ -353,7 +354,7 @@ class Platform:
                     result = new_result
         return result
 
-    def execute_pulse_sequences(self, sequences: List[PulseSequence], options, **kwargs):
+    def execute_pulse_sequences(self, sequences: List[PulseSequence], options: ExecutionParameters, **kwargs):
         """Executes a List of PulseSequence.
 
         Returns:
@@ -376,7 +377,7 @@ class Platform:
                     result = new_result
         return result
 
-    def sweep(self, sequence: PulseSequence, options, *sweepers: Sweeper):
+    def sweep(self, sequence: PulseSequence, options: ExecutionParameters, *sweepers: Sweeper):
         """Executes a pulse sequence for different values of sweeped parameters.
 
         Useful for performing chip characterization.

--- a/tests/test_platforms_dummy.py
+++ b/tests/test_platforms_dummy.py
@@ -34,7 +34,7 @@ def test_dummy_execute_pulse_sequence_unrolling(acquisition):
     for _ in range(5):
         sequences.append(sequence)
     options = ExecutionParameters(nshots=None, acquisition_type=acquisition)
-    result = platform.execute_pulse_sequence(sequences, options)
+    result = platform.execute_pulse_sequences(sequences, options)
 
 
 def test_dummy_single_sweep_RAW():

--- a/tests/test_platforms_dummy.py
+++ b/tests/test_platforms_dummy.py
@@ -25,6 +25,18 @@ def test_dummy_execute_pulse_sequence(acquisition):
     result = platform.execute_pulse_sequence(sequence, options)
 
 
+@pytest.mark.parametrize("acquisition", [AcquisitionType.INTEGRATION, AcquisitionType.DISCRIMINATION])
+def test_dummy_execute_pulse_sequence_unrolling(acquisition):
+    platform = create_platform("dummy")
+    sequences = []
+    sequence = PulseSequence()
+    sequence.add(platform.create_qubit_readout_pulse(0, 0))
+    for _ in range(5):
+        sequences.append(sequence)
+    options = ExecutionParameters(nshots=None, acquisition_type=acquisition)
+    result = platform.execute_pulse_sequence(sequences, options)
+
+
 def test_dummy_single_sweep_RAW():
     swept_points = 5
     platform = create_platform("dummy")


### PR DESCRIPTION
Add sequence unrolling for the dummy to test things in https://github.com/qiboteam/qibocal/pull/398 assuming sequence to be unrolled to be a list of `PulseSequences`.

Tested with the AllXY_unrolling_lists routine using "multiplex".

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
