### PR TITLE
Instruments section in runcard

### DIFF
--- a/doc/source/tutorials/lab.rst
+++ b/doc/source/tutorials/lab.rst
@@ -356,3 +356,153 @@ the above runcard:
 
 Note that this assumes that the runcard is saved as ``my_platform.yml`` in the
 same directory with the Python file that contains ``create()``.
+
+
+Instrument settings
+^^^^^^^^^^^^^^^^^^^
+
+The runcard of the previous example contains only parameters associated to the qubits
+and their respective native gates. In some cases parameters associated to instruments
+need to also be calibrated. An example is the frequency and the power of local oscillators,
+such as the one used to pump a traveling wave parametric amplifier (TWPA).
+
+The runcard can contain an ``instruments`` section that provides these parameters
+
+.. code-block::  yaml
+
+    nqubits: 2
+
+    qubits: [0, 1]
+
+    settings:
+        nshots: 1024
+        sampling_rate: 1000000000
+        relaxation_time: 50_000
+
+    topology: [[0, 1]]
+
+    instruments:
+        twpa_pump:
+            frequency: 4_600_000_000
+            power: 5
+
+    native_gates:
+        single_qubit:
+            0: # qubit number
+                RX:
+                    duration: 40
+                    amplitude: 0.0484
+                    frequency: 4_855_663_000
+                    shape: Drag(5, -0.02)
+                    type: qd # qubit drive
+                    start: 0
+                    phase: 0
+                MZ:
+                    duration: 620
+                    amplitude: 0.003575
+                    frequency: 7_453_265_000
+                    shape: Rectangular()
+                    type: ro # readout
+                    start: 0
+                    phase: 0
+            1: # qubit number
+                RX:
+                    duration: 40
+                    amplitude: 0.05682
+                    frequency: 5_800_563_000
+                    shape: Drag(5, -0.04)
+                    type: qd # qubit drive
+                    start: 0
+                    phase: 0
+                MZ:
+                    duration: 960
+                    amplitude: 0.00325
+                    frequency: 7_655_107_000
+                    shape: Rectangular()
+                    type: ro # readout
+                    start: 0
+                    phase: 0
+
+        two_qubit:
+            0-1:
+                CZ:
+                - duration: 30
+                  amplitude: 0.055
+                  shape: Rectangular()
+                  qubit: 1
+                  relative_start: 0
+                  type: qf
+                - type: virtual_z
+                  phase: -1.5707963267948966
+                  qubit: 0
+                - type: virtual_z
+                  phase: -1.5707963267948966
+                  qubit: 1
+
+    characterization:
+        single_qubit:
+            0:
+                readout_frequency: 7_453_265_000
+                drive_frequency: 4_855_663_000
+                T1: 0.0
+                T2: 0.0
+                sweetspot: -0.047
+                # parameters for single shot classification
+                threshold: 0.00028502261712637096
+                iq_angle: 1.283105298787488
+            1:
+                readout_frequency: 7_655_107_000
+                drive_frequency: 5_800_563_000
+                T1: 0.0
+                T2: 0.0
+                sweetspot: -0.045
+                # parameters for single shot classification
+                threshold: 0.0002694329123116206
+                iq_angle: 4.912447775569025
+
+
+These settings are loaded when creating the platform using :meth:`qibolab.serialize.load_instrument_settings`.
+Note that the key used in the runcard should be the same with the name used when instantiating the instrument,
+in this case ``"twpa_pump"``.
+
+.. code-block::  python
+
+    from pathlib import Path
+    from qibolab import Platform
+    from qibolab.channels import ChannelMap, Channel
+    from qibolab.serialize import load_runcard, load_qubits, load_settings, load_instrument_settings
+    from qibolab.instruments.dummy import DummyInstrument
+    from qibolab.instruments.oscillator import LocalOscillator
+
+
+    def create():
+        # Create a controller instrument
+        instrument = DummyInstrument("my_instrument", "0.0.0.0:0")
+        twpa = LocalOscillator("twpa_pump", "0.0.0.1")
+
+        # Create channel objects and assign to them the controller ports
+        channels = ChannelMap()
+        channels |= Channel("ch1out", port=instrument["o1"])
+        channels |= Channel("ch2", port=instrument["o2"])
+        channels |= Channel("ch3", port=instrument["o3"])
+        channels |= Channel("ch1in", port=instrument["i1"])
+
+        # create ``Qubit`` and ``QubitPair`` objects by loading the runcard
+        runcard = load_runcard(Path(__file__).parent / "my_platform.yml")
+        qubits, pairs = load_qubits(runcard)
+
+        # assign channels to the qubit
+        for q in range(2):
+            qubits[q].readout = channels["ch1out"]
+            qubits[q].feedback = channels["ch1in"]
+            qubits[q].drive = channels[f"ch{q + 2}"]
+
+        # create dictionary of instruments
+        instruments = {instrument.name: instrument, twpa.name: twpa}
+        # load instrument settings from the runcard
+        instruments = load_instrument_settings(runcard, instruments)
+        # load ``settings`` from the runcard
+        settings = load_settings(runcard)
+        return Platform(
+            "my_platform", qubits, pairs, instruments, settings, resonator_type="2D"
+        )

