### PR TITLE
Move `platform.dump` to `qibolab.serialize`

### DIFF
--- a/src/qibolab/platform.py
+++ b/src/qibolab/platform.py
@@ -2,12 +2,10 @@
 
 import math
 import re
-from dataclasses import asdict, dataclass, field, replace
-from pathlib import Path
+from dataclasses import dataclass, field, replace
 from typing import Dict, List, Optional
 
 import networkx as nx
-import yaml
 from qibo.config import log, raise_error
 
 from qibolab.execution_parameters import ExecutionParameters
@@ -83,24 +81,6 @@ class Platform:
         """Total number of usable qubits in the QPU.."""
         # TODO: Seperate couplers from qubits (PR #508)
         return len([qubit for qubit in self.qubits if not (isinstance(qubit, str) and "c" in qubit)])
-
-    def dump(self, path: Path):
-        """Serializes the platform and saves it as a yaml file.
-
-        This follows the format explained in :ref:`Using runcards <using_runcards>`.
-
-        Args:
-            path (pathlib.Path): Path that the yaml file will be saved.
-        """
-        from qibolab.serialize import dump_qubits
-
-        settings = {
-            "nqubits": self.nqubits,
-            "qubits": list(self.qubits),
-            "settings": asdict(self.settings),
-        }
-        settings.update(dump_qubits(self.qubits, self.pairs))
-        path.write_text(yaml.dump(settings, sort_keys=False, indent=4, default_flow_style=None))
 
     def update(self, updates: dict):
         r"""Updates platform common runcard parameters after calibration actions.

--- a/src/qibolab/serialize.py
+++ b/src/qibolab/serialize.py
@@ -10,7 +10,7 @@ from typing import Tuple
 import yaml
 
 from qibolab.native import SingleQubitNatives, TwoQubitNatives
-from qibolab.platform import QubitMap, QubitPairMap, Settings
+from qibolab.platform import Platform, QubitMap, QubitPairMap, Settings
 from qibolab.qubits import Qubit, QubitPair
 
 
@@ -67,3 +67,21 @@ def dump_qubits(qubits: QubitMap, pairs: QubitPairMap) -> dict:
         "native_gates": native_gates,
         "characterization": {"single_qubit": {q: qubit.characterization for q, qubit in qubits.items()}},
     }
+
+
+def dump_runcard(platform: Platform, path: Path):
+    """Serializes the platform and saves it as a yaml runcard file.
+
+    The file saved follows the format explained in :ref:`Using runcards <using_runcards>`.
+
+    Args:
+        platform (qibolab.platform.Platform): The platform to be serialized.
+        path (pathlib.Path): Path that the yaml file will be saved.
+    """
+    settings = {
+        "nqubits": platform.nqubits,
+        "qubits": list(platform.qubits),
+        "settings": asdict(platform.settings),
+    }
+    settings.update(dump_qubits(platform.qubits, platform.pairs))
+    path.write_text(yaml.dump(settings, sort_keys=False, indent=4, default_flow_style=None))

--- a/src/qibolab/serialize.py
+++ b/src/qibolab/serialize.py
@@ -4,6 +4,7 @@ The format of runcards in the ``qiboteam/qibolab_platforms_qrc``
 repository is assumed here. See :ref:`Using runcards <using_runcards>`
 example for more details.
 """
+from dataclasses import asdict
 from pathlib import Path
 from typing import Tuple
 
@@ -54,9 +55,13 @@ def dump_qubits(qubits: QubitMap, pairs: QubitPairMap) -> dict:
     """Dump qubit and pair objects to a dictionary following the runcard format."""
     native_gates = {
         "topology": [list(pair) for pair in pairs],
-        "single_qubit": {q: qubit.native_gates.raw for q, qubit in qubits.items()},
+        "single_qubit": {},
         "two_qubit": {},
     }
+    # add single-qubit native gates
+    for q, qubit in qubits.items():
+        if qubit.native_gates.MZ is not None and qubit.native_gates.RX is not None:
+            native_gates["single_qubit"][q] = qubit.native_gates.raw
     # add two-qubit native gates
     for p, pair in pairs.items():
         natives = pair.native_gates.raw

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -1,6 +1,8 @@
 """Tests :class:`qibolab.platforms.multiqubit.MultiqubitPlatform` and
 :class:`qibolab.platforms.platform.DesignPlatform`.
 """
+import os
+import pathlib
 import pickle
 import warnings
 
@@ -16,6 +18,7 @@ from qibolab.instruments.qblox.controller import QbloxController
 from qibolab.instruments.rfsoc.driver import RFSoC
 from qibolab.platform import Platform
 from qibolab.pulses import PulseSequence, Rectangular
+from qibolab.serialize import dump_runcard
 
 from .conftest import find_instrument
 
@@ -69,6 +72,12 @@ def test_update(platform, par):
             assert value == getattr(qubit, par)
         else:
             assert value == float(getattr(qubit, par))
+
+
+def test_dump_runcard(platform):
+    path = pathlib.Path(__file__).parent / "test.yml"
+    dump_runcard(platform, path)
+    os.remove(path)
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
As mentioned in #560, this is the last place that the `Platform` is assuming the runcard structure.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
