### PR TITLE
Execute circuits with unrolling

### DIFF
--- a/src/qibolab/platform.py
+++ b/src/qibolab/platform.py
@@ -1,6 +1,6 @@
 """A platform for executing quantum algorithms."""
 
-from collections import defaultdict
+from collections import defaultdict, deque
 from dataclasses import dataclass, field, replace
 from typing import Dict, List, Optional
 
@@ -229,7 +229,7 @@ class Platform:
             # find readout pulses
             ro_pulses = {pulse.serial: pulse.qubit for sequence in sequences for pulse in sequence.ro_pulses}
 
-            results = defaultdict(list)
+            results = defaultdict(deque)
             for batch in chunked(sequences, batch_size):
                 sequence, readouts = unroll_sequences(batch, options.relaxation_time)
                 result = self._execute("play", sequence, options, **kwargs)

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -8,14 +8,6 @@ from qibo.models import Circuit
 from qibolab.backends import QibolabBackend
 
 
-@pytest.fixture(scope="module")
-def backend(connected_platform):
-    connected_platform.setup()
-    connected_platform.start()
-    yield QibolabBackend(connected_platform)
-    connected_platform.stop()
-
-
 def generate_circuit_with_gate(nqubits, gate, **kwargs):
     circuit = Circuit(nqubits)
     circuit.add(gate(qubit, **kwargs) for qubit in range(nqubits))
@@ -23,8 +15,16 @@ def generate_circuit_with_gate(nqubits, gate, **kwargs):
     return circuit
 
 
-@pytest.mark.qpu
-def test_execute_circuit_initial_state(backend):
+@pytest.fixture(scope="module")
+def connected_backend(connected_platform):
+    connected_platform.setup()
+    connected_platform.start()
+    yield QibolabBackend(connected_platform)
+    connected_platform.stop()
+
+
+def test_execute_circuit_initial_state():
+    backend = QibolabBackend("dummy")
     circuit = Circuit(1)
     circuit.add(gates.X(0))
     circuit.add(gates.M(0))
@@ -36,7 +36,6 @@ def test_execute_circuit_initial_state(backend):
     backend.execute_circuit(circuit, initial_state=initial_circuit)
 
 
-@pytest.mark.qpu
 @pytest.mark.parametrize(
     "gate,kwargs",
     [
@@ -50,29 +49,50 @@ def test_execute_circuit_initial_state(backend):
         (gates.U3, {"theta": 0.1, "phi": 0.2, "lam": 0.3}),
     ],
 )
-def test_execute_circuit(backend, gate, kwargs):
+def test_execute_circuit(gate, kwargs):
+    backend = QibolabBackend("dummy")
     nqubits = backend.platform.nqubits
     circuit = generate_circuit_with_gate(nqubits, gate, **kwargs)
     result = backend.execute_circuit(circuit, nshots=100)
 
 
-@pytest.mark.qpu
-def test_measurement_samples(backend):
+def test_measurement_samples():
+    backend = QibolabBackend("dummy")
     nqubits = backend.platform.nqubits
+
     circuit = Circuit(nqubits)
     circuit.add(gates.M(*range(nqubits)))
     result = backend.execute_circuit(circuit, nshots=100)
     assert result.samples().shape == (100, nqubits)
     assert sum(result.frequencies().values()) == 100
 
+    circuit = Circuit(nqubits)
+    circuit.add(gates.M(0, 2))
+    result = backend.execute_circuit(circuit, nshots=100)
+    assert result.samples().shape == (100, 2)
+    assert sum(result.frequencies().values()) == 100
+
+
+def test_execute_circuits():
+    backend = QibolabBackend("dummy")
+    circuit = Circuit(3)
+    circuit.add(gates.H(i) for i in range(3))
+    circuit.add(gates.M(0, 1, 2))
+
+    results = backend.execute_circuits(5 * [circuit], nshots=100)
+    assert len(results) == 5
+    for result in results:
+        assert result.samples().shape == (100, 3)
+        assert sum(result.frequencies().values()) == 100
+
 
 @pytest.mark.qpu
 @pytest.mark.xfail(raises=AssertionError, reason="Probabilities are not well calibrated")