--- a/src/qibolab/instruments/abstract.py
+++ b/src/qibolab/instruments/abstract.py
@@ -1,11 +1,16 @@
 import tempfile
 from abc import ABC, abstractmethod
 from pathlib import Path
+from typing import Optional
 
 from qibolab.instruments.port import Port
 
 InstrumentId = str
 INSTRUMENTS_DATA_FOLDER = Path.home() / ".qibolab" / "instruments" / "data"
+
+
+class InstrumentSettings:
+    """Container of settings that are dumped in the platform runcard yaml."""
 
 
 class Instrument(ABC):
@@ -21,6 +26,7 @@ class Instrument(ABC):
         self.address: str = address
         self.is_connected: bool = False
         self.signature: str = f"{type(self).__name__}@{address}"
+        self.settings: Optional[InstrumentSettings] = None
         # create local storage folder
         instruments_data_folder = INSTRUMENTS_DATA_FOLDER
         instruments_data_folder.mkdir(parents=True, exist_ok=True)

--- a/src/qibolab/instruments/erasynth.py
+++ b/src/qibolab/instruments/erasynth.py
@@ -29,10 +29,6 @@ class ERA(LocalOscillator):
 
     @property
     def frequency(self):
-        if self.is_connected:
-            if self.ethernet:
-                return int(self._get("frequency"))
-            return self.device.get("frequency")
         return self.settings.frequency
 
     @frequency.setter
@@ -43,10 +39,6 @@ class ERA(LocalOscillator):
 
     @property
     def power(self):
-        if self.is_connected:
-            if self.ethernet:
-                return float(self._get("amplitude"))
-            return self.device.get("power")
         return self.settings.power
 
     @power.setter

--- a/src/qibolab/instruments/oscillator.py
+++ b/src/qibolab/instruments/oscillator.py
@@ -1,4 +1,13 @@
-from qibolab.instruments.abstract import Instrument
+from dataclasses import dataclass
+from typing import Optional
+
+from qibolab.instruments.abstract import Instrument, InstrumentSettings
+
+
+@dataclass
+class LocalOscillatorSettings(InstrumentSettings):
+    power: Optional[float] = None
+    frequency: Optional[float] = None
 
 
 class LocalOscillator(Instrument):
@@ -12,24 +21,23 @@ class LocalOscillator(Instrument):
 
     def __init__(self, name, address):
         super().__init__(name, address)
-        self._power: float
-        self._frequency: float
+        self.settings = LocalOscillatorSettings()
 
     @property
     def frequency(self):
-        return self._frequency
+        return self.settings.frequency
 
     @frequency.setter
     def frequency(self, x):
-        self._frequency = x
+        self.settings.frequency = x
 
     @property
     def power(self):
-        return self._power
+        return self.settings.power
 
     @power.setter
     def power(self, x):
-        self._power = x
+        self.settings.power = x
 
     def connect(self):
         self.is_connected = True

--- a/src/qibolab/instruments/qm/simulator.py
+++ b/src/qibolab/instruments/qm/simulator.py
@@ -28,6 +28,7 @@ class QMSim(QMOPX):
     def __post_init__(self):
         """Convert simulation duration from ns to clock cycles."""
         self.simulation_duration //= 4
+        self.settings = None
 
     def connect(self):
         host, port = self.address.split(":")

