### PR TITLE
Fix Rabi probability qblox

### DIFF
--- a/src/qibolab/instruments/qblox/controller.py
+++ b/src/qibolab/instruments/qblox/controller.py
@@ -216,6 +216,7 @@ class QbloxController(Controller):
         for ro_pulse in sequence.ro_pulses:
             if options.acquisition_type is AcquisitionType.DISCRIMINATION:
                 _res = acquisition_results[ro_pulse.serial][2]
+                _res = _res.reshape(nshots, -1) if options.averaging_mode == AveragingMode.SINGLESHOT else _res
                 if average:
                     _res = np.mean(_res, axis=0)
             else:


### PR DESCRIPTION
This PR fix the problem the error reported by @andrea-pasquale in issue https://github.com/qiboteam/qibolab/issues/637 about Rabi lenght and Rabi amplitude (probability).
The report can be found here: http://login.qrccluster.com:9000/0w6uZuWgRomTy5wS3QYeMA==
I'm not sure if it will fix also the problems observed by @stavros11 about the cryoscope routine.
Closes #637 
Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
