### PR TITLE
Add tests for result shapes

### DIFF
--- a/src/qibolab/instruments/dummy.py
+++ b/src/qibolab/instruments/dummy.py
@@ -82,7 +82,7 @@ class DummyInstrument(Controller):
         results = {}
 
         for ro_pulse in sequence.ro_pulses:
-            values = self.get_values(options, ro_pulse, shape)
+            values = np.squeeze(self.get_values(options, ro_pulse, shape))
             results[ro_pulse.qubit] = results[ro_pulse.serial] = options.results_type(values)
 
         return results

--- a/src/qibolab/instruments/qblox/controller.py
+++ b/src/qibolab/instruments/qblox/controller.py
@@ -198,7 +198,7 @@ class QbloxController(Controller):
                         acquisition_results[key] = value
 
         # TODO: move to QRM_RF.acquire()
-        shape = tuple(len(sweeper.values) for sweeper in sweepers)
+        shape = tuple(len(sweeper.values) for sweeper in reversed(sweepers))
         shots_shape = (nshots,) + shape
         for ro_pulse in sequence.ro_pulses:
             if options.acquisition_type is AcquisitionType.DISCRIMINATION:

--- a/src/qibolab/instruments/qblox/controller.py
+++ b/src/qibolab/instruments/qblox/controller.py
@@ -134,14 +134,12 @@ class QbloxController(Controller):
         if not self.is_connected:
             raise_error(RuntimeError, "Execution failed because modules are not connected.")
 
-        if options.averaging_mode == AveragingMode.SINGLESHOT:
+        if options.averaging_mode is AveragingMode.SINGLESHOT:
             nshots = options.nshots
             navgs = 1
-            average = False
         else:
             navgs = options.nshots
             nshots = 1
-            average = True
 
         relaxation_time = options.relaxation_time
         repetition_duration = sequence.finish + relaxation_time
@@ -200,18 +198,24 @@ class QbloxController(Controller):
                         acquisition_results[key] = value
 
         # TODO: move to QRM_RF.acquire()
+        shape = tuple(len(sweeper.values) for sweeper in sweepers)
+        shots_shape = (nshots,) + shape
         for ro_pulse in sequence.ro_pulses:
             if options.acquisition_type is AcquisitionType.DISCRIMINATION:
                 _res = acquisition_results[ro_pulse.serial][2]
-                _res = _res.reshape(nshots, -1) if options.averaging_mode == AveragingMode.SINGLESHOT else _res
-                if average:
+                _res = np.reshape(_res, shots_shape)
+                if options.averaging_mode is not AveragingMode.SINGLESHOT:
                     _res = np.mean(_res, axis=0)
             else:
                 ires = acquisition_results[ro_pulse.serial][0]
                 qres = acquisition_results[ro_pulse.serial][1]
                 _res = ires + 1j * qres
+                if options.averaging_mode is AveragingMode.SINGLESHOT:
+                    _res = np.reshape(_res, shots_shape)
+                else:
+                    _res = np.reshape(_res, shape)
 
-            acquisition = options.results_type(_res)
+            acquisition = options.results_type(np.squeeze(_res))
             data[ro_pulse.serial] = data[ro_pulse.qubit] = acquisition
 
             # data[ro_pulse.serial] = ExecutionResults.from_components(*acquisition_results[ro_pulse.serial])

--- a/src/qibolab/instruments/zhinst.py
+++ b/src/qibolab/instruments/zhinst.py
@@ -1062,15 +1062,15 @@ class Zurich(Controller):
         for qubit in qubits.values():
             q = qubit.name  # pylint: disable=C0103
             if len(self.sequence[f"readout{q}"]) != 0:
-                for i in range(len(self.sequence[f"readout{q}"])):
+                for i, ropulse in enumerate(self.sequence[f"readout{q}"]):
                     exp_res = self.results.get_data(f"sequence{q}_{i}")
                     # Reorder dimensions
                     data = np.moveaxis(exp_res, rearranging_axes[0], rearranging_axes[1])
                     if options.acquisition_type is AcquisitionType.DISCRIMINATION:
                         data = np.ones(data.shape) - data.real  # Probability inversion patch
 
-                    serial = self.sequence[f"readout{q}"][i].pulse.serial
-                    qubit = self.sequence[f"readout{q}"][i].pulse.qubit
+                    serial = ropulse.pulse.serial
+                    qubit = ropulse.pulse.qubit
                     results[serial] = results[qubit] = options.results_type(data)
 
         self.offsets_off()

--- a/src/qibolab/instruments/zhinst.py
+++ b/src/qibolab/instruments/zhinst.py
@@ -523,9 +523,6 @@ class Zurich(Controller):
     def play(self, qubits, couplers, sequence, options):
         """Play pulse sequence"""
         self.signal_map = {}
