### PR TITLE
Introduce a threshold for coverage failures

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,2 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 0.5%
+
 github_checks:
   annotations: false


### PR DESCRIPTION
It's a tiny maintenance update. Qibolab is hard to test, but waiting for anything better it's just silly the sensible PRs like https://github.com/qiboteam/qibolab/pull/511 are marked with a red cross because of a mild coverage decrease. Essentially, it makes red crosses useless (and green ticks extremely rare).

In principle, we could completely [disable the failure](https://docs.codecov.com/docs/commit-status#if_ci_failed) due to Codecov in Qibolab since we are not really looking at the coverage.

However, for the time being I've just chosen the slimmest approach, trying not to change that much the current status. If it will be again not enough, we could reconsider the options.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
