### PR TITLE
adding Ec, Ej, g and assigment fidelity to the qubit object

### DIFF
--- a/src/qibolab/qubits.py
+++ b/src/qibolab/qubits.py
@@ -37,7 +37,7 @@ class Qubit:
     Ec: int = 0
     Ej: int = 0
     g: int = 0
-    assigment_fidelity: float = 0.0    
+    assigment_fidelity: float = 0.0
     sweetspot: float = 0
     peak_voltage: float = 0
     pi_pulse_amplitude: float = 0

--- a/src/qibolab/qubits.py
+++ b/src/qibolab/qubits.py
@@ -34,6 +34,10 @@ class Qubit:
     readout_frequency: int = 0  # this is the dressed frequency
     drive_frequency: int = 0
     anharmonicity: int = 0
+    Ec: int = 0
+    Ej: int = 0
+    g: int = 0
+    assigment_fidelity: float = 0.0    
     sweetspot: float = 0
     peak_voltage: float = 0
     pi_pulse_amplitude: float = 0


### PR DESCRIPTION
This PR adds the Ec, Ej, g and assigment fidelity to the qubit object. These attributes are needed in qibocal for flux flux routines fitting (david/flux_routines_fitting).

Assigment fidelity needed for a webapp tool that I have implemented that shows the qpus/qubits status and latest characterization

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
