### PR TITLE
Set platform-variable in windows

### DIFF
--- a/doc/source/getting-started/experiment.rst
+++ b/doc/source/getting-started/experiment.rst
@@ -107,11 +107,18 @@ Setting up the environment
 --------------------------
 
 After defining the platform, we must instruct ``qibolab`` of the location of the create file.
-This can be done using an environment variable:
+This can be done using an environment variable.
+for Unix based systems:
 
 .. code-block:: bash
 
     export QIBOLAB_PLATFORMS=<path-to-create-file>
+
+for Windows:
+
+.. code-block:: bash
+
+    $env:QIBOLAB_PLATFORMS="<path-to-create-file>"
 
 To avoid having to repeat this export command for every session, this line can be added to the ``.bashrc`` file (or alternatives as ``.zshrc``).
 

--- a/doc/source/getting-started/experiment.rst
+++ b/doc/source/getting-started/experiment.rst
@@ -107,7 +107,7 @@ Setting up the environment
 --------------------------
 
 After defining the platform, we must instruct ``qibolab`` of the location of the create file.
-This can be done using an environment variable.
+This can be done using an environment variable:
 for Unix based systems:
 
 .. code-block:: bash


### PR DESCRIPTION
Hello!
I was trying to prepare a windows environment to use Qibolab and I noticed that the `export` command behaves a bit differently there.

I changed the tutorial accordingly. 

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
