### PR TITLE
remove classifiers hpars

### DIFF
--- a/src/qibolab/dummy.yml
+++ b/src/qibolab/dummy.yml
@@ -109,7 +109,6 @@ characterization:
             mixer_drive_phi: 0.0
             mixer_readout_g: 0.0
             mixer_readout_phi: 0.0
-            classifiers_hpars: {}
         1:
             bare_resonator_frequency: 0
             readout_frequency: 4900000000.0
@@ -139,7 +138,6 @@ characterization:
             mixer_drive_phi: 0.0
             mixer_readout_g: 0.0
             mixer_readout_phi: 0.0
-            classifiers_hpars: {}
         2:
             bare_resonator_frequency: 0
             readout_frequency: 6100000000.0
@@ -169,7 +167,6 @@ characterization:
             mixer_drive_phi: 0.0
             mixer_readout_g: 0.0
             mixer_readout_phi: 0.0
-            classifiers_hpars: {}
         3:
             bare_resonator_frequency: 0
             readout_frequency: 5800000000.0
@@ -199,7 +196,6 @@ characterization:
             mixer_drive_phi: 0.0
             mixer_readout_g: 0.0
             mixer_readout_phi: 0.0
-            classifiers_hpars: {}
         4:
             bare_resonator_frequency: 0
             readout_frequency: 5500000000.0
@@ -229,7 +225,6 @@ characterization:
             mixer_drive_phi: 0.0
             mixer_readout_g: 0.0
             mixer_readout_phi: 0.0
-            classifiers_hpars: {}
     coupler:
         0: {sweetspot: 0.0}
         1: {sweetspot: 0.0}

--- a/src/qibolab/qubits.py
+++ b/src/qibolab/qubits.py
@@ -85,8 +85,6 @@ class Qubit:
     drive: Optional[Channel] = None
     flux: Optional[Channel] = None
 
-    classifiers_hpars: dict = field(default_factory=dict)
-    qutrit_classifiers_hpars: dict = field(default_factory=dict)
     native_gates: SingleQubitNatives = field(default_factory=SingleQubitNatives)
 
     @property

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -62,20 +62,6 @@ def test_dump_runcard(platform):
     os.remove(path)
 
 
-# TODO: this test should be improved
-@pytest.mark.parametrize(
-    "par",
-    [
-        "readout_frequency",
-        "sweetspot",
-        "threshold",
-        "bare_resonator_frequency",
-        "drive_frequency",
-        "iq_angle",
-        "mean_gnd_states",
-        "mean_exc_states",
-    ],
-)
 @pytest.fixture(scope="module")
 def qpu_platform(connected_platform):
     connected_platform.connect()

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -74,7 +74,6 @@ def test_dump_runcard(platform):
         "iq_angle",
         "mean_gnd_states",
         "mean_exc_states",
-        "classifiers_hpars",
     ],
 )
 @pytest.fixture(scope="module")


### PR DESCRIPTION
After discussing with @andrea-pasquale, we decided to remove them, since this classifiers feature is not used and worsen platform runcard readibility. https://github.com/qiboteam/qibocal/pull/543#discussion_r1369776945

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
