### PR TITLE
Fix RFSoC QPU tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,6 +50,13 @@ def dummy_qrc():
     set_platform_profile()
 
 
+def find_instrument(platform, instrument_type):
+    for instrument in platform.instruments:
+        if isinstance(instrument, instrument_type):
+            return instrument
+    return None
+
+
 def get_instrument(platform, instrument_type):
     """Finds if an instrument of a given type exists in the given platform.
 
@@ -57,10 +64,10 @@ def get_instrument(platform, instrument_type):
     that asked for this instrument is skipped.
     This ensures that QPU tests are executed only on the available instruments.
     """
-    for instrument in platform.instruments:
-        if isinstance(instrument, instrument_type):
-            return instrument
-    pytest.skip(f"Skipping {instrument_type.__name__} test for {platform.name}.")
+    instrument = find_instrument(platform, instrument_type)
+    if instrument is None:
+        pytest.skip(f"Skipping {instrument_type.__name__} test for {platform.name}.")
+    return instrument
 
 
 @pytest.fixture(scope="module", params=DUMMY_PLATFORM_NAMES)

--- a/tests/test_instruments_rfsoc.py
+++ b/tests/test_instruments_rfsoc.py
@@ -560,11 +560,13 @@ def test_call_executepulsesequence(connected_platform, instrument):
     sequence.add(platform.create_RX_pulse(qubit=0, start=0))
     sequence.add(platform.create_MZ_pulse(qubit=0, start=100))
 
+    instrument.cfg.average = False
     i_vals_nav, q_vals_nav = instrument._execute_pulse_sequence(
-        sequence, platform.qubits, False, rfsoc.OperationCode.EXECUTE_PULSE_SEQUENCE
+        sequence, platform.qubits, rfsoc.OperationCode.EXECUTE_PULSE_SEQUENCE
     )
+    instrument.cfg.average = True
     i_vals_av, q_vals_av = instrument._execute_pulse_sequence(
-        sequence, platform.qubits, True, rfsoc.OperationCode.EXECUTE_PULSE_SEQUENCE
+        sequence, platform.qubits, rfsoc.OperationCode.EXECUTE_PULSE_SEQUENCE
     )
 
     assert np.shape(i_vals_nav) == (1, 1, 1000)
@@ -589,8 +591,10 @@ def test_call_execute_sweeps(connected_platform, instrument):
     expts = len(sweep.values)
 
     sweep = [convert(sweep, sequence, platform.qubits)]
-    i_vals_nav, q_vals_nav = instrument._execute_sweeps(sequence, platform.qubits, sweep, False)
-    i_vals_av, q_vals_av = instrument._execute_sweeps(sequence, platform.qubits, sweep, True)
+    instrument.cfg.average = False
+    i_vals_nav, q_vals_nav = instrument._execute_sweeps(sequence, platform.qubits, sweep)
+    instrument.cfg.average = True
+    i_vals_av, q_vals_av = instrument._execute_sweeps(sequence, platform.qubits, sweep)
 
     assert np.shape(i_vals_nav) == (1, 1, expts, 1000)
     assert np.shape(q_vals_nav) == (1, 1, expts, 1000)

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -111,10 +111,10 @@ def test_platform_execute_one_long_drive_pulse(qpu_platform):
     sequence = PulseSequence()
     sequence.add(platform.create_qubit_drive_pulse(qubit, start=0, duration=8192 + 200))
     options = ExecutionParameters(nshots=nshots)
-    if find_instrument(platform, QbloxController):
+    if find_instrument(platform, QbloxController) is not None:
         with pytest.raises(NotImplementedError):
             platform.execute_pulse_sequence(sequence, options)
-    elif find_instrument(platform, RFSoC):
+    elif find_instrument(platform, RFSoC) is not None:
         with pytest.raises(RuntimeError):
             platform.execute_pulse_sequence(sequence, options)
     else:
@@ -129,10 +129,10 @@ def test_platform_execute_one_extralong_drive_pulse(qpu_platform):
     sequence = PulseSequence()
     sequence.add(platform.create_qubit_drive_pulse(qubit, start=0, duration=2 * 8192 + 200))
     options = ExecutionParameters(nshots=nshots)
-    if find_instrument(platform, QbloxController):
+    if find_instrument(platform, QbloxController) is not None:
         with pytest.raises(NotImplementedError):
             platform.execute_pulse_sequence(sequence, options)
-    elif find_instrument(platform, RFSoC):
+    elif find_instrument(platform, RFSoC) is not None:
         with pytest.raises(RuntimeError):
             platform.execute_pulse_sequence(sequence, options)
     else:

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -15,7 +15,7 @@ from qibolab.execution_parameters import ExecutionParameters
 from qibolab.instruments.qblox.controller import QbloxController
 from qibolab.instruments.rfsoc.driver import RFSoC
 from qibolab.platform import Platform
-from qibolab.pulses import PulseSequence
+from qibolab.pulses import PulseSequence, Rectangular
 
 from .conftest import find_instrument
 