-def test_ground_state_probabilities_circuit(backend):
-    nqubits = backend.platform.nqubits
+def test_ground_state_probabilities_circuit(connected_backend):
+    nqubits = connected_backend.platform.nqubits
     circuit = Circuit(nqubits)
     circuit.add(gates.M(*range(nqubits)))
-    result = backend.execute_circuit(circuit, nshots=5000)
+    result = connected_backend.execute_circuit(circuit, nshots=5000)
     probs = result.probabilities()
     warnings.warn(f"Ground state probabilities: {probs}")
     target_probs = np.zeros(2**nqubits)
@@ -82,12 +102,12 @@ def test_ground_state_probabilities_circuit(backend):
 
 @pytest.mark.qpu
 @pytest.mark.xfail(raises=AssertionError, reason="Probabilities are not well calibrated")
-def test_excited_state_probabilities_circuit(backend):
-    nqubits = backend.platform.nqubits
+def test_excited_state_probabilities_circuit(connected_backend):
+    nqubits = connected_backend.platform.nqubits
     circuit = Circuit(nqubits)
     circuit.add(gates.X(q) for q in range(nqubits))
     circuit.add(gates.M(*range(nqubits)))
-    result = backend.execute_circuit(circuit, nshots=5000)
+    result = connected_backend.execute_circuit(circuit, nshots=5000)
     probs = result.probabilities()
     warnings.warn(f"Excited state probabilities: {probs}")
     target_probs = np.zeros(2**nqubits)
@@ -97,15 +117,15 @@ def test_excited_state_probabilities_circuit(backend):
 
 @pytest.mark.qpu
 @pytest.mark.xfail(raises=AssertionError, reason="Probabilities are not well calibrated")
-def test_superposition_for_all_qubits(backend):
+def test_superposition_for_all_qubits(connected_backend):
     """Applies an H gate to each qubit of the circuit and measures the probabilities."""
-    nqubits = backend.platform.nqubits
+    nqubits = connected_backend.platform.nqubits
     probs = []
     for q in range(nqubits):
         circuit = Circuit(nqubits)
         circuit.add(gates.H(q=q))
         circuit.add(gates.M(q))
-        probs.append(backend.execute_circuit(circuit, nshots=5000).probabilities())
+        probs.append(connected_backend.execute_circuit(circuit, nshots=5000).probabilities())
         warnings.warn(f"Probabilities after an Hadamard gate applied to qubit {q}: {probs[-1]}")
     probs = np.asarray(probs)
     target_probs = np.repeat(a=0.5, repeats=nqubits)

--- a/tests/test_instruments_qmsim.py
+++ b/tests/test_instruments_qmsim.py
@@ -443,7 +443,7 @@ def test_qmsim_bell_circuit(simulator, folder, qubits):
     circuit.add(gates.H(qubits[0]))
     circuit.add(gates.CNOT(*qubits))
     circuit.add(gates.M(*qubits))
-    result = backend.execute_circuit(circuit, nshots=1, check_transpiled=True)
+    result = backend.execute_circuit(circuit, nshots=1)
     result = result.execution_result
     samples = result.get_simulated_samples()
     qubitstr = "".join(str(q) for q in qubits)
@@ -457,7 +457,7 @@ def test_qmsim_ghz_circuit(simulator, folder):
     circuit.add(gates.CNOT(2, 1))
     circuit.add(gates.CNOT(2, 3))
     circuit.add(gates.M(1, 2, 3))
-    result = backend.execute_circuit(circuit, nshots=1, check_transpiled=True)
+    result = backend.execute_circuit(circuit, nshots=1)
     result = result.execution_result
     samples = result.get_simulated_samples()
     assert_regression(samples, folder, "ghz_circuit_123")


### PR DESCRIPTION
Extending qiboteam/qibo#1046 to hardware using the sequence unrolling implemented in #618. Hopefully this can be used to speed up randomized benchmarking.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
