### PR TITLE
Add fidelity to qubit and fix typo

### DIFF
--- a/src/qibolab/dummy.yml
+++ b/src/qibolab/dummy.yml
@@ -91,7 +91,7 @@ characterization:
             Ec: 0.0
             Ej: 0.0
             g: 0.0
-            assigment_fidelity: 0.0
+            assignment_fidelity: 0.0
             peak_voltage: 0
             pi_pulse_amplitude: 0
             T1: 0.0
@@ -121,7 +121,7 @@ characterization:
             Ec: 0.0
             Ej: 0.0
             g: 0.0
-            assigment_fidelity: 0.0
+            assignment_fidelity: 0.0
             peak_voltage: 0
             pi_pulse_amplitude: 0
             T1: 0.0
@@ -151,7 +151,7 @@ characterization:
             Ec: 0.0
             Ej: 0.0
             g: 0.0
-            assigment_fidelity: 0.0
+            assignment_fidelity: 0.0
             peak_voltage: 0
             pi_pulse_amplitude: 0
             T1: 0.0
@@ -181,7 +181,7 @@ characterization:
             Ec: 0.0
             Ej: 0.0
             g: 0.0
-            assigment_fidelity: 0.0
+            assignment_fidelity: 0.0
             peak_voltage: 0
             pi_pulse_amplitude: 0
             T1: 0.0
@@ -211,7 +211,7 @@ characterization:
             Ec: 0.0
             Ej: 0.0
             g: 0.0
-            assigment_fidelity: 0.0
+            assignment_fidelity: 0.0
             peak_voltage: 0
             pi_pulse_amplitude: 0
             T1: 0.0

--- a/src/qibolab/qubits.py
+++ b/src/qibolab/qubits.py
@@ -57,7 +57,8 @@ class Qubit:
     g: float = 0.0
     """Readout coupling"""
 
-    assigment_fidelity: float = 0.0
+    assignment_fidelity: float = 0.0
+    fidelity: float = 0.0
     peak_voltage: float = 0
     pi_pulse_amplitude: float = 0
     T1: int = 0

--- a/src/qibolab/qubits.py
+++ b/src/qibolab/qubits.py
@@ -56,9 +56,10 @@ class Qubit:
     """Readout Josephson Energy"""
     g: float = 0.0
     """Readout coupling"""
-
     assignment_fidelity: float = 0.0
-    fidelity: float = 0.0
+    """Assignment fidelity."""
+    readout_fidelity: float = 0.0
+    """Readout fidelity."""
     peak_voltage: float = 0
     pi_pulse_amplitude: float = 0
     T1: int = 0


### PR DESCRIPTION
This PR adds a `fidelity` argument to qubit and it also fixes the a typo `assigment_fidelity` -> `assignment_fidelity`.
I spotted this errors while working on qiboteam/qibocal#548.
I will open also a PR in qibolab_platform_qrc.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
