### PR TITLE
change Backpropagation name to Reverse Traversal Technique

### DIFF
--- a/src/qibolab/transpilers/__init__.py
+++ b/src/qibolab/transpilers/__init__.py
@@ -1,11 +1,6 @@
 from qibolab.transpilers.fusion import Fusion, Rearrange
 from qibolab.transpilers.gate_decompositions import NativeGates
 from qibolab.transpilers.pipeline import Pipeline
-from qibolab.transpilers.placer import (
-    Random,
-    ReverseTraversalTechnique,
-    Subgraph,
-    Trivial,
-)
+from qibolab.transpilers.placer import Random, ReverseTraversal, Subgraph, Trivial
 from qibolab.transpilers.routing import ShortestPaths
 from qibolab.transpilers.star_connectivity import StarConnectivity

--- a/src/qibolab/transpilers/__init__.py
+++ b/src/qibolab/transpilers/__init__.py
@@ -1,6 +1,11 @@
 from qibolab.transpilers.fusion import Fusion, Rearrange
 from qibolab.transpilers.gate_decompositions import NativeGates
 from qibolab.transpilers.pipeline import Pipeline
-from qibolab.transpilers.placer import Backpropagation, Random, Subgraph, Trivial
+from qibolab.transpilers.placer import (
+    Random,
+    ReverseTraversalTechnique,
+    Subgraph,
+    Trivial,
+)
 from qibolab.transpilers.routing import ShortestPaths
 from qibolab.transpilers.star_connectivity import StarConnectivity

--- a/src/qibolab/transpilers/placer.py
+++ b/src/qibolab/transpilers/placer.py
@@ -215,7 +215,7 @@ class Random(Placer):
         return len(gates_qubits_pairs) - allowed
 
 
-class ReverseTraversalTechnique(Placer):
+class ReverseTraversal(Placer):
     """
     Place qubits based on the algorithm proposed in https://doi.org/10.48550/arXiv.1809.02573.
     Works with ShortestPaths routing.
@@ -236,7 +236,7 @@ class ReverseTraversalTechnique(Placer):
         self.depth = depth
 
     def __call__(self, circuit: Circuit):
-        """Find the initial layout of the given circuit using Reverse Traversal Technique placement.
+        """Find the initial layout of the given circuit using Reverse Traversal placement.
 
         Args:
             circuit (qibo.models.Circuit): circuit to be transpiled.
@@ -252,7 +252,7 @@ class ReverseTraversalTechnique(Placer):
         return final_placement
 
     def assemble_circuit(self, circuit: Circuit):
-        """Assemble a single circuit to apply Reverse Traversal Technique placement based on depth.
+        """Assemble a single circuit to apply Reverse Traversal placement based on depth.
         Example: for a circuit with four two qubit gates A-B-C-D using depth = 6,
         the function will return the circuit C-D-D-C-B-A.
 
@@ -260,7 +260,7 @@ class ReverseTraversalTechnique(Placer):
             circuit (qibo.models.Circuit): circuit to be transpiled.
 
         Returns:
-            new_circuit (qibo.models.Circuit): assembled circuit to perform Reverse Traversal Technique placement.
+            new_circuit (qibo.models.Circuit): assembled circuit to perform Reverse Traversal placement.
         """
 
         if self.depth is None:

--- a/src/qibolab/transpilers/placer.py
+++ b/src/qibolab/transpilers/placer.py
@@ -215,7 +215,7 @@ class Random(Placer):
         return len(gates_qubits_pairs) - allowed
 
 
-class Backpropagation(Placer):
+class ReverseTraversalTechnique(Placer):
     """
     Place qubits based on the algorithm proposed in https://doi.org/10.48550/arXiv.1809.02573.
     Works with ShortestPaths routing.
@@ -236,7 +236,7 @@ class Backpropagation(Placer):
         self.depth = depth
 
     def __call__(self, circuit: Circuit):
-        """Find the initial layout of the given circuit using backpropagation placement.
+        """Find the initial layout of the given circuit using Reverse Traversal Technique placement.
 
         Args:
             circuit (qibo.models.Circuit): circuit to be transpiled.
@@ -252,7 +252,7 @@ class Backpropagation(Placer):
         return final_placement
 
     def assemble_circuit(self, circuit: Circuit):
-        """Assemble a single circuit to apply backpropagation placement based on depth.
+        """Assemble a single circuit to apply Reverse Traversal Technique placement based on depth.
         Example: for a circuit with four two qubit gates A-B-C-D using depth = 6,
         the function will return the circuit C-D-D-C-B-A.
 
@@ -260,7 +260,7 @@ class Backpropagation(Placer):
             circuit (qibo.models.Circuit): circuit to be transpiled.
 
         Returns:
-            new_circuit (qibo.models.Circuit): assembled circuit to perform backpropagation placement.
+            new_circuit (qibo.models.Circuit): assembled circuit to perform Reverse Traversal Technique placement.
         """
 
         if self.depth is None:

--- a/tests/test_transpilers_placer.py
+++ b/tests/test_transpilers_placer.py
@@ -4,10 +4,10 @@ from qibo import gates
 from qibo.models import Circuit
 
 from qibolab.transpilers.placer import (
-    Backpropagation,
     Custom,
     PlacementError,
     Random,
+    ReverseTraversalTechnique,
     Subgraph,
     Trivial,
     assert_mapping_consistency,
@@ -158,19 +158,19 @@ def test_random(reps):
 
 
 @pytest.mark.parametrize("gates", [None, 5, 13])
-def test_backpropagation(gates):
+def test_ReverseTraversalTechnique(gates):
     circuit = star_circuit()
     connectivity = star_connectivity()
     routing = ShortestPaths(connectivity=connectivity)
-    placer = Backpropagation(connectivity, routing, depth=gates)
+    placer = ReverseTraversalTechnique(connectivity, routing, depth=gates)
     layout = placer(circuit)
     assert_placement(circuit, layout)
 
 
-def test_backpropagation_no_gates():
+def test_ReverseTraversalTechnique_no_gates():
     connectivity = star_connectivity()
     routing = ShortestPaths(connectivity=connectivity)
-    placer = Backpropagation(connectivity, routing, depth=10)
+    placer = ReverseTraversalTechnique(connectivity, routing, depth=10)
     circuit = Circuit(5)
     with pytest.raises(ValueError):
         layout = placer(circuit)

--- a/tests/test_transpilers_placer.py
+++ b/tests/test_transpilers_placer.py
@@ -7,7 +7,7 @@ from qibolab.transpilers.placer import (
     Custom,
     PlacementError,
     Random,
-    ReverseTraversalTechnique,
+    ReverseTraversal,
     Subgraph,
     Trivial,
     assert_mapping_consistency,
@@ -158,19 +158,19 @@ def test_random(reps):
 
 
 @pytest.mark.parametrize("gates", [None, 5, 13])
-def test_ReverseTraversalTechnique(gates):
+def test_revers_traversal(gates):
     circuit = star_circuit()
     connectivity = star_connectivity()
     routing = ShortestPaths(connectivity=connectivity)
-    placer = ReverseTraversalTechnique(connectivity, routing, depth=gates)
+    placer = ReverseTraversal(connectivity, routing, depth=gates)
     layout = placer(circuit)
     assert_placement(circuit, layout)
 
 
-def test_ReverseTraversalTechnique_no_gates():
+def test_revers_traversal_no_gates():
     connectivity = star_connectivity()
     routing = ShortestPaths(connectivity=connectivity)
-    placer = ReverseTraversalTechnique(connectivity, routing, depth=10)
+    placer = ReverseTraversal(connectivity, routing, depth=10)
     circuit = Circuit(5)
     with pytest.raises(ValueError):
         layout = placer(circuit)

--- a/tests/test_transpilers_placer.py
+++ b/tests/test_transpilers_placer.py
@@ -158,7 +158,7 @@ def test_random(reps):
 
 
 @pytest.mark.parametrize("gates", [None, 5, 13])
-def test_revers_traversal(gates):
+def test_reverse_traversal(gates):
     circuit = star_circuit()
     connectivity = star_connectivity()
     routing = ShortestPaths(connectivity=connectivity)
@@ -167,7 +167,7 @@ def test_revers_traversal(gates):
     assert_placement(circuit, layout)
 
 
-def test_revers_traversal_no_gates():
+def test_reverse_traversal_no_gates():
     connectivity = star_connectivity()
     routing = ShortestPaths(connectivity=connectivity)
     placer = ReverseTraversal(connectivity, routing, depth=10)


### PR DESCRIPTION
Super small PR to change the BackPropagation placer name into "Reverse Traversal Technique", in order to keep the convention purposed in [SABRE's paper](https://arxiv.org/abs/1809.02573).
This follows a discussion had together with @Simone-Bordoni. 

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
