### PR TITLE
Two qubit gate decomposition without entangling gates

### DIFF
--- a/src/qibolab/transpilers/unitary_decompositions.py
+++ b/src/qibolab/transpilers/unitary_decompositions.py
@@ -213,7 +213,9 @@ def two_qubit_decomposition(q0, q1, unitary):
         ud_diag = to_bell_diagonal(ud)
 
     hx, hy, hz = calculate_h_vector(ud_diag)
-    if hz == 0:
+    if np.allclose([hx, hy, hz], [0, 0, 0]):
+        gatelist = [gates.Unitary(u4 @ u1, q0), gates.Unitary(v4 @ v1, q1)]
+    elif np.allclose(hz, 0):
         gatelist = cnot_decomposition_light(q0, q1, hx, hy)
         if ud is None:
             return gatelist


### PR DESCRIPTION
I have added a flag to decompose 2 qubit unitaries that  do not generate entanglement into only two single qubit gates. This can be useful as in some cases the decomposition was adding two qubit gates where it didn't need to.

I am using `np.allclose` to check if the numbers are `0`, without any change to `rtol` and `atol`. We could figure out what tolerance we allow. I have also added it to the check for `hz` as in some of the testing I have done, it did not consider `hz` of the order of `10**(-17)` to be 0.

Anyone has experience setting tolerances for this method? 

We can set up special tests for this extra case as well.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