-        dimensions = []
-        if options.averaging_mode is AveragingMode.SINGLESHOT:
-            dimensions = [options.nshots]
 
         self.frequency_from_pulses(qubits, sequence)
 
@@ -539,22 +536,12 @@ class Zurich(Controller):
             q = qubit.name  # pylint: disable=C0103
             if len(self.sequence[f"readout{q}"]) != 0:
                 for i, ropulse in enumerate(self.sequence[f"readout{q}"]):
-                    exp_res = self.results.get_data(f"sequence{q}_{i}")
+                    exp_res = np.array(self.results.get_data(f"sequence{q}_{i}"))
                     if options.acquisition_type is AcquisitionType.DISCRIMINATION:
-                        data = (
-                            np.array([exp_res]) if options.averaging_mode is AveragingMode.CYCLIC else np.array(exp_res)
-                        )
                         data = np.ones(data.shape) - data.real  # Probability inversion patch
-                        results[ropulse.pulse.serial] = options.results_type(data)
-                        results[ropulse.pulse.qubit] = options.results_type(data)
-                    else:
-                        results[ropulse.pulse.serial] = options.results_type(data=np.array(exp_res))
-                        results[ropulse.pulse.qubit] = options.results_type(data=np.array(exp_res))
-
-        exp_dimensions = list(np.array(exp_res).shape)
-        if dimensions != exp_dimensions:
-            log.warning("dimensions %d , exp_dimensions %d", dimensions, exp_dimensions)
-            log.warning("dimensions not properly ordered")
+                    serial = ropulse.pulse.serial
+                    qubit = ropulse.pulse.qubit
+                    results[serial] = results[qubit] = options.results_type(data)
 
         # html containing the pulse sequence schedule
         # lo.show_pulse_sheet("pulses", self.exp)
@@ -1062,14 +1049,6 @@ class Zurich(Controller):
         self.signal_map = {}
         self.nt_sweeps = None
         sweepers = list(sweepers)
-
-        dimensions = []
-        if options.averaging_mode is AveragingMode.SINGLESHOT:
-            dimensions = [options.nshots]
-
-        for sweeper in sweepers:
-            dimensions.append(len(sweeper.values))
-
         rearranging_axes, sweepers = self.rearrange_sweepers(sweepers)
         self.sweepers = sweepers
 
@@ -1086,30 +1065,15 @@ class Zurich(Controller):
                 for i in range(len(self.sequence[f"readout{q}"])):
                     exp_res = self.results.get_data(f"sequence{q}_{i}")
                     # Reorder dimensions
-                    exp_res = np.moveaxis(exp_res, rearranging_axes[0], rearranging_axes[1])
+                    data = np.moveaxis(exp_res, rearranging_axes[0], rearranging_axes[1])
                     if options.acquisition_type is AcquisitionType.DISCRIMINATION:
-                        data = (
-                            np.array([exp_res]) if options.averaging_mode is AveragingMode.CYCLIC else np.array(exp_res)
-                        )
-                        data = data.real
-                        data = np.ones(data.shape) - data  # Probability inversion patch
-                        results[self.sequence[f"readout{q}"][i].pulse.serial] = options.results_type(data)
-                        results[self.sequence[f"readout{q}"][i].pulse.qubit] = options.results_type(data)
-                    else:
-                        results[self.sequence[f"readout{q}"][i].pulse.serial] = options.results_type(
-                            data=np.array(exp_res)
-                        )
-                        results[self.sequence[f"readout{q}"][i].pulse.qubit] = options.results_type(
-                            data=np.array(exp_res)
-                        )
+                        data = np.ones(data.shape) - data.real  # Probability inversion patch
 
-        exp_dimensions = list(np.array(exp_res).shape)
-        if dimensions != exp_dimensions:
-            log.warning("dimensions {}, exp_dimensions {}".format(dimensions, exp_dimensions))
-            log.warning("dimensions not properly ordered")
+                    serial = self.sequence[f"readout{q}"][i].pulse.serial
+                    qubit = self.sequence[f"readout{q}"][i].pulse.qubit
+                    results[serial] = results[qubit] = options.results_type(data)
 
         self.offsets_off()
-
         # html containing the pulse sequence schedule
         # lo.show_pulse_sheet("pulses", self.exp)
         return results

--- a/src/qibolab/instruments/zhinst.py
+++ b/src/qibolab/instruments/zhinst.py
@@ -536,7 +536,7 @@ class Zurich(Controller):
             q = qubit.name  # pylint: disable=C0103
             if len(self.sequence[f"readout{q}"]) != 0:
                 for i, ropulse in enumerate(self.sequence[f"readout{q}"]):
-                    exp_res = np.array(self.results.get_data(f"sequence{q}_{i}"))
+                    data = np.array(self.results.get_data(f"sequence{q}_{i}"))
                     if options.acquisition_type is AcquisitionType.DISCRIMINATION:
                         data = np.ones(data.shape) - data.real  # Probability inversion patch
                     serial = ropulse.pulse.serial