@@ -108,13 +108,14 @@ def test_platform_execute_one_long_drive_pulse(qpu_platform):
     # Long duration
     platform = qpu_platform
     qubit = next(iter(platform.qubits))
+    pulse = platform.create_qubit_drive_pulse(qubit, start=0, duration=8192 + 200)
     sequence = PulseSequence()
-    sequence.add(platform.create_qubit_drive_pulse(qubit, start=0, duration=8192 + 200))
+    sequence.add(pulse)
     options = ExecutionParameters(nshots=nshots)
     if find_instrument(platform, QbloxController) is not None:
         with pytest.raises(NotImplementedError):
             platform.execute_pulse_sequence(sequence, options)
-    elif find_instrument(platform, RFSoC) is not None:
+    elif find_instrument(platform, RFSoC) is not None and not isinstance(pulse.shape, Rectangular):
         with pytest.raises(RuntimeError):
             platform.execute_pulse_sequence(sequence, options)
     else:
@@ -126,13 +127,14 @@ def test_platform_execute_one_extralong_drive_pulse(qpu_platform):
     # Extra Long duration
     platform = qpu_platform
     qubit = next(iter(platform.qubits))
+    pulse = platform.create_qubit_drive_pulse(qubit, start=0, duration=2 * 8192 + 200)
     sequence = PulseSequence()
-    sequence.add(platform.create_qubit_drive_pulse(qubit, start=0, duration=2 * 8192 + 200))
+    sequence.add(pulse)
     options = ExecutionParameters(nshots=nshots)
     if find_instrument(platform, QbloxController) is not None:
         with pytest.raises(NotImplementedError):
             platform.execute_pulse_sequence(sequence, options)
-    elif find_instrument(platform, RFSoC) is not None:
+    elif find_instrument(platform, RFSoC) is not None and not isinstance(pulse.shape, Rectangular):
         with pytest.raises(RuntimeError):
             platform.execute_pulse_sequence(sequence, options)
     else:

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -12,8 +12,12 @@ from qibo.states import CircuitResult
 from qibolab import create_platform
 from qibolab.backends import QibolabBackend
 from qibolab.execution_parameters import ExecutionParameters
+from qibolab.instruments.qblox.controller import QbloxController
+from qibolab.instruments.rfsoc.driver import RFSoC
 from qibolab.platform import Platform
 from qibolab.pulses import PulseSequence
+
+from .conftest import find_instrument
 
 nshots = 1024
 
@@ -100,25 +104,39 @@ def test_platform_execute_one_drive_pulse(qpu_platform):
 
 
 @pytest.mark.qpu
-@pytest.mark.xfail(raises=NotImplementedError, reason="Qblox does not support long waveforms.")
 def test_platform_execute_one_long_drive_pulse(qpu_platform):
     # Long duration
     platform = qpu_platform
     qubit = next(iter(platform.qubits))
     sequence = PulseSequence()
     sequence.add(platform.create_qubit_drive_pulse(qubit, start=0, duration=8192 + 200))
-    platform.execute_pulse_sequence(sequence, ExecutionParameters(nshots=nshots))
+    options = ExecutionParameters(nshots=nshots)
+    if find_instrument(platform, QbloxController):
+        with pytest.raises(NotImplementedError):
+            platform.execute_pulse_sequence(sequence, options)
+    elif find_instrument(platform, RFSoC):
+        with pytest.raises(RuntimeError):
+            platform.execute_pulse_sequence(sequence, options)
+    else:
+        platform.execute_pulse_sequence(sequence, options)
 
 
 @pytest.mark.qpu
-@pytest.mark.xfail(raises=NotImplementedError, reason="Qblox does not support long waveforms.")
 def test_platform_execute_one_extralong_drive_pulse(qpu_platform):
     # Extra Long duration
     platform = qpu_platform
     qubit = next(iter(platform.qubits))
     sequence = PulseSequence()
     sequence.add(platform.create_qubit_drive_pulse(qubit, start=0, duration=2 * 8192 + 200))
-    platform.execute_pulse_sequence(sequence, ExecutionParameters(nshots=nshots))
+    options = ExecutionParameters(nshots=nshots)
+    if find_instrument(platform, QbloxController):
+        with pytest.raises(NotImplementedError):
+            platform.execute_pulse_sequence(sequence, options)
+    elif find_instrument(platform, RFSoC):
+        with pytest.raises(RuntimeError):
+            platform.execute_pulse_sequence(sequence, options)
+    else:
+        platform.execute_pulse_sequence(sequence, options)
 
 
 @pytest.mark.qpu


### PR DESCRIPTION
QPU tests are passing with QM (qw25q), qblox (qw5q_gold) and now RFSoC (on tii1q_b1):
```sh
srun -p tii1q_b1 pytest -m qpu --no-cov --platform tii1q_b1
```
(requires the `QIBOLAB_PLATFORMS` environment variable properly set)

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
