### PR TITLE
Add CZ and virtual Z phase to `platform.update`

### DIFF
--- a/src/qibolab/platform.py
+++ b/src/qibolab/platform.py
@@ -10,7 +10,7 @@ from qibo.config import log, raise_error
 
 from qibolab.execution_parameters import ExecutionParameters
 from qibolab.instruments.abstract import Controller, Instrument, InstrumentId
-from qibolab.native import NativeType
+from qibolab.native import NativeType, VirtualZPulse
 from qibolab.pulses import PulseSequence
 from qibolab.qubits import Qubit, QubitId, QubitPair, QubitPairId
 from qibolab.sweeper import Sweeper
@@ -212,6 +212,21 @@ class Platform:
 
                 elif par == "classifiers_hpars":
                     self.qubits[qubit].classifiers_hpars = value
+
+                elif par == "virtual_z_phase":
+                    virtual_z_pulses = {
+                        pulse.qubit.name: pulse
+                        for pulse in self.pairs[qubit].native_gates.CZ.pulses
+                        if isinstance(pulse, VirtualZPulse)
+                    }
+
+                    for qubit_id, phase in value.items():
+                        if qubit_id in virtual_z_pulses:
+                            virtual_z_pulses[qubit_id].phase = phase
+                        else:
+                            virtual_z_pulses[qubit_id] = VirtualZPulse(phase=phase, qubit=self.qubits[qubit_id])
+                            self.pairs[qubit].native_gates.CZ.pulses.append(virtual_z_pulses[qubit_id])
+
                 else:
                     raise_error(ValueError, f"Unknown parameter {par} for qubit {qubit}")
 

--- a/src/qibolab/platform.py
+++ b/src/qibolab/platform.py
@@ -107,6 +107,8 @@ class Platform:
                             - mean_gnd_states(V)
                             - mean_exc_states(V)
                             - beta(dimensionless)