--- a/tests/test_result_shapes.py
+++ b/tests/test_result_shapes.py
@@ -1,0 +1,79 @@
+import numpy as np
+import pytest
+
+from qibolab import AcquisitionType, AveragingMode, ExecutionParameters
+from qibolab.pulses import PulseSequence
+from qibolab.result import (
+    AveragedIntegratedResults,
+    AveragedSampleResults,
+    IntegratedResults,
+    SampleResults,
+)
+from qibolab.sweeper import Parameter, Sweeper
+
+NSHOTS = 50
+NSWEEP = 5
+
+
+def execute(platform, acquisition_type, averaging_mode, sweep=False):
+    qubit = next(iter(platform.qubits))
+
+    qd_pulse = platform.create_RX_pulse(qubit, start=0)
+    ro_pulse = platform.create_MZ_pulse(qubit, start=qd_pulse.finish)
+    sequence = PulseSequence()
+    sequence.add(qd_pulse)
+    sequence.add(ro_pulse)
+
+    options = ExecutionParameters(nshots=NSHOTS, acquisition_type=acquisition_type, averaging_mode=averaging_mode)
+    if sweep:
+        values = np.linspace(0.1, 0.5, NSWEEP)
+        sweeper1 = Sweeper(Parameter.amplitude, values, pulses=[qd_pulse])
+        sweeper2 = Sweeper(Parameter.amplitude, values, pulses=[ro_pulse])
+        results = platform.sweep(sequence, options, sweeper1, sweeper2)
+    else:
+        results = platform.execute_pulse_sequence(sequence, options)
+    return results[qubit]
+
+
+@pytest.mark.qpu
+@pytest.mark.parametrize("sweep", [False, True])
+def test_discrimination_singleshot(connected_platform, sweep):
+    result = execute(connected_platform, AcquisitionType.DISCRIMINATION, AveragingMode.SINGLESHOT, sweep)
+    assert isinstance(result, SampleResults)
+    if sweep:
+        assert result.samples.shape == (NSHOTS, NSWEEP, NSWEEP)
+    else:
+        assert result.samples.shape == (NSHOTS,)
+
+
+@pytest.mark.qpu
+@pytest.mark.parametrize("sweep", [False, True])
+def test_discrimination_cyclic(connected_platform, sweep):
+    result = execute(connected_platform, AcquisitionType.DISCRIMINATION, AveragingMode.CYCLIC, sweep)
+    assert isinstance(result, AveragedSampleResults)
+    if sweep:
+        assert result.statistical_frequency.shape == (NSWEEP, NSWEEP)
+    else:
+        assert result.statistical_frequency.shape == tuple()
+
+
+@pytest.mark.qpu
+@pytest.mark.parametrize("sweep", [False, True])
+def test_integration_singleshot(connected_platform, sweep):
+    result = execute(connected_platform, AcquisitionType.INTEGRATION, AveragingMode.SINGLESHOT, sweep)
+    assert isinstance(result, IntegratedResults)
+    if sweep:
+        assert result.voltage.shape == (NSHOTS, NSWEEP, NSWEEP)
+    else:
+        assert result.voltage.shape == (NSHOTS,)
+
+
+@pytest.mark.qpu
+@pytest.mark.parametrize("sweep", [False, True])
+def test_integration_cyclic(connected_platform, sweep):
+    result = execute(connected_platform, AcquisitionType.INTEGRATION, AveragingMode.CYCLIC, sweep)
+    assert isinstance(result, AveragedIntegratedResults)
+    if sweep:
+        assert result.voltage.shape == (NSWEEP, NSWEEP)
+    else:
+        assert result.voltage.shape == tuple()

