### PR TITLE
Add TWPA to dummy platform

### DIFF
--- a/src/qibolab/dummy.py
+++ b/src/qibolab/dummy.py
@@ -1,5 +1,6 @@
 from qibolab.channels import Channel, ChannelMap
 from qibolab.instruments.dummy import DummyInstrument
+from qibolab.instruments.oscillator import LocalOscillator
 from qibolab.platform import Platform
 from qibolab.serialize import load_qubits, load_settings
 
@@ -206,13 +207,20 @@ def create_dummy():
     # Create dummy controller
     instrument = DummyInstrument(NAME, 0)
 
+    # Create local oscillator
+    twpa_pump = LocalOscillator(name="twpa_pump", address=0)
+    twpa_pump.frequency = 1e9
+    twpa_pump.power = 10
+
     # Create channel objects
     nqubits = RUNCARD["nqubits"]
     channels = ChannelMap()
     channels |= Channel("readout", port=instrument["readout"])
     channels |= (Channel(f"drive-{i}", port=instrument[f"drive-{i}"]) for i in range(nqubits))
     channels |= (Channel(f"flux-{i}", port=instrument[f"flux-{i}"]) for i in range(nqubits))
+    channels |= Channel("twpa", port=None)
     channels["readout"].attenuation = 0
+    channels["twpa"].local_oscillator = twpa_pump
 
     qubits, pairs = load_qubits(RUNCARD)
     settings = load_settings(RUNCARD)
@@ -222,7 +230,8 @@ def create_dummy():
         qubit.readout = channels["readout"]
         qubit.drive = channels[f"drive-{q}"]
         qubit.flux = channels[f"flux-{q}"]
+        qubit.twpa = channels["twpa"]
 
-    instruments = {instrument.name: instrument}
+    instruments = {instrument.name: instrument, twpa_pump.name: twpa_pump}
     instrument.sampling_rate = settings.sampling_rate * 1e-9
     return Platform(NAME, qubits, pairs, instruments, settings, resonator_type="2D")


### PR DESCRIPTION
This PR adds a TWPA to the `dummy` platform.
This is necessary to test new incoming protocols in qibocal.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
