### PR TITLE
Logging with timings for instruments + Ideal

### DIFF
--- a/src/qibolab/instruments/erasynth.py
+++ b/src/qibolab/instruments/erasynth.py
@@ -56,7 +56,7 @@ class ERA(LocalOscillator):
     def connect(self):
         """Connects to the instrument using the IP address set in the runcard."""
         if not self.is_connected:
-            for attempt in range(3):
+            for attempt in range(5):
                 try:
                     if not self.ethernet:
                         self.device = ERASynthPlusPlus(f"{self.name}", f"TCPIP::{self.address}::INSTR")


### PR DESCRIPTION
For now I did it only for the Zurich separating different sections of the code and making use of the LabOneQ logging to get some information I could get from the driver. Maybe we can try to extract that info for other devices as well.

Timings:

- Pulse translation
- Creation of the experiment (calibration, assigning waves, sweeper loops, etc)
- Compiling
- Execution and whatever the device is doing I am not sure about (It could be wave baking, connection or data transfer, frequency stabilization as this was a frequency sweep) This step is the longer as it roughly takes 2s.

![imagen](https://github.com/qiboteam/qibolab/assets/19141117/5863c3cb-4e39-4265-b4fe-fcdf2dd0ba80)


Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