+                            - CZ_flux_amplitude (dimensionless)
+                            - CZ_flux_duration (ns)
 
         """
         for par, values in updates.items():
@@ -156,9 +158,19 @@ class Platform:
                     if par == "drive_amplitude" or par == "amplitudes":
                         self.qubits[qubit].native_gates.RX.amplitude = amplitude
 
+                    if par == "CZ_flux_amplitude":
+                        for pulse in self.pairs[qubit].native_gates.CZ.pulses:
+                            if pulse.qubit.name == qubit[1]:
+                                pulse.amplitude = float(value)
+
                 # rabi_duration
                 elif par == "drive_length":
                     self.qubits[qubit].native_gates.RX.duration = int(value)
+
+                elif par == "CZ_flux_duration":
+                    for pulse in self.pairs[qubit].native_gates.CZ.pulses:
+                        if pulse.qubit.name == qubit[1]:
+                            pulse.duration = int(value)
 
                 # ramsey
                 elif par == "t2":
@@ -200,7 +212,6 @@ class Platform:
 
                 elif par == "classifiers_hpars":
                     self.qubits[qubit].classifiers_hpars = value
-
                 else:
                     raise_error(ValueError, f"Unknown parameter {par} for qubit {qubit}")
 

--- a/tests/dummy_qrc/qblox.yml
+++ b/tests/dummy_qrc/qblox.yml
@@ -166,7 +166,7 @@ native_gates:
               type: qf
             - type: virtual_z
               phase: -3.630
-              qubit: 3
+              qubit: 1
 
             - duration: 32
               amplitude: 0

--- a/tests/dummy_qrc/zurich.yml
+++ b/tests/dummy_qrc/zurich.yml
@@ -127,7 +127,7 @@ native_gates:
               type: qf
             - type: virtual_z
               phase: -3.630
-              qubit: 3
+              qubit: 1
 
             - duration: 32
               amplitude: 0

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -22,7 +22,7 @@ from qibolab.serialize import dump_runcard, load_runcard
 
 from .conftest import find_instrument
 
-nshots = 1024
+NSHOTS = 1024
 
 
 def test_create_platform(platform):
@@ -123,7 +123,7 @@ def test_platform_execute_empty(qpu_platform):
     # an empty pulse sequence
     platform = qpu_platform
     sequence = PulseSequence()
-    platform.execute_pulse_sequence(sequence, ExecutionParameters(nshots=nshots))
+    platform.execute_pulse_sequence(sequence, ExecutionParameters(nshots=NSHOTS))
 
 
 @pytest.mark.qpu
@@ -133,7 +133,7 @@ def test_platform_execute_one_drive_pulse(qpu_platform):
     qubit = next(iter(platform.qubits))
     sequence = PulseSequence()
     sequence.add(platform.create_qubit_drive_pulse(qubit, start=0, duration=200))
-    platform.execute_pulse_sequence(sequence, ExecutionParameters(nshots=nshots))
+    platform.execute_pulse_sequence(sequence, ExecutionParameters(nshots=NSHOTS))
 
 
 @pytest.mark.qpu
@@ -144,7 +144,7 @@ def test_platform_execute_one_long_drive_pulse(qpu_platform):
     pulse = platform.create_qubit_drive_pulse(qubit, start=0, duration=8192 + 200)
     sequence = PulseSequence()
     sequence.add(pulse)
-    options = ExecutionParameters(nshots=nshots)
+    options = ExecutionParameters(nshots=NSHOTS)
     if find_instrument(platform, QbloxController) is not None:
         with pytest.raises(NotImplementedError):
             platform.execute_pulse_sequence(sequence, options)
@@ -163,7 +163,7 @@ def test_platform_execute_one_extralong_drive_pulse(qpu_platform):
     pulse = platform.create_qubit_drive_pulse(qubit, start=0, duration=2 * 8192 + 200)
     sequence = PulseSequence()
     sequence.add(pulse)
-    options = ExecutionParameters(nshots=nshots)
+    options = ExecutionParameters(nshots=NSHOTS)
     if find_instrument(platform, QbloxController) is not None:
         with pytest.raises(NotImplementedError):
             platform.execute_pulse_sequence(sequence, options)
@@ -182,7 +182,7 @@ def test_platform_execute_one_drive_one_readout(qpu_platform):
     sequence = PulseSequence()
     sequence.add(platform.create_qubit_drive_pulse(qubit, start=0, duration=200))
     sequence.add(platform.create_qubit_readout_pulse(qubit, start=200))
-    platform.execute_pulse_sequence(sequence, ExecutionParameters(nshots=nshots))
+    platform.execute_pulse_sequence(sequence, ExecutionParameters(nshots=NSHOTS))
 
 
 @pytest.mark.qpu
@@ -195,7 +195,7 @@ def test_platform_execute_multiple_drive_pulses_one_readout(qpu_platform):
     sequence.add(platform.create_qubit_drive_pulse(qubit, start=204, duration=200))
     sequence.add(platform.create_qubit_drive_pulse(qubit, start=408, duration=400))
     sequence.add(platform.create_qubit_readout_pulse(qubit, start=808))
-    platform.execute_pulse_sequence(sequence, ExecutionParameters(nshots=nshots))
+    platform.execute_pulse_sequence(sequence, ExecutionParameters(nshots=NSHOTS))
 
 
 @pytest.mark.qpu
@@ -210,7 +210,7 @@ def test_platform_execute_multiple_drive_pulses_one_readout_no_spacing(
     sequence.add(platform.create_qubit_drive_pulse(qubit, start=200, duration=200))
     sequence.add(platform.create_qubit_drive_pulse(qubit, start=400, duration=400))
     sequence.add(platform.create_qubit_readout_pulse(qubit, start=800))
-    platform.execute_pulse_sequence(sequence, ExecutionParameters(nshots=nshots))
+    platform.execute_pulse_sequence(sequence, ExecutionParameters(nshots=NSHOTS))
 
 
 @pytest.mark.qpu
@@ -225,7 +225,7 @@ def test_platform_execute_multiple_overlaping_drive_pulses_one_readout(
     sequence.add(platform.create_qubit_drive_pulse(qubit, start=200, duration=200))
     sequence.add(platform.create_qubit_drive_pulse(qubit, start=50, duration=400))
     sequence.add(platform.create_qubit_readout_pulse(qubit, start=800))
-    platform.execute_pulse_sequence(sequence, ExecutionParameters(nshots=nshots))
+    platform.execute_pulse_sequence(sequence, ExecutionParameters(nshots=NSHOTS))
 
 
 @pytest.mark.qpu
@@ -242,7 +242,7 @@ def test_platform_execute_multiple_readout_pulses(qpu_platform):
     sequence.add(ro_pulse1)
     sequence.add(qd_pulse2)
     sequence.add(ro_pulse2)
-    platform.execute_pulse_sequence(sequence, ExecutionParameters(nshots=nshots))
+    platform.execute_pulse_sequence(sequence, ExecutionParameters(nshots=NSHOTS))
 
 
 @pytest.mark.qpu

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -91,6 +91,19 @@ def test_update(platform, par):
             assert value == float(getattr(qubit, par))
 
 
+@pytest.mark.parametrize("parameter, value", [("CZ_flux_amplitude", 0.5), ("CZ_flux_duration", 10)])
+def test_update_pairs(platform, parameter, value):
+    pairs = {q: pair for q, pair in platform.pairs.items() if pair.native_gates.CZ is not None}
+    updates = {parameter: {q: value for q in pairs}}
+    platform.update(updates)
+
+    for name, pair in pairs.items():
+        value = updates[parameter][name]
+        for pulse in pair.native_gates.CZ.pulses:
+            if pulse.qubit.name == name[1]:
+                assert value == value
+
+
 @pytest.fixture(scope="module")
 def qpu_platform(connected_platform):
     connected_platform.connect()


### PR DESCRIPTION
This PR allows to update the CZ and the virtual Z parameters in the platform object in order to dump it to a runcard.
I also fixed a few things in the runcards coded here for tests

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