--- a/src/qibolab/instruments/rfsoc/convert.py
+++ b/src/qibolab/instruments/rfsoc/convert.py
@@ -36,7 +36,7 @@ def pulse_lo_frequency(pulse: Pulse, qubits: dict[int, Qubit]) -> int:
     """Return local_oscillator frequency (HZ) of a pulse."""
     pulse_type = pulse.type.name.lower()
     try:
-        lo_frequency = getattr(qubits[pulse.qubit], pulse_type).local_oscillator._frequency
+        lo_frequency = getattr(qubits[pulse.qubit], pulse_type).local_oscillator.frequency
     except AttributeError:
         lo_frequency = 0
     return lo_frequency

--- a/src/qibolab/instruments/rohde_schwarz.py
+++ b/src/qibolab/instruments/rohde_schwarz.py
@@ -23,8 +23,6 @@ class SGS100A(LocalOscillator):
 
     @property
     def frequency(self):
-        if self.is_connected:
-            return self.device.get("frequency")
         return self.settings.frequency
 
     @frequency.setter
@@ -35,8 +33,6 @@ class SGS100A(LocalOscillator):
 
     @property
     def power(self):
-        if self.is_connected:
-            return self.device.get("power")
         return self.settings.power
 
     @power.setter
@@ -47,8 +43,6 @@ class SGS100A(LocalOscillator):
 
     @property
     def ref_osc_source(self):
-        if self.is_connected:
-            return self.device.ref_osc_source
         return self._ref_osc_source
 
     @ref_osc_source.setter

--- a/src/qibolab/instruments/zhinst.py
+++ b/src/qibolab/instruments/zhinst.py
@@ -317,6 +317,7 @@ class Zurich(Controller):
         "Storing sweepers"
         # Improve the storing of multiple sweeps
         self._ports = {}
+        self.settings = None
 
     def connect(self):
         self.create_device_setup()

--- a/tests/dummy_qrc/qblox.py
+++ b/tests/dummy_qrc/qblox.py
@@ -26,7 +26,12 @@ from qibolab.instruments.qblox.port import (
 )
 from qibolab.instruments.rohde_schwarz import SGS100A
 from qibolab.platform import Platform
-from qibolab.serialize import load_qubits, load_runcard, load_settings
+from qibolab.serialize import (
+    load_instrument_settings,
+    load_qubits,
+    load_runcard,
+    load_settings,
+)
 
 NAME = "qblox"
 ADDRESS = "192.168.0.6"
@@ -231,4 +236,5 @@ def create(runcard_path=RUNCARD):
 
     instruments = {controller.name: controller, twpa_pump.name: twpa_pump}
     settings = load_settings(runcard)
+    instruments = load_instrument_settings(runcard, instruments)
     return Platform("qblox", qubits, pairs, instruments, settings, resonator_type="2D")

--- a/tests/dummy_qrc/qblox.yml
+++ b/tests/dummy_qrc/qblox.yml
@@ -9,6 +9,11 @@ qubits: [0, 1, 2, 3, 4]
 
 topology: [[0, 2], [1, 2], [2, 3], [2, 4]]
 
+instruments:
+    twpa_pump:
+      frequency: 6_535_900_000
+      power: 4
+
 native_gates:
     single_qubit:
         0: # qubit id

--- a/tests/dummy_qrc/qm.py
+++ b/tests/dummy_qrc/qm.py
@@ -4,7 +4,12 @@ from qibolab.channels import Channel, ChannelMap
 from qibolab.instruments.oscillator import LocalOscillator
 from qibolab.instruments.qm import QMSim
 from qibolab.platform import Platform
-from qibolab.serialize import load_qubits, load_runcard, load_settings
+from qibolab.serialize import (
+    load_instrument_settings,
+    load_qubits,
+    load_runcard,
+    load_settings,
+)
 
 RUNCARD = pathlib.Path(__file__).parent / "qm.yml"
 
@@ -43,19 +48,6 @@ def create(runcard_path=RUNCARD):
         LocalOscillator("lo_drive_high", "192.168.0.34"),
         LocalOscillator("twpa_a", "192.168.0.35"),
     ]
