### PR TITLE
Driver are working but problem with jobs on node zeraa1

### DIFF
--- a/src/qibolab/instruments/qblox/cluster_qcm_bb.py
+++ b/src/qibolab/instruments/qblox/cluster_qcm_bb.py
@@ -206,48 +206,40 @@ class ClusterQCM_BB(Instrument):
                     self.device.sequencers[self.DEFAULT_SEQUENCERS["o3"]],
                     self.device.sequencers[self.DEFAULT_SEQUENCERS["o4"]],
                 ]:
-                    self._set_device_parameter(
-                        target, "channel_map_path0_out0_en", value=False
-                    )  # Default after reboot = True
-                    self._set_device_parameter(
-                        target, "channel_map_path1_out1_en", value=False
-                    )  # Default after reboot = True
-                    self._set_device_parameter(
-                        target, "channel_map_path0_out2_en", value=False
-                    )  # Default after reboot = True
-                    self._set_device_parameter(
-                        target, "channel_map_path1_out3_en", value=False
-                    )  # Default after reboot = True
+                    self._set_device_parameter(target, "connect_out0", value="off")  # Default after reboot = True
+                    self._set_device_parameter(target, "connect_out1", value="off")  # Default after reboot = True
+                    self._set_device_parameter(target, "connect_out2", value="off")  # Default after reboot = True
+                    self._set_device_parameter(target, "connect_out3", value="off")  # Default after reboot = True
 
                 self._set_device_parameter(
                     self.device.sequencers[self.DEFAULT_SEQUENCERS["o1"]],
-                    "channel_map_path0_out0_en",
-                    value=True,
+                    "connect_out0",
+                    value="I",
                 )
                 self._set_device_parameter(
                     self.device.sequencers[self.DEFAULT_SEQUENCERS["o2"]],
-                    "channel_map_path1_out1_en",
-                    value=True,
+                    "connect_out1",
+                    value="Q",  # TODO: check if order of I and Q is right
                 )
                 self._set_device_parameter(
                     self.device.sequencers[self.DEFAULT_SEQUENCERS["o3"]],
-                    "channel_map_path0_out2_en",
-                    value=True,
+                    "connect_out2",
+                    value="I",
                 )
                 self._set_device_parameter(
                     self.device.sequencers[self.DEFAULT_SEQUENCERS["o4"]],
-                    "channel_map_path1_out3_en",
-                    value=True,
+                    "connect_out3",
+                    value="Q",
                 )
 
                 # on initialisation, disconnect all other sequencers from the ports
                 self._device_num_sequencers = len(self.device.sequencers)
                 for sequencer in range(4, self._device_num_sequencers):
                     target = self.device.sequencers[sequencer]