--- a/tests/test_result_shapes.py
+++ b/tests/test_result_shapes.py
@@ -12,7 +12,8 @@ from qibolab.result import (
 from qibolab.sweeper import Parameter, Sweeper
 
 NSHOTS = 50
-NSWEEP = 5
+NSWEEP1 = 5
+NSWEEP2 = 8
 
 
 def execute(platform, acquisition_type, averaging_mode, sweep=False):
@@ -26,8 +27,8 @@ def execute(platform, acquisition_type, averaging_mode, sweep=False):
 
     options = ExecutionParameters(nshots=NSHOTS, acquisition_type=acquisition_type, averaging_mode=averaging_mode)
     if sweep:
-        amp_values = np.linspace(0.1, 0.5, NSWEEP)
-        freq_values = np.linspace(-2e6, 2e6, NSWEEP)
+        amp_values = np.linspace(0.1, 0.5, NSWEEP1)
+        freq_values = np.linspace(-2e6, 2e6, NSWEEP2)
         sweeper1 = Sweeper(Parameter.amplitude, amp_values, pulses=[qd_pulse])
         sweeper2 = Sweeper(Parameter.frequency, freq_values, pulses=[ro_pulse])
         results = platform.sweep(sequence, options, sweeper1, sweeper2)
@@ -42,7 +43,7 @@ def test_discrimination_singleshot(connected_platform, sweep):
     result = execute(connected_platform, AcquisitionType.DISCRIMINATION, AveragingMode.SINGLESHOT, sweep)
     assert isinstance(result, SampleResults)
     if sweep:
-        assert result.samples.shape == (NSHOTS, NSWEEP, NSWEEP)
+        assert result.samples.shape == (NSHOTS, NSWEEP1, NSWEEP2)
     else:
         assert result.samples.shape == (NSHOTS,)
 
@@ -53,7 +54,7 @@ def test_discrimination_cyclic(connected_platform, sweep):
     result = execute(connected_platform, AcquisitionType.DISCRIMINATION, AveragingMode.CYCLIC, sweep)
     assert isinstance(result, AveragedSampleResults)
     if sweep:
-        assert result.statistical_frequency.shape == (NSWEEP, NSWEEP)
+        assert result.statistical_frequency.shape == (NSWEEP1, NSWEEP2)
     else:
         assert result.statistical_frequency.shape == tuple()
 
@@ -64,7 +65,7 @@ def test_integration_singleshot(connected_platform, sweep):
     result = execute(connected_platform, AcquisitionType.INTEGRATION, AveragingMode.SINGLESHOT, sweep)
     assert isinstance(result, IntegratedResults)
     if sweep:
-        assert result.voltage.shape == (NSHOTS, NSWEEP, NSWEEP)
+        assert result.voltage.shape == (NSHOTS, NSWEEP1, NSWEEP2)
     else:
         assert result.voltage.shape == (NSHOTS,)
 
@@ -75,6 +76,6 @@ def test_integration_cyclic(connected_platform, sweep):
     result = execute(connected_platform, AcquisitionType.INTEGRATION, AveragingMode.CYCLIC, sweep)
     assert isinstance(result, AveragedIntegratedResults)
     if sweep:
-        assert result.voltage.shape == (NSWEEP, NSWEEP)
+        assert result.voltage.shape == (NSWEEP1, NSWEEP2)
     else:
         assert result.voltage.shape == tuple()

--- a/tests/test_result_shapes.py
+++ b/tests/test_result_shapes.py
@@ -26,9 +26,10 @@ def execute(platform, acquisition_type, averaging_mode, sweep=False):
 
     options = ExecutionParameters(nshots=NSHOTS, acquisition_type=acquisition_type, averaging_mode=averaging_mode)
     if sweep:
-        values = np.linspace(0.1, 0.5, NSWEEP)
-        sweeper1 = Sweeper(Parameter.amplitude, values, pulses=[qd_pulse])
-        sweeper2 = Sweeper(Parameter.amplitude, values, pulses=[ro_pulse])
+        amp_values = np.linspace(0.1, 0.5, NSWEEP)
+        freq_values = np.linspace(-2e6, 2e6, NSWEEP)
+        sweeper1 = Sweeper(Parameter.amplitude, amp_values, pulses=[qd_pulse])
+        sweeper2 = Sweeper(Parameter.frequency, freq_values, pulses=[ro_pulse])
         results = platform.sweep(sequence, options, sweeper1, sweeper2)
     else:
         results = platform.execute_pulse_sequence(sequence, options)

--- a/tests/test_result_shapes.py
+++ b/tests/test_result_shapes.py
@@ -27,9 +27,10 @@ def execute(platform, acquisition_type, averaging_mode, sweep=False):
 
     options = ExecutionParameters(nshots=NSHOTS, acquisition_type=acquisition_type, averaging_mode=averaging_mode)
     if sweep:
-        amp_values = np.linspace(0.1, 0.5, NSWEEP1)
+        amp_values = np.linspace(0.01, 0.05, NSWEEP1)
         freq_values = np.linspace(-2e6, 2e6, NSWEEP2)
-        sweeper1 = Sweeper(Parameter.amplitude, amp_values, pulses=[qd_pulse])
+        sweeper1 = Sweeper(Parameter.bias, amp_values, qubits=[platform.qubits[qubit]])
+        # sweeper1 = Sweeper(Parameter.amplitude, amp_values, pulses=[qd_pulse])
         sweeper2 = Sweeper(Parameter.frequency, freq_values, pulses=[ro_pulse])
         results = platform.sweep(sequence, options, sweeper1, sweeper2)
     else:


### PR DESCRIPTION
Fixes #647 for qblox and adds qpu tests that check that the shapes are correct for each acquisition type (except raw) and averaging mode.

I would also like to fix the shapes for Zurich and also do a quick test with qibocal before merging.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