-    # Set LO parameters
-    local_oscillators[0].frequency = 7_300_000_000
-    local_oscillators[1].frequency = 7_900_000_000
-    local_oscillators[2].frequency = 4_700_000_000
-    local_oscillators[3].frequency = 5_600_000_000
-    local_oscillators[4].frequency = 6_500_000_000
-    local_oscillators[0].power = 18.0
-    local_oscillators[1].power = 15.0
-    for i in range(2, 5):
-        local_oscillators[i].power = 16.0
-    # Set TWPA parameters
-    local_oscillators[5].frequency = 6_511_000_000
-    local_oscillators[5].power = 4.5
     # Map LOs to channels
     channels["L3-25_a"].local_oscillator = local_oscillators[0]
     channels["L3-25_b"].local_oscillator = local_oscillators[1]
@@ -95,4 +87,5 @@ def create(runcard_path=RUNCARD):
     instruments = {controller.name: controller}
     instruments.update({lo.name: lo for lo in local_oscillators})
     settings = load_settings(runcard)
+    instruments = load_instrument_settings(runcard, instruments)
     return Platform("qm", qubits, pairs, instruments, settings, resonator_type="2D")

--- a/tests/dummy_qrc/qm.yml
+++ b/tests/dummy_qrc/qm.yml
@@ -9,6 +9,27 @@ settings:
 
 topology: [[0, 2], [1, 2], [2, 3], [2, 4]]
 
+instruments:
+    lo_readout_a:
+        frequency: 7_300_000_000
+        power: 18
+    lo_readout_b:
+        frequency: 7_900_000_000
+        power: 15
+    lo_drive_low:
+        frequency: 4_700_000_000
+        power: 16
+    lo_drive_mid:
+        frequency: 5_600_000_000
+        power: 16
+    lo_drive_high:
+        frequency: 6_500_000_000
+        power: 16
+    twpa_a:
+        frequency: 6_511_000_000
+        power: 4.5
+
+
 native_gates:
     single_qubit:
         0: # qubit number

--- a/tests/dummy_qrc/rfsoc.py
+++ b/tests/dummy_qrc/rfsoc.py
@@ -5,7 +5,12 @@ from qibolab.instruments.erasynth import ERA
 from qibolab.instruments.rfsoc import RFSoC
 from qibolab.instruments.rohde_schwarz import SGS100A
 from qibolab.platform import Platform
-from qibolab.serialize import load_qubits, load_runcard, load_settings
+from qibolab.serialize import (
+    load_instrument_settings,
+    load_qubits,
+    load_runcard,
+    load_settings,
+)
 
 RUNCARD = pathlib.Path(__file__).parent / "rfsoc.yml"
 
@@ -27,9 +32,6 @@ def create(runcard_path=RUNCARD):
 
     lo_twpa = SGS100A("twpa_a", "192.168.0.32")
     lo_era = ERA("ErasynthLO", "192.168.0.212", ethernet=True)
-    lo_twpa.frequency = 6_200_000_000
-    lo_twpa.power = -1
-    lo_era.frequency = 0
     channels["L3-18_ro"].local_oscillator = lo_era
 
     runcard = load_runcard(runcard_path)
@@ -43,4 +45,5 @@ def create(runcard_path=RUNCARD):
 
     instruments = {inst.name: inst for inst in [controller, lo_twpa, lo_era]}
     settings = load_settings(runcard)
+    instruments = load_instrument_settings(runcard, instruments)
     return Platform("rfsoc", qubits, pairs, instruments, settings, resonator_type="3D")

--- a/tests/dummy_qrc/rfsoc.yml
+++ b/tests/dummy_qrc/rfsoc.yml
@@ -5,6 +5,13 @@ settings:
     nshots: 1024
     relaxation_time: 100000
     sampling_rate: 9830400000
+instruments:
+    twpa_a:
+        frequency: 6_200_000_000
+        power: -1
+    ErasynthLO:
+        frequency: 0
+        power: 0
 native_gates:
     single_qubit:
         0:

--- a/tests/dummy_qrc/zurich.py
+++ b/tests/dummy_qrc/zurich.py
@@ -7,7 +7,12 @@ from qibolab.channels import Channel, ChannelMap
 from qibolab.instruments.oscillator import LocalOscillator
 from qibolab.instruments.zhinst import Zurich
 from qibolab.platform import Platform