-                    self._set_device_parameter(target, "channel_map_path0_out0_en", value=False)
-                    self._set_device_parameter(target, "channel_map_path1_out1_en", value=False)
-                    self._set_device_parameter(target, "channel_map_path0_out2_en", value=False)
-                    self._set_device_parameter(target, "channel_map_path1_out3_en", value=False)
+                    self._set_device_parameter(target, "connect_out0", value="off")
+                    self._set_device_parameter(target, "connect_out1", value="off")
+                    self._set_device_parameter(target, "connect_out2", value="off")
+                    self._set_device_parameter(target, "connect_out3", value="off")
 
     def _set_device_parameter(self, target, *parameters, value):
         """Sets a parameter of the instrument, if it changed from the last stored in the cache.
@@ -746,10 +738,10 @@ class ClusterQCM_BB(Instrument):
             self._set_device_parameter(target, "marker_ovr_en", value=True)  # Default after reboot = False
             self._set_device_parameter(target, "marker_ovr_value", value=0)  # Default after reboot = 0
             if sequencer_number >= 4:  # Never disconnect default sequencers
-                self._set_device_parameter(target, "channel_map_path0_out0_en", value=False)
-                self._set_device_parameter(target, "channel_map_path0_out2_en", value=False)
-                self._set_device_parameter(target, "channel_map_path1_out1_en", value=False)
-                self._set_device_parameter(target, "channel_map_path1_out3_en", value=False)
+                self._set_device_parameter(target, "connect_out0", value="off")
+                self._set_device_parameter(target, "connect_out1", value="off")
+                self._set_device_parameter(target, "connect_out2", value="off")
+                self._set_device_parameter(target, "connect_out3", value="off")
 
         # There seems to be a bug in qblox that when any of the mappings between paths and outputs is set,
         # the general offset goes to 0 (eventhough the parameter will still show the right value).

--- a/src/qibolab/instruments/qblox/cluster_qcm_rf.py
+++ b/src/qibolab/instruments/qblox/cluster_qcm_rf.py
@@ -222,27 +222,23 @@ class ClusterQCM_RF(Instrument):
 
                 self._set_device_parameter(
                     self.device.sequencers[self.DEFAULT_SEQUENCERS["o1"]],
-                    "channel_map_path0_out0_en",
-                    "channel_map_path1_out1_en",
-                    value=True,
+                    "connect_out0",
+                    value="IQ",
                 )
                 self._set_device_parameter(
                     self.device.sequencers[self.DEFAULT_SEQUENCERS["o1"]],
-                    "channel_map_path0_out2_en",
-                    "channel_map_path1_out3_en",
-                    value=False,
+                    "connect_out1",
+                    value="off",
                 )
                 self._set_device_parameter(
                     self.device.sequencers[self.DEFAULT_SEQUENCERS["o2"]],
-                    "channel_map_path0_out0_en",
-                    "channel_map_path1_out1_en",
-                    value=False,
+                    "connect_out1",
+                    value="IQ",
                 )
                 self._set_device_parameter(
                     self.device.sequencers[self.DEFAULT_SEQUENCERS["o2"]],
-                    "channel_map_path0_out2_en",
-                    "channel_map_path1_out3_en",
-                    value=True,
+                    "connect_out0",
+                    value="off",
                 )
 
                 # on initialisation, disconnect all other sequencers from the ports
@@ -250,15 +246,13 @@ class ClusterQCM_RF(Instrument):
                 for sequencer in range(2, self._device_num_sequencers):
                     self._set_device_parameter(
                         self.device.sequencers[sequencer],
-                        "channel_map_path0_out0_en",
-                        "channel_map_path1_out1_en",
-                        value=False,
+                        "connect_out0",
+                        value="off",
                     )  # Default after reboot = True
                     self._set_device_parameter(
                         self.device.sequencers[sequencer],
-                        "channel_map_path0_out2_en",
-                        "channel_map_path1_out3_en",
-                        value=False,
+                        "connect_out1",
+                        value="off",
                     )  # Default after reboot = True
 
     def _set_device_parameter(self, target, *parameters, value):
@@ -762,10 +756,8 @@ class ClusterQCM_RF(Instrument):
             self._set_device_parameter(target, "marker_ovr_en", value=True)  # Default after reboot = False
             self._set_device_parameter(target, "marker_ovr_value", value=0)  # Default after reboot = 0
             if sequencer_number >= 2:  # Never disconnect default sequencers
-                self._set_device_parameter(target, "channel_map_path0_out0_en", value=False)
-                self._set_device_parameter(target, "channel_map_path0_out2_en", value=False)
-                self._set_device_parameter(target, "channel_map_path1_out1_en", value=False)
-                self._set_device_parameter(target, "channel_map_path1_out3_en", value=False)
+                self._set_device_parameter(target, "connect_out0", value="off")
+                self._set_device_parameter(target, "connect_out1", value="off")
 
         # Upload waveforms and program
         qblox_dict = {}

--- a/src/qibolab/instruments/qblox/cluster_qrm_rf.py
+++ b/src/qibolab/instruments/qblox/cluster_qrm_rf.py
@@ -209,7 +209,7 @@ class ClusterQRM_RF(Instrument):
                 # connection the instruction self._set_device_parameter(self.device, "in0_att", value=0)
                 # fails, providing a misleading error message
 
-                # save reference to cluster
+                # save reference to cluster         CICLO WHILE PER ATTENDERE CONNESSIONE?
                 self._cluster = cluster
                 self.is_connected = True
 
@@ -236,7 +236,8 @@ class ClusterQRM_RF(Instrument):
                 # with the same parameters as the default in process_pulse_sequence()
                 target = self.device.sequencers[self.DEFAULT_SEQUENCERS["o1"]]
 
-                self._set_device_parameter(target, "channel_map_path0_out0_en", "channel_map_path1_out1_en", value=True)
+                self._set_device_parameter(target, "connect_out0", value="IQ")
+                self._set_device_parameter(target, "connect_acq", value="in0")
                 self._set_device_parameter(target, "cont_mode_en_awg_path0", "cont_mode_en_awg_path1", value=False)
                 self._set_device_parameter(
                     target, "cont_mode_waveform_idx_awg_path0", "cont_mode_waveform_idx_awg_path1", value=0
@@ -255,9 +256,8 @@ class ClusterQRM_RF(Instrument):
                 for sequencer in range(1, self._device_num_sequencers):
                     self._set_device_parameter(
                         self.device.sequencers[sequencer],
-                        "channel_map_path0_out0_en",
-                        "channel_map_path1_out1_en",
-                        value=False,
+                        "connect_out0",
+                        value="off",
                     )  # Default after reboot = True
 
     def _set_device_parameter(self, target, *parameters, value):
@@ -868,8 +868,8 @@ class ClusterQRM_RF(Instrument):
             self._set_device_parameter(target, "marker_ovr_en", value=False)  # Default after reboot = False
             self._set_device_parameter(target, "marker_ovr_value", value=0)  # Default after reboot = 0
             if sequencer_number >= 1:  # Never disconnect default sequencers
-                self._set_device_parameter(target, "channel_map_path0_out0_en", value=False)
-                self._set_device_parameter(target, "channel_map_path1_out1_en", value=False)
+                self._set_device_parameter(target, "connect_out0", value="off")
+                self._set_device_parameter(target, "connect_acq", value="in0")
 
         # Upload waveforms and program
         qblox_dict = {}


### PR DESCRIPTION
It seems to be a problem on job handling for the node zeraa1.
It is not due to my minor code modification since I have tried to downgrade the cluster firmware and launch a resonator spectroscopy with main branch of qibolab.
The problem is that when I submit a job with sbatch the routine (e.g. resonator spectroscopy) ends normally and produce the right reports html, but the job on zeraa1 seems to go indefinitely even after the fit is completed and I have to terminate it with scancel. 
I tried to execute the same qq command directly from zeraa1 (without submitting the job through sbtach) and in that case all is fine. 
So i suspect there is a problem on how slurm handle jobs on zeraa1 node, but I don't know why.