### PR TITLE
Fixed precision issue in 2q unitary gate decomposition

### DIFF
--- a/src/qibolab/transpilers/unitary_decompositions.py
+++ b/src/qibolab/transpilers/unitary_decompositions.py
@@ -46,7 +46,7 @@ def calculate_psi(unitary):
     u_magic = np.dot(np.dot(np.conj(magic_basis.T), unitary), magic_basis)
     # construct and diagonalize UT_U
     ut_u = np.dot(u_magic.T, u_magic)
-    # When the matrix given to np.linalg.eig is a diagonal matrix up to machine precision the decomposition 
+    # When the matrix given to np.linalg.eig is a diagonal matrix up to machine precision the decomposition
     # is not accurate anymore. decimals = 20 works for random 2q Clifford unitaries.
     eigvals, psi_magic = np.linalg.eig(np.round(ut_u, decimals=20))
     # orthogonalize eigenvectors in the case of degeneracy (Gram-Schmidt)

--- a/src/qibolab/transpilers/unitary_decompositions.py
+++ b/src/qibolab/transpilers/unitary_decompositions.py
@@ -46,6 +46,8 @@ def calculate_psi(unitary):
     u_magic = np.dot(np.dot(np.conj(magic_basis.T), unitary), magic_basis)
     # construct and diagonalize UT_U
     ut_u = np.dot(u_magic.T, u_magic)
+    # When the matrix given to np.linalg.eig is a diagonal matrix up to machine precision the decomposition 
+    # is not accurate anymore. decimals = 20 works for random 2q Clifford unitaries.
     eigvals, psi_magic = np.linalg.eig(np.round(ut_u, decimals=20))
     # orthogonalize eigenvectors in the case of degeneracy (Gram-Schmidt)
     psi_magic, _ = np.linalg.qr(psi_magic)

--- a/src/qibolab/transpilers/unitary_decompositions.py
+++ b/src/qibolab/transpilers/unitary_decompositions.py
@@ -46,7 +46,7 @@ def calculate_psi(unitary):
     u_magic = np.dot(np.dot(np.conj(magic_basis.T), unitary), magic_basis)
     # construct and diagonalize UT_U
     ut_u = np.dot(u_magic.T, u_magic)
-    eigvals, psi_magic = np.linalg.eig(ut_u)
+    eigvals, psi_magic = np.linalg.eig(np.round(ut_u, decimals=20))
     # orthogonalize eigenvectors in the case of degeneracy (Gram-Schmidt)
     psi_magic, _ = np.linalg.qr(psi_magic)
     # write psi in computational basis


### PR DESCRIPTION
There was this TODO in the 2q unitary gate decomposition where sometime the eigenvalues returned where imaginary where they should not be. In some cases (maybe not all) this was due to numpy doing strange things where machine precision was an issue.

I attempt to fix that with a np.round(ut_u, decimals=20). I feel like if at some point we are concerned with gates beyond 20 decimals of precision we will have to deal with other headaches as well. That being said, there might be a more elegant solution to this.

This is sufficient to decompose random 2 qubit Clifford gates, but it might also resolve other problematic matrices.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