-from qibolab.serialize import load_qubits, load_runcard, load_settings
+from qibolab.serialize import (
+    load_instrument_settings,
+    load_qubits,
+    load_runcard,
+    load_settings,
+)
 
 RUNCARD = pathlib.Path(__file__).parent / "zurich.yml"
 
@@ -117,13 +122,7 @@ def create(runcard_path=RUNCARD):
         channels[f"L4-{i}"].power_range = 0.8
 
     # Instantiate local oscillators
-    local_oscillators = [LocalOscillator(f"lo_{kind}", None) for kind in ["readout"] + [f"drive_{n}" for n in range(4)]]
-
-    # Set Dummy LO parameters (Map only the two by two oscillators)
-    local_oscillators[0].frequency = 5_500_000_000  # For SG0 (Readout)
-    local_oscillators[1].frequency = 4_200_000_000  # For SG1 and SG2 (Drive)
-    local_oscillators[2].frequency = 4_600_000_000  # For SG3 and SG4 (Drive)
-    local_oscillators[3].frequency = 4_800_000_000  # For SG5 and SG6 (Drive)
+    local_oscillators = [LocalOscillator(f"lo_{kind}", None) for kind in ["readout"] + [f"drive_{n}" for n in range(3)]]
 
     # Map LOs to channels
     ch_to_lo = {"L2-7": 0, "L4-15": 1, "L4-16": 1, "L4-17": 2, "L4-18": 2, "L4-19": 3}
@@ -160,4 +159,5 @@ def create(runcard_path=RUNCARD):
     instruments = {controller.name: controller}
     instruments.update({lo.name: lo for lo in local_oscillators})
     settings = load_settings(runcard)
+    instruments = load_instrument_settings(runcard, instruments)
     return Platform("zurich", qubits, pairs, instruments, settings, resonator_type="2D")

--- a/tests/dummy_qrc/zurich.yml
+++ b/tests/dummy_qrc/zurich.yml
@@ -9,6 +9,20 @@ qubits: [0, 1, 2, 3, 4, "c0", "c1", "c3", "c4"]
 
 topology: [[0, 2], [1, 2], [2, 3], [2, 4]]
 
+instruments:
+    lo_readout:
+        frequency: 5_500_000_000
+        power: null
+    lo_drive_0:
+        frequency: 4_200_000_000
+        power: null
+    lo_drive_1:
+        frequency: 4_600_000_000
+        power: null
+    lo_drive_2:
+        frequency: 4_800_000_000
+        power: null
+
 native_gates:
     single_qubit:
         0: # qubit number

--- a/tests/test_instruments_rfsoc.py
+++ b/tests/test_instruments_rfsoc.py
@@ -129,7 +129,7 @@ def test_convert_units_sweeper(dummy_qrc):
     qubit.drive.ports = [("name", 4)]
     qubit.readout.ports = [("name", 2)]
     qubit.feedback.ports = [("name", 1)]
-    qubit.readout.local_oscillator._frequency = 1e6
+    qubit.readout.local_oscillator.frequency = 1e6
 
     seq = PulseSequence()
     pulse0 = Pulse(0, 40, 0.9, 50e6, 0, Gaussian(2), 0, PulseType.DRIVE, 0)

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -55,6 +55,10 @@ def test_dump_runcard(platform):
     for qubit, values in target_char.items():
         for name, value in values.items():
             assert final_char[qubit][name] == value
+    # assert instrument section is dumped properly in the runcard
+    target_instruments = target_runcard.pop("instruments")
+    final_instruments = final_runcard.pop("instruments")
+    assert final_instruments == target_instruments
     os.remove(path)
 
 


### PR DESCRIPTION
Fix #576. Needed for qibocal routines that update instrument (not qubit) parameters, such as the TWPA calibration. It is also useful to dump some instrument settings (LO frequency, etc.) in the runcard so that we can keep them in record. qibolab_platforms_qrc also needs to be updated for this to work.

@rodolfocarobene can you please confirm that my change in
https://github.com/qiboteam/qibolab/blob/f896cc2dd13890dc40e758281ce05bb182f88fc5/src/qibolab/instruments/rfsoc/convert.py#L39

is okay?

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [x] Documentation is updated.
