### PR TITLE
Remove hard-coded sampling rate from pulses

### DIFF
--- a/src/qibolab/dummy.py
+++ b/src/qibolab/dummy.py
@@ -70,7 +70,5 @@ def create_dummy(with_couplers: bool = True):
             coupler.flux = channels[f"flux_coupler-{c}"]
 
     instruments = {instrument.name: instrument, twpa_pump.name: twpa_pump}
-    instrument.sampling_rate = settings.sampling_rate * 1e-9
-
     name = "dummy_couplers" if with_couplers else "dummy"
     return Platform(name, qubits, pairs, instruments, settings, resonator_type="2D", couplers=couplers)

--- a/src/qibolab/dummy.yml
+++ b/src/qibolab/dummy.yml
@@ -1,6 +1,6 @@
 nqubits: 5
 
-settings: {nshots: 1024, sampling_rate: 1000000000, relaxation_time: 0}
+settings: {nshots: 1024, relaxation_time: 0}
 
 qubits: [0, 1, 2, 3, 4]
 

--- a/src/qibolab/instruments/dummy.py
+++ b/src/qibolab/instruments/dummy.py
@@ -12,6 +12,8 @@ from qibolab.pulses import PulseSequence
 from qibolab.qubits import QubitId
 from qibolab.sweeper import Sweeper
 
+SAMPLING_RATE = 1
+
 
 @dataclass
 class DummyPort(Port):
@@ -39,7 +41,6 @@ class DummyInstrument(Controller):
     """
 
     PortType = DummyPort
-    sampling_rate = 1
 
     def connect(self):
         log.info(f"Connecting to {self.name} instrument.")
@@ -63,7 +64,7 @@ class DummyInstrument(Controller):
             elif options.averaging_mode is AveragingMode.CYCLIC:
                 values = np.random.rand(*shape)
         elif options.acquisition_type is AcquisitionType.RAW:
-            samples = int(ro_pulse.duration * self.sampling_rate)
+            samples = int(ro_pulse.duration * SAMPLING_RATE)
             waveform_shape = tuple(samples * dim for dim in shape)
             values = np.random.rand(*waveform_shape) * 100 + 1j * np.random.rand(*waveform_shape) * 100
         elif options.acquisition_type is AcquisitionType.INTEGRATION:

--- a/src/qibolab/instruments/qblox/acquisition.py
+++ b/src/qibolab/instruments/qblox/acquisition.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 
 import numpy as np
 
-SAMPLING_RATE = 1e9
+SAMPLING_RATE = 1
 
 
 def demodulate(input_i, input_q, frequency):

--- a/src/qibolab/instruments/qblox/cluster_qcm_bb.py
+++ b/src/qibolab/instruments/qblox/cluster_qcm_bb.py
@@ -97,7 +97,6 @@ class ClusterQCM_BB(Instrument):
     """
 
     DEFAULT_SEQUENCERS = {"o1": 0, "o2": 1, "o3": 2, "o4": 3}
-    SAMPLING_RATE: int = 1e9  # 1 GSPS
     FREQUENCY_LIMIT = 500e6
 
     property_wrapper = lambda parent, *parameter: property(

--- a/src/qibolab/instruments/qblox/cluster_qcm_rf.py
+++ b/src/qibolab/instruments/qblox/cluster_qcm_rf.py
@@ -117,7 +117,6 @@ class ClusterQCM_RF(Instrument):
     """
 
     DEFAULT_SEQUENCERS = {"o1": 0, "o2": 1}
-    SAMPLING_RATE: int = 1e9  # 1 GSPS
     FREQUENCY_LIMIT = 500e6
 
     property_wrapper = lambda parent, *parameter: property(

--- a/src/qibolab/instruments/qblox/cluster_qrm_rf.py
+++ b/src/qibolab/instruments/qblox/cluster_qrm_rf.py
@@ -124,7 +124,6 @@ class ClusterQRM_RF(Instrument):
     """
 
     DEFAULT_SEQUENCERS: dict = {"o1": 0, "i1": 0}
-    SAMPLING_RATE: int = 1e9  # 1 GSPS
     FREQUENCY_LIMIT = 500e6  # 500 MHz
 
     property_wrapper = lambda parent, *parameter: property(

--- a/src/qibolab/instruments/qblox/sequencer.py
+++ b/src/qibolab/instruments/qblox/sequencer.py
@@ -5,7 +5,7 @@ from qibolab.instruments.qblox.q1asm import Program
 from qibolab.pulses import Pulse, PulseSequence, PulseType
 from qibolab.sweeper import Parameter, Sweeper
 
-SAMPLING_RATE = 1e9
+SAMPLING_RATE = 1
 """Sampling rate for qblox instruments."""
 
 

--- a/src/qibolab/instruments/qblox/sequencer.py
+++ b/src/qibolab/instruments/qblox/sequencer.py
@@ -6,7 +6,7 @@ from qibolab.pulses import Pulse, PulseSequence, PulseType
 from qibolab.sweeper import Parameter, Sweeper
 
 SAMPLING_RATE = 1
-"""Sampling rate for qblox instruments."""
+"""Sampling rate for qblox instruments in GSps."""
 
 
 class WaveformsBuffer:

--- a/src/qibolab/instruments/qblox/sequencer.py
+++ b/src/qibolab/instruments/qblox/sequencer.py
@@ -5,6 +5,9 @@ from qibolab.instruments.qblox.q1asm import Program
 from qibolab.pulses import Pulse, PulseSequence, PulseType
 from qibolab.sweeper import Parameter, Sweeper
 
+SAMPLING_RATE = 1e9
+"""Sampling rate for qblox instruments."""
+
 
 class WaveformsBuffer:
     """A class to represent a buffer that holds the unique waveforms used by a sequencer.
@@ -55,9 +58,9 @@ class WaveformsBuffer:
 
         if not baking_required:
             if hardware_mod_en:
-                waveform_i, waveform_q = pulse_copy.envelope_waveforms
+                waveform_i, waveform_q = pulse_copy.envelope_waveforms(SAMPLING_RATE)
             else:
-                waveform_i, waveform_q = pulse_copy.modulated_waveforms
+                waveform_i, waveform_q = pulse_copy.modulated_waveforms(SAMPLING_RATE)
 
             pulse.waveform_i = waveform_i
             pulse.waveform_q = waveform_q
@@ -120,9 +123,9 @@ class WaveformsBuffer:
             for duration in values:
                 pulse_copy.duration = duration
                 if hardware_mod_en:
-                    waveform = pulse_copy.envelope_waveform_i
+                    waveform = pulse_copy.envelope_waveform_i(SAMPLING_RATE)
                 else:
-                    waveform = pulse_copy.modulated_waveform_i
+                    waveform = pulse_copy.modulated_waveform_i(SAMPLING_RATE)
 
                 padded_duration = int(np.ceil(duration / 4)) * 4
                 memory_needed = padded_duration
@@ -141,9 +144,9 @@ class WaveformsBuffer:
             for duration in values:
                 pulse_copy.duration = duration
                 if hardware_mod_en:
-                    waveform_i, waveform_q = pulse_copy.envelope_waveforms
+                    waveform_i, waveform_q = pulse_copy.envelope_waveforms(SAMPLING_RATE)
                 else:
-                    waveform_i, waveform_q = pulse_copy.modulated_waveforms
+                    waveform_i, waveform_q = pulse_copy.modulated_waveforms(SAMPLING_RATE)
 
                 padded_duration = int(np.ceil(duration / 4)) * 4
                 memory_needed = padded_duration * 2

--- a/src/qibolab/instruments/qm/config.py
+++ b/src/qibolab/instruments/qm/config.py
@@ -13,6 +13,9 @@ PortId = Tuple[str, int]
 IQPortId = Union[Tuple[PortId], Tuple[PortId, PortId]]
 """Type for collections of IQ ports."""
 
+SAMPLING_RATE = 1e9
+"""Sampling rate of Quantum Machines OPX."""
+
 
 @dataclass
 class QMPort(Port):
@@ -294,7 +297,7 @@ class QMConfig:
             if serial not in self.waveforms:
                 self.waveforms[serial] = {"type": "constant", "sample": pulse.amplitude}
         else:
-            waveform = getattr(pulse, f"envelope_waveform_{mode}")
+            waveform = getattr(pulse, f"envelope_waveform_{mode}")(SAMPLING_RATE)
             serial = waveform.serial
             if serial not in self.waveforms:
                 self.waveforms[serial] = {"type": "arbitrary", "samples": waveform.data.tolist()}

--- a/src/qibolab/instruments/qm/config.py
+++ b/src/qibolab/instruments/qm/config.py
@@ -14,7 +14,7 @@ IQPortId = Union[Tuple[PortId], Tuple[PortId, PortId]]
 """Type for collections of IQ ports."""
 
 SAMPLING_RATE = 1
-"""Sampling rate of Quantum Machines OPX."""
+"""Sampling rate of Quantum Machines OPX in GSps."""
 
 
 @dataclass

--- a/src/qibolab/instruments/qm/config.py
+++ b/src/qibolab/instruments/qm/config.py
@@ -13,7 +13,7 @@ PortId = Tuple[str, int]
 IQPortId = Union[Tuple[PortId], Tuple[PortId, PortId]]
 """Type for collections of IQ ports."""
 
-SAMPLING_RATE = 1e9
+SAMPLING_RATE = 1
 """Sampling rate of Quantum Machines OPX."""
 
 

--- a/src/qibolab/instruments/qm/sequence.py
+++ b/src/qibolab/instruments/qm/sequence.py
@@ -20,7 +20,7 @@ from qibolab.instruments.qm.acquisition import (
 from qibolab.pulses import Pulse, PulseType
 from qibolab.sweeper import Parameter
 
-from .config import QMConfig
+from .config import SAMPLING_RATE, QMConfig
 
 DurationsType = Union[List[int], npt.NDArray[int]]
 """Type of values that can be accepted in a duration sweeper."""
@@ -148,11 +148,11 @@ class BakedPulse(QMPulse):
         for t in durations:
             with baking(config.__dict__, padding_method="right") as segment:
                 if self.pulse.type is PulseType.FLUX:
-                    waveform = self.pulse.envelope_waveform_i.data.tolist()
+                    waveform = self.pulse.envelope_waveform_i(SAMPLING_RATE).data.tolist()
                     waveform = self.calculate_waveform(waveform, t)
                 else:
-                    waveform_i = self.pulse.envelope_waveform_i.data.tolist()
-                    waveform_q = self.pulse.envelope_waveform_q.data.tolist()
+                    waveform_i = self.pulse.envelope_waveform_i(SAMPLING_RATE).data.tolist()
+                    waveform_q = self.pulse.envelope_waveform_q(SAMPLING_RATE).data.tolist()
                     waveform = [
                         self.calculate_waveform(waveform_i, t),
                         self.calculate_waveform(waveform_q, t),

--- a/src/qibolab/instruments/rfsoc/convert.py
+++ b/src/qibolab/instruments/rfsoc/convert.py
@@ -18,7 +18,9 @@ def replace_pulse_shape(rfsoc_pulse: rfsoc_pulses.Pulse, shape: PulseShape) -> r
     """Set pulse shape parameters in rfsoc_pulses pulse object."""
     if shape.name not in {"Gaussian", "Drag", "Rectangular", "Exponential"}:
         new_pulse = rfsoc_pulses.Arbitrary(
-            **asdict(rfsoc_pulse), i_values=shape.envelope_waveform_i, q_values=shape.envelope_waveform_q
+            **asdict(rfsoc_pulse),
+            i_values=shape.envelope_waveform_i(sampling_rate),
+            q_values=shape.envelope_waveform_q(sampling_rate),
         )
         return new_pulse
     new_pulse_cls = getattr(rfsoc_pulses, shape.name)

--- a/src/qibolab/instruments/rfsoc/driver.py
+++ b/src/qibolab/instruments/rfsoc/driver.py
@@ -45,7 +45,7 @@ class RFSoC(Controller):
 
     PortType = RFSoCPort
 
-    def __init__(self, name: str, address: str, port: int):
+    def __init__(self, name: str, address: str, port: int, sampling_rate: float = 1e9):
         """Set server information and base configuration.
 
         Args:
@@ -57,6 +57,7 @@ class RFSoC(Controller):
         self.host = address
         self.port = port
         self.cfg = rfsoc.Config()
+        self.sampling_rate = sampling_rate
 
     def connect(self):
         """Empty method to comply with Instrument interface."""
@@ -88,7 +89,7 @@ class RFSoC(Controller):
         server_commands = {
             "operation_code": opcode,
             "cfg": asdict(self.cfg),
-            "sequence": convert(sequence, qubits),
+            "sequence": convert(sequence, qubits, self.sampling_rate),
             "qubits": [asdict(convert(qubits[idx])) for idx in qubits],
         }
         return client.connect(server_commands, self.host, self.port)
@@ -113,7 +114,7 @@ class RFSoC(Controller):
         server_commands = {
             "operation_code": rfsoc.OperationCode.EXECUTE_SWEEPS,
             "cfg": asdict(self.cfg),
-            "sequence": convert(sequence, qubits),
+            "sequence": convert(sequence, qubits, self.sampling_rate),
             "qubits": [asdict(convert(qubits[idx])) for idx in qubits],
             "sweepers": [sweeper.serialized for sweeper in sweepers],
         }

--- a/src/qibolab/instruments/rfsoc/driver.py
+++ b/src/qibolab/instruments/rfsoc/driver.py
@@ -45,7 +45,7 @@ class RFSoC(Controller):
 
     PortType = RFSoCPort
 
-    def __init__(self, name: str, address: str, port: int, sampling_rate: float = 1e9):
+    def __init__(self, name: str, address: str, port: int, sampling_rate: float = 1):
         """Set server information and base configuration.
 
         Args:

--- a/src/qibolab/instruments/zhinst.py
+++ b/src/qibolab/instruments/zhinst.py
@@ -29,6 +29,7 @@ from qibolab.sweeper import Parameter
 os.environ["LABONEQ_TOKEN"] = "not required"
 laboneq._token.is_valid_token = lambda _token: True  # pylint: disable=W0212
 
+SAMPLING_RATE = 2e9
 NANO_TO_SECONDS = 1e-9
 COMPILER_SETTINGS = {
     "SHFSG_FORCE_COMMAND_TABLE": True,
@@ -105,17 +106,18 @@ def select_pulse(pulse, pulse_type):
                 zero_boundaries=False,
             )
 
-    if np.all(pulse.envelope_waveform_q.data == 0):
+    if np.all(pulse.envelope_waveform_q(SAMPLING_RATE).data == 0):
         return sampled_pulse_real(
             uid=(f"{pulse_type}_{pulse.qubit}_"),
-            samples=pulse.envelope_waveform_i.data,
+            samples=pulse.envelope_waveform_i(SAMPLING_RATE).data,
             can_compress=True,
         )
     else:
         # Test this when we have pulses that use it
         return sampled_pulse_complex(
             uid=(f"{pulse_type}_{pulse.qubit}_"),
-            samples=pulse.envelope_waveform_i.data + (1j * pulse.envelope_waveform_q.data),
+            samples=pulse.envelope_waveform_i(SAMPLING_RATE).data
+            + (1j * pulse.envelope_waveform_q(SAMPLING_RATE).data),
             can_compress=True,
         )
 

--- a/src/qibolab/instruments/zhinst.py
+++ b/src/qibolab/instruments/zhinst.py
@@ -29,7 +29,7 @@ from qibolab.sweeper import Parameter
 os.environ["LABONEQ_TOKEN"] = "not required"
 laboneq._token.is_valid_token = lambda _token: True  # pylint: disable=W0212
 
-SAMPLING_RATE = 2e9
+SAMPLING_RATE = 2
 NANO_TO_SECONDS = 1e-9
 COMPILER_SETTINGS = {
     "SHFSG_FORCE_COMMAND_TABLE": True,

--- a/src/qibolab/platform.py
+++ b/src/qibolab/platform.py
@@ -57,8 +57,6 @@ class Settings:
 
     nshots: int = 1024
     """Default number of repetitions when executing a pulse sequence."""
-    sampling_rate: int = 1
-    """Number of waveform samples supported by the instruments per second."""
     relaxation_time: int = int(1e5)
     """Time in ns to wait for the qubit to relax to its ground state between shots."""
 

--- a/src/qibolab/platform.py
+++ b/src/qibolab/platform.py
@@ -57,7 +57,7 @@ class Settings:
 
     nshots: int = 1024
     """Default number of repetitions when executing a pulse sequence."""
-    sampling_rate: int = int(1e9)
+    sampling_rate: int = 1
     """Number of waveform samples supported by the instruments per second."""
     relaxation_time: int = int(1e5)
     """Time in ns to wait for the qubit to relax to its ground state between shots."""

--- a/src/qibolab/pulses.py
+++ b/src/qibolab/pulses.py
@@ -10,6 +10,11 @@ from scipy.signal import lfilter
 
 from qibolab.symbolic import intSymbolicExpression as se_int
 
+SAMPLING_RATE = 1e9
+"""Default sampling rate in samples per second.
+Used for generating waveform envelopes if the instruments do not provide a different value.
+"""
+
 
 class PulseType(Enum):
     """An enumeration to distinguish different types of pulses.
@@ -105,65 +110,56 @@ class ShapeInitError(RuntimeError):
 class PulseShape(ABC):
     """Abstract class for pulse shapes.
 
-    A PulseShape object is responsible for generating envelope and modulated waveforms from a set
-    of pulse parameters, its type and a predefined SAMPLING_RATE. PulsShape generates both i (in-phase)
-    and q (quadrature) components.
+    This object is responsible for generating envelope and modulated waveforms from a set
+    of pulse parameters and its type. Generates both i (in-phase) and q (quadrature) components.
     """
 
-    SAMPLING_RATE = 1e9  # 1GSaPS
-    """SAMPLING_RATE (int): sampling rate in samples per second (SaPS)"""
     pulse = None
     """pulse (Pulse): the pulse associated with it. Its parameters are used to generate pulse waveforms."""
 
-    @property
     @abstractmethod
-    def envelope_waveform_i(self) -> Waveform:  # pragma: no cover
+    def envelope_waveform_i(self, sampling_rate=SAMPLING_RATE) -> Waveform:  # pragma: no cover
         raise NotImplementedError
 
-    @property
     @abstractmethod
-    def envelope_waveform_q(self) -> Waveform:  # pragma: no cover
+    def envelope_waveform_q(self, sampling_rate=SAMPLING_RATE) -> Waveform:  # pragma: no cover
         raise NotImplementedError
 
-    @property
-    def envelope_waveforms(self):  #  -> tuple[Waveform, Waveform]:  # pragma: no cover
+    def envelope_waveforms(self, sampling_rate=SAMPLING_RATE):  #  -> tuple[Waveform, Waveform]:  # pragma: no cover
         """A tuple with the i and q envelope waveforms of the pulse."""
 
-        return (self.envelope_waveform_i, self.envelope_waveform_q)
+        return (self.envelope_waveform_i(sampling_rate), self.envelope_waveform_q(sampling_rate))
 
-    @property
-    def modulated_waveform_i(self) -> Waveform:
+    def modulated_waveform_i(self, sampling_rate=SAMPLING_RATE) -> Waveform:
         """The waveform of the i component of the pulse, modulated with its frequency."""
 
-        return self.modulated_waveforms[0]
+        return self.modulated_waveforms(sampling_rate)[0]
 
-    @property
-    def modulated_waveform_q(self) -> Waveform:
+    def modulated_waveform_q(self, sampling_rate=SAMPLING_RATE) -> Waveform:
         """The waveform of the q component of the pulse, modulated with its frequency."""
 
-        return self.modulated_waveforms[1]
+        return self.modulated_waveforms(sampling_rate)[1]
 
-    @property
-    def modulated_waveforms(self):
+    def modulated_waveforms(self, sampling_rate=SAMPLING_RATE):
         """A tuple with the i and q waveforms of the pulse, modulated with its frequency."""
 
         if not self.pulse:
             raise ShapeInitError
 
         pulse = self.pulse
-        if abs(pulse._if) * 2 > PulseShape.SAMPLING_RATE:
+        if abs(pulse._if) * 2 > sampling_rate:
             log.info(
-                f"WARNING: The frequency of pulse {pulse.serial} is higher than the nyqusit frequency ({int(PulseShape.SAMPLING_RATE // 2)}) for the device sampling rate: {int(PulseShape.SAMPLING_RATE)}"
+                f"WARNING: The frequency of pulse {pulse.serial} is higher than the nyqusit frequency ({int(sampling_rate // 2)}) for the device sampling rate: {int(sampling_rate)}"
             )
-        num_samples = int(np.rint(pulse.duration / 1e9 * PulseShape.SAMPLING_RATE))
-        time = np.arange(num_samples) / PulseShape.SAMPLING_RATE
+        num_samples = int(np.rint(pulse.duration / 1e9 * sampling_rate))
+        time = np.arange(num_samples) / sampling_rate
         global_phase = pulse.global_phase
         cosalpha = np.cos(2 * np.pi * pulse._if * time + global_phase + pulse.relative_phase)
         sinalpha = np.sin(2 * np.pi * pulse._if * time + global_phase + pulse.relative_phase)
 
         mod_matrix = np.array([[cosalpha, -sinalpha], [sinalpha, cosalpha]]) / np.sqrt(2)
 
-        (envelope_waveform_i, envelope_waveform_q) = self.envelope_waveforms
+        (envelope_waveform_i, envelope_waveform_q) = self.envelope_waveforms(sampling_rate)
         result = []
         for n, t, ii, qq in zip(
             np.arange(num_samples),
@@ -192,23 +188,21 @@ class Rectangular(PulseShape):
         self.name = "Rectangular"
         self.pulse: Pulse = None
 
-    @property
-    def envelope_waveform_i(self) -> Waveform:
+    def envelope_waveform_i(self, sampling_rate=SAMPLING_RATE) -> Waveform:
         """The envelope waveform of the i component of the pulse."""
 
         if self.pulse:
-            num_samples = int(np.rint(self.pulse.duration / 1e9 * PulseShape.SAMPLING_RATE))
+            num_samples = int(np.rint(self.pulse.duration / 1e9 * sampling_rate))
             waveform = Waveform(self.pulse.amplitude * np.ones(num_samples))
             waveform.serial = f"Envelope_Waveform_I(num_samples = {num_samples}, amplitude = {format(self.pulse.amplitude, '.6f').rstrip('0').rstrip('.')}, shape = {repr(self)})"
             return waveform
         raise ShapeInitError
 
-    @property
-    def envelope_waveform_q(self) -> Waveform:
+    def envelope_waveform_q(self, sampling_rate=SAMPLING_RATE) -> Waveform:
         """The envelope waveform of the q component of the pulse."""
 
         if self.pulse:
-            num_samples = int(np.rint(self.pulse.duration / 1e9 * PulseShape.SAMPLING_RATE))
+            num_samples = int(np.rint(self.pulse.duration / 1e9 * sampling_rate))
             waveform = Waveform(np.zeros(num_samples))
             waveform.serial = f"Envelope_Waveform_Q(num_samples = {num_samples}, amplitude = {format(self.pulse.amplitude, '.6f').rstrip('0').rstrip('.')}, shape = {repr(self)})"
             return waveform
@@ -240,12 +234,11 @@ class Exponential(PulseShape):
         self.upsilon: float = float(upsilon)
         self.g: float = float(g)
 
-    @property
-    def envelope_waveform_i(self) -> Waveform:
+    def envelope_waveform_i(self, sampling_rate=SAMPLING_RATE) -> Waveform:
         """The envelope waveform of the i component of the pulse."""
 
         if self.pulse:
-            num_samples = int(np.rint(self.pulse.duration / 1e9 * PulseShape.SAMPLING_RATE))
+            num_samples = int(np.rint(self.pulse.duration / 1e9 * sampling_rate))
             x = np.arange(0, num_samples, 1)
             waveform = Waveform(
                 self.pulse.amplitude
@@ -257,12 +250,11 @@ class Exponential(PulseShape):
             return waveform
         raise ShapeInitError
 
-    @property
-    def envelope_waveform_q(self) -> Waveform:
+    def envelope_waveform_q(self, sampling_rate=SAMPLING_RATE) -> Waveform:
         """The envelope waveform of the q component of the pulse."""
 
         if self.pulse:
-            num_samples = int(np.rint(self.pulse.duration / 1e9 * PulseShape.SAMPLING_RATE))
+            num_samples = int(np.rint(self.pulse.duration / 1e9 * sampling_rate))
             waveform = Waveform(np.zeros(num_samples))
             waveform.serial = f"Envelope_Waveform_Q(num_samples = {num_samples}, amplitude = {format(self.pulse.amplitude, '.6f').rstrip('0').rstrip('.')}, shape = {repr(self)})"
             return waveform
@@ -294,12 +286,11 @@ class Gaussian(PulseShape):
             return self.rel_sigma == item.rel_sigma
         return False
 
-    @property
-    def envelope_waveform_i(self) -> Waveform:
+    def envelope_waveform_i(self, sampling_rate=SAMPLING_RATE) -> Waveform:
         """The envelope waveform of the i component of the pulse."""
 
         if self.pulse:
-            num_samples = int(np.rint(self.pulse.duration / 1e9 * PulseShape.SAMPLING_RATE))
+            num_samples = int(np.rint(self.pulse.duration / 1e9 * sampling_rate))
             x = np.arange(0, num_samples, 1)
             waveform = Waveform(
                 self.pulse.amplitude
@@ -309,12 +300,11 @@ class Gaussian(PulseShape):
             return waveform
         raise ShapeInitError
 
-    @property
-    def envelope_waveform_q(self) -> Waveform:
+    def envelope_waveform_q(self, sampling_rate=SAMPLING_RATE) -> Waveform:
         """The envelope waveform of the q component of the pulse."""
 
         if self.pulse:
-            num_samples = int(np.rint(self.pulse.duration / 1e9 * PulseShape.SAMPLING_RATE))
+            num_samples = int(np.rint(self.pulse.duration / 1e9 * sampling_rate))
             waveform = Waveform(np.zeros(num_samples))
             waveform.serial = f"Envelope_Waveform_Q(num_samples = {num_samples}, amplitude = {format(self.pulse.amplitude, '.6f').rstrip('0').rstrip('.')}, shape = {repr(self)})"
             return waveform
@@ -348,12 +338,11 @@ class Drag(PulseShape):
             return self.rel_sigma == item.rel_sigma and self.beta == item.beta
         return False
 
-    @property
-    def envelope_waveform_i(self) -> Waveform:
+    def envelope_waveform_i(self, sampling_rate=SAMPLING_RATE) -> Waveform:
         """The envelope waveform of the i component of the pulse."""
 
         if self.pulse:
-            num_samples = int(np.rint(self.pulse.duration / 1e9 * PulseShape.SAMPLING_RATE))
+            num_samples = int(np.rint(self.pulse.duration / 1e9 * sampling_rate))
             x = np.arange(0, num_samples, 1)
             i = self.pulse.amplitude * np.exp(
                 -(1 / 2) * (((x - (num_samples - 1) / 2) ** 2) / (((num_samples) / self.rel_sigma) ** 2))
@@ -363,12 +352,11 @@ class Drag(PulseShape):
             return waveform
         raise ShapeInitError
 
-    @property
-    def envelope_waveform_q(self) -> Waveform:
+    def envelope_waveform_q(self, sampling_rate=SAMPLING_RATE) -> Waveform:
         """The envelope waveform of the q component of the pulse."""
 
         if self.pulse:
-            num_samples = int(np.rint(self.pulse.duration / 1e9 * PulseShape.SAMPLING_RATE))
+            num_samples = int(np.rint(self.pulse.duration / 1e9 * sampling_rate))
             x = np.arange(0, num_samples, 1)
             i = self.pulse.amplitude * np.exp(
                 -(1 / 2) * (((x - (num_samples - 1) / 2) ** 2) / (((num_samples) / self.rel_sigma) ** 2))
@@ -377,7 +365,7 @@ class Drag(PulseShape):
                 self.beta
                 * (-(x - (num_samples - 1) / 2) / ((num_samples / self.rel_sigma) ** 2))
                 * i
-                * PulseShape.SAMPLING_RATE
+                * sampling_rate
                 / 1e9
             )
             waveform = Waveform(q)
@@ -420,17 +408,16 @@ class IIR(PulseShape):
         self._pulse = value
         self.target.pulse = value
 
-    @property
-    def envelope_waveform_i(self) -> Waveform:
+    def envelope_waveform_i(self, sampling_rate=SAMPLING_RATE) -> Waveform:
         """The envelope waveform of the i component of the pulse."""
 
         if self.pulse:
-            num_samples = int(np.rint(self.pulse.duration / 1e9 * PulseShape.SAMPLING_RATE))
+            num_samples = int(np.rint(self.pulse.duration / 1e9 * sampling_rate))
             self.a = self.a / self.a[0]
             gain = np.sum(self.b) / np.sum(self.a)
             if not gain == 0:
                 self.b = self.b / gain
-            data = lfilter(b=self.b, a=self.a, x=self.target.envelope_waveform_i.data)
+            data = lfilter(b=self.b, a=self.a, x=self.target.envelope_waveform_i(sampling_rate).data)
             if not np.max(np.abs(data)) == 0:
                 data = data / np.max(np.abs(data))
             data = np.abs(self.pulse.amplitude) * data
@@ -439,17 +426,16 @@ class IIR(PulseShape):
             return waveform
         raise ShapeInitError
 
-    @property
-    def envelope_waveform_q(self) -> Waveform:
+    def envelope_waveform_q(self, sampling_rate=SAMPLING_RATE) -> Waveform:
         """The envelope waveform of the q component of the pulse."""
 
         if self.pulse:
-            num_samples = int(np.rint(self.pulse.duration / 1e9 * PulseShape.SAMPLING_RATE))
+            num_samples = int(np.rint(self.pulse.duration / 1e9 * sampling_rate))
             self.a = self.a / self.a[0]
             gain = np.sum(self.b) / np.sum(self.a)
             if not gain == 0:
                 self.b = self.b / gain
-            data = lfilter(b=self.b, a=self.a, x=self.target.envelope_waveform_q.data)
+            data = lfilter(b=self.b, a=self.a, x=self.target.envelope_waveform_q(sampling_rate).data)
             if not np.max(np.abs(data)) == 0:
                 data = data / np.max(np.abs(data))
             data = np.abs(self.pulse.amplitude) * data
@@ -484,8 +470,7 @@ class SNZ(PulseShape):
             return self.t_idling == item.t_idling and self.b_amplitude == item.b_amplitude
         return False
 
-    @property
-    def envelope_waveform_i(self) -> Waveform:
+    def envelope_waveform_i(self, sampling_rate=SAMPLING_RATE) -> Waveform:
         """The envelope waveform of the i component of the pulse."""
 
         if self.pulse:
@@ -493,7 +478,7 @@ class SNZ(PulseShape):
                 raise ValueError(f"Cannot put idling time {self.t_idling} higher than duration {self.pulse.duration}.")
             if self.b_amplitude is None:
                 self.b_amplitude = self.pulse.amplitude / 2
-            num_samples = int(np.rint(self.pulse.duration / 1e9 * PulseShape.SAMPLING_RATE))
+            num_samples = int(np.rint(self.pulse.duration / 1e9 * sampling_rate))
             half_pulse_duration = (self.pulse.duration - self.t_idling) / 2
             half_flux_pulse_samples = int(np.rint(num_samples * half_pulse_duration / self.pulse.duration))
             idling_samples = num_samples - 2 * half_flux_pulse_samples
@@ -512,12 +497,11 @@ class SNZ(PulseShape):
             return waveform
         raise ShapeInitError
 
-    @property
-    def envelope_waveform_q(self) -> Waveform:
+    def envelope_waveform_q(self, sampling_rate=SAMPLING_RATE) -> Waveform:
         """The envelope waveform of the q component of the pulse."""
 
         if self.pulse:
-            num_samples = int(np.rint(self.pulse.duration / 1e9 * PulseShape.SAMPLING_RATE))
+            num_samples = int(np.rint(self.pulse.duration / 1e9 * sampling_rate))
             waveform = Waveform(np.zeros(num_samples))
             waveform.serial = f"Envelope_Waveform_Q(num_samples = {num_samples}, amplitude = {format(self.pulse.amplitude, '.6f').rstrip('0').rstrip('.')}, shape = {repr(self)})"
             return waveform
@@ -551,10 +535,9 @@ class eCap(PulseShape):
             return self.alpha == item.alpha
         return False
 
-    @property
-    def envelope_waveform_i(self) -> Waveform:
+    def envelope_waveform_i(self, sampling_rate=SAMPLING_RATE) -> Waveform:
         if self.pulse:
-            num_samples = int(self.pulse.duration / 1e9 * PulseShape.SAMPLING_RATE)
+            num_samples = int(self.pulse.duration / 1e9 * sampling_rate)
             x = np.arange(0, num_samples, 1)
             waveform = Waveform(
                 self.pulse.amplitude
@@ -566,10 +549,9 @@ class eCap(PulseShape):
             return waveform
         raise ShapeInitError
 
-    @property
-    def envelope_waveform_q(self) -> Waveform:
+    def envelope_waveform_q(self, sampling_rate=SAMPLING_RATE) -> Waveform:
         if self.pulse:
-            num_samples = int(self.pulse.duration / 1e9 * PulseShape.SAMPLING_RATE)
+            num_samples = int(self.pulse.duration / 1e9 * sampling_rate)
             waveform = Waveform(np.zeros(num_samples))
             waveform.serial = f"Envelope_Waveform_Q(num_samples = {num_samples}, amplitude = {format(self.pulse.amplitude, '.6f').rstrip('0').rstrip('.')}, shape = {repr(self)})"
             return waveform
@@ -591,28 +573,26 @@ class Custom(PulseShape):
         else:
             self.envelope_q = self.envelope_i
 
-    @property
-    def envelope_waveform_i(self) -> Waveform:
+    def envelope_waveform_i(self, sampling_rate=SAMPLING_RATE) -> Waveform:
         """The envelope waveform of the i component of the pulse."""
 
         if self.pulse:
             if self.pulse.duration != len(self.envelope_i):
                 raise ValueError("Length of envelope_i must be equal to pulse duration")
-            num_samples = int(np.rint(self.pulse.duration / 1e9 * PulseShape.SAMPLING_RATE))
+            num_samples = int(np.rint(self.pulse.duration / 1e9 * sampling_rate))
 
             waveform = Waveform(self.envelope_i * self.pulse.amplitude)
             waveform.serial = f"Envelope_Waveform_I(num_samples = {num_samples}, amplitude = {format(self.pulse.amplitude, '.6f').rstrip('0').rstrip('.')}, shape = {repr(self)})"
             return waveform
         raise ShapeInitError
 
-    @property
-    def envelope_waveform_q(self) -> Waveform:
+    def envelope_waveform_q(self, sampling_rate=SAMPLING_RATE) -> Waveform:
         """The envelope waveform of the q component of the pulse."""
 
         if self.pulse:
             if self.pulse.duration != len(self.envelope_q):
                 raise ValueError("Length of envelope_q must be equal to pulse duration")
-            num_samples = int(np.rint(self.pulse.duration / 1e9 * PulseShape.SAMPLING_RATE))
+            num_samples = int(np.rint(self.pulse.duration / 1e9 * sampling_rate))
 
             waveform = Waveform(self.envelope_q * self.pulse.amplitude)
             waveform.serial = f"Envelope_Waveform_Q(num_samples = {num_samples}, amplitude = {format(self.pulse.amplitude, '.6f').rstrip('0').rstrip('.')}, shape = {repr(self)})"
@@ -1034,41 +1014,35 @@ class Pulse:
     def id(self) -> int:
         return id(self)
 
-    @property
-    def envelope_waveform_i(self) -> Waveform:
+    def envelope_waveform_i(self, sampling_rate=SAMPLING_RATE) -> Waveform:
         """The envelope waveform of the i component of the pulse."""
 
-        return self._shape.envelope_waveform_i
+        return self._shape.envelope_waveform_i(sampling_rate)
 
-    @property
-    def envelope_waveform_q(self) -> Waveform:
+    def envelope_waveform_q(self, sampling_rate=SAMPLING_RATE) -> Waveform:
         """The envelope waveform of the q component of the pulse."""
 
-        return self._shape.envelope_waveform_q
+        return self._shape.envelope_waveform_q(sampling_rate)
 
-    @property
-    def envelope_waveforms(self):  #  -> tuple[Waveform, Waveform]:
+    def envelope_waveforms(self, sampling_rate=SAMPLING_RATE):  #  -> tuple[Waveform, Waveform]:
         """A tuple with the i and q envelope waveforms of the pulse."""
 
-        return (self._shape.envelope_waveform_i, self._shape.envelope_waveform_q)
+        return (self._shape.envelope_waveform_i(sampling_rate), self._shape.envelope_waveform_q(sampling_rate))
 
-    @property
-    def modulated_waveform_i(self) -> Waveform:
+    def modulated_waveform_i(self, sampling_rate=SAMPLING_RATE) -> Waveform:
         """The waveform of the i component of the pulse, modulated with its frequency."""
 
-        return self._shape.modulated_waveform_i
+        return self._shape.modulated_waveform_i(sampling_rate)
 
-    @property
-    def modulated_waveform_q(self) -> Waveform:
+    def modulated_waveform_q(self, sampling_rate=SAMPLING_RATE) -> Waveform:
         """The waveform of the q component of the pulse, modulated with its frequency."""
 
         return self._shape.modulated_waveform_q
 
-    @property
-    def modulated_waveforms(self):  #  -> tuple[Waveform, Waveform]:
+    def modulated_waveforms(self, sampling_rate):  #  -> tuple[Waveform, Waveform]:
         """A tuple with the i and q waveforms of the pulse, modulated with its frequency."""
 
-        return self._shape.modulated_waveforms
+        return self._shape.modulated_waveforms(sampling_rate)
 
     def __repr__(self):
         return self.serial
@@ -1173,7 +1147,7 @@ class Pulse:
             and self.qubit == item.qubit
         )
 
-    def plot(self, savefig_filename=None):
+    def plot(self, savefig_filename=None, sampling_rate=SAMPLING_RATE):
         """Plots the pulse envelope and modulated waveforms.
 
         Args:
@@ -1183,28 +1157,31 @@ class Pulse:
         import matplotlib.pyplot as plt
         from matplotlib import gridspec
 
-        num_samples = len(self.shape.envelope_waveform_i)
-        time = self.start + np.arange(num_samples) / PulseShape.SAMPLING_RATE * 1e9
+        waveform_i = self.shape.envelope_waveform_i(sampling_rate)
+        waveform_q = self.shape.envelope_waveform_q(sampling_rate)
+
+        num_samples = len(waveform_i)
+        time = self.start + np.arange(num_samples) / sampling_rate * 1e9
         fig = plt.figure(figsize=(14, 5), dpi=200)
         gs = gridspec.GridSpec(ncols=2, nrows=1, width_ratios=[2, 1])
         ax1 = plt.subplot(gs[0])
         ax1.plot(
             time,
-            self.shape.envelope_waveform_i.data,
+            waveform_i.data,
             label="envelope i",
             c="C0",
             linestyle="dashed",
         )
         ax1.plot(
             time,
-            self.shape.envelope_waveform_q.data,
+            waveform_q.data,
             label="envelope q",
             c="C1",
             linestyle="dashed",
         )
-        ax1.plot(time, self.shape.modulated_waveform_i.data, label="modulated i", c="C0")
-        ax1.plot(time, self.shape.modulated_waveform_q.data, label="modulated q", c="C1")
-        ax1.plot(time, -self.shape.envelope_waveform_i.data, c="silver", linestyle="dashed")
+        ax1.plot(time, self.shape.modulated_waveform_i(sampling_rate).data, label="modulated i", c="C0")
+        ax1.plot(time, self.shape.modulated_waveform_q(sampling_rate).data, label="modulated q", c="C1")
+        ax1.plot(time, -waveform_i.data, c="silver", linestyle="dashed")
         ax1.set_xlabel("Time [ns]")
         ax1.set_ylabel("Amplitude")
 
@@ -1212,30 +1189,32 @@ class Pulse:
         ax1.axis([self.start, self.finish, -1, 1])
         ax1.legend()
 
+        modulated_i = self.shape.modulated_waveform_i(sampling_rate).data
+        modulated_q = self.shape.modulated_waveform_q(sampling_rate).data
         ax2 = plt.subplot(gs[1])
         ax2.plot(
-            self.shape.modulated_waveform_i.data,
-            self.shape.modulated_waveform_q.data,
+            modulated_i,
+            modulated_q,
             label="modulated",
             c="C3",
         )
         ax2.plot(
-            self.shape.envelope_waveform_i.data,
-            self.shape.envelope_waveform_q.data,
+            waveform_i.data,
+            waveform_q.data,
             label="envelope",
             c="C2",
         )
         ax2.plot(
-            self.shape.modulated_waveform_i.data[0],
-            self.shape.modulated_waveform_q.data[0],
+            modulated_i[0],
+            modulated_q[0],
             marker="o",
             markersize=5,
             label="start",
             c="lightcoral",
         )
         ax2.plot(
-            self.shape.modulated_waveform_i.data[-1],
-            self.shape.modulated_waveform_q.data[-1],
+            modulated_i[-1],
+            modulated_q[-1],
             marker="o",
             markersize=5,
             label="finish",
@@ -1377,29 +1356,15 @@ class FluxPulse(Pulse):
             qubit=qubit,
         )
 
-    @property
-    def envelope_waveform_i(self) -> Waveform:
-        return self._shape.envelope_waveform_i
+    def envelope_waveform_q(self, sampling_rate=SAMPLING_RATE) -> Waveform:
+        """Flux pulses only have i component."""
+        return self._shape.envelope_waveform_i(sampling_rate)
 
-    @property
-    def envelope_waveform_q(self) -> Waveform:
-        return self._shape.envelope_waveform_i
+    def modulated_waveform_i(self, sampling_rate=SAMPLING_RATE) -> Waveform:
+        return self._shape.envelope_waveform_i(sampling_rate)
 
-    @property
-    def envelope_waveforms(self):  #  -> tuple[Waveform, Waveform]:
-        return (self._shape.envelope_waveform_i, self._shape.envelope_waveform_i)
-
-    @property
-    def modulated_waveform_i(self) -> Waveform:
-        return self._shape.envelope_waveform_i
-
-    @property
-    def modulated_waveform_q(self) -> Waveform:
-        return self._shape.envelope_waveform_i
-
-    @property
-    def modulated_waveforms(self):  #  -> tuple[Waveform, Waveform]:
-        return (self._shape.envelope_waveform_i, self._shape.envelope_waveform_i)
+    def modulated_waveform_q(self, sampling_rate=SAMPLING_RATE) -> Waveform:
+        return self._shape.envelope_waveform_i(sampling_rate)
 
     @property
     def serial(self):
@@ -1471,98 +1436,97 @@ class SplitPulse(Pulse):
     def serial(self):
         return f"SplitPulse({self.window_start}, {self.window_duration}, {format(self.amplitude, '.6f').rstrip('0').rstrip('.')}, {format(self.frequency, '_')}, {format(self.relative_phase, '.6f').rstrip('0').rstrip('.')}, {self.shape}, {self.channel}, {self.qubit})"
 
-    @property
-    def envelope_waveform_i(self) -> Waveform:
+    def envelope_waveform_i(self, sampling_rate=SAMPLING_RATE) -> Waveform:
         waveform = Waveform(
-            self._shape.envelope_waveform_i.data[self._window_start - self.start : self._window_finish - self.start]
+            self._shape.envelope_waveform_i(sampling_rate).data[
+                self._window_start - self.start : self._window_finish - self.start
+            ]
         )
         waveform.serial = (
-            self._shape.envelope_waveform_i.serial
+            self._shape.envelope_waveform_i(sampling_rate).serial
             + f"[{self._window_start - self.start} : {self._window_finish - self.start}]"
         )
         return waveform
 
-    @property
-    def envelope_waveform_q(self) -> Waveform:
+    def envelope_waveform_q(self, sampling_rate=SAMPLING_RATE) -> Waveform:
         waveform = Waveform(
-            self._shape.modulated_waveform_i.data[self._window_start - self.start : self._window_finish - self.start]
+            self._shape.modulated_waveform_q(sampling_rate).data[
+                self._window_start - self.start : self._window_finish - self.start
+            ]
         )
         waveform.serial = (
-            self._shape.modulated_waveform_i.serial
+            self._shape.modulated_waveform_q(sampling_rate).serial
             + f"[{self._window_start - self.start} : {self._window_finish - self.start}]"
         )
         return waveform
 
-    @property
-    def envelope_waveforms(self):  #  -> tuple[Waveform, Waveform]:
-        return (self.envelope_waveform_i, self.envelope_waveform_q)
-
-    @property
-    def modulated_waveform_i(self) -> Waveform:
+    def modulated_waveform_i(self, sampling_rate=SAMPLING_RATE) -> Waveform:
         waveform = Waveform(
-            self._shape.envelope_waveform_q.data[self._window_start - self.start : self._window_finish - self.start]
+            self._shape.modulated_waveform_i(sampling_rate).data[
+                self._window_start - self.start : self._window_finish - self.start
+            ]
         )
         waveform.serial = (
-            self._shape.envelope_waveform_q.serial
+            self._shape.modulated_waveform_q(sampling_rate).serial
             + f"[{self._window_start - self.start} : {self._window_finish - self.start}]"
         )
         return waveform
 
-    @property
-    def modulated_waveform_q(self) -> Waveform:
+    def modulated_waveform_q(self, sampling_rate=SAMPLING_RATE) -> Waveform:
         waveform = Waveform(
-            self._shape.modulated_waveform_q.data[self._window_start - self.start : self._window_finish - self.start]
+            self._shape.modulated_waveform_q(sampling_rate).data[
+                self._window_start - self.start : self._window_finish - self.start
+            ]
         )
         waveform.serial = (
-            self._shape.modulated_waveform_q.serial
+            self._shape.modulated_waveform_q(sampling_rate).serial
             + f"[{self._window_start - self.start} : {self._window_finish - self.start}]"
         )
         return waveform
 
-    @property
-    def modulated_waveforms(self):  #  -> tuple[Waveform, Waveform]:
-        return (self.modulated_waveform_i, self.modulated_waveform_q)
-
-    def plot(self, savefig_filename=None):
+    def plot(self, savefig_filename=None, sampling_rate=SAMPLING_RATE):
         import matplotlib.pyplot as plt
         from matplotlib import gridspec
 
         idx = slice(self._window_start - self.start, self._window_finish - self.start)
-        num_samples = len(self.shape.envelope_waveform_i.data[idx])
-        time = self.window_start + np.arange(num_samples) / PulseShape.SAMPLING_RATE * 1e9
+        waveform_i = self.shape.envelope_waveform_i(sampling_rate).data[idx]
+        waveform_q = self.shape.envelope_waveform_q(sampling_rate).data[idx]
+
+        num_samples = len(waveform_i)
+        time = self.window_start + np.arange(num_samples) / sampling_rate * 1e9
 
         fig = plt.figure(figsize=(14, 5), dpi=200)
         gs = gridspec.GridSpec(ncols=2, nrows=1, width_ratios=[2, 1])
         ax1 = plt.subplot(gs[0])
         ax1.plot(
             time,
-            self.shape.envelope_waveform_i.data[idx],
+            waveform_i,
             label="envelope i",
             c="C0",
             linestyle="dashed",
         )
         ax1.plot(
             time,
-            self.shape.envelope_waveform_q.data[idx],
+            waveform_q,
             label="envelope q",
             c="C1",
             linestyle="dashed",
         )
         ax1.plot(
             time,
-            self.shape.modulated_waveform_i.data[idx],
+            self.shape.modulated_waveform_i(sampling_rate).data[idx],
             label="modulated i",
             c="C0",
         )
         ax1.plot(
             time,
-            self.shape.modulated_waveform_q.data[idx],
+            self.shape.modulated_waveform_q(sampling_rate).data[idx],
             label="modulated q",
             c="C1",
         )
         ax1.plot(
             time,
-            -self.shape.envelope_waveform_i.data[idx],
+            -waveform_i,
             c="silver",
             linestyle="dashed",
         )
@@ -1575,14 +1539,14 @@ class SplitPulse(Pulse):
 
         ax2 = plt.subplot(gs[1])
         ax2.plot(
-            self.shape.modulated_waveform_i.data[idx],
-            self.shape.modulated_waveform_q.data[idx],
+            self.shape.modulated_waveform_i(sampling_rate).data[idx],
+            self.shape.modulated_waveform_q(sampling_rate).data[idx],
             label="modulated",
             c="C3",
         )
         ax2.plot(
-            self.shape.envelope_waveform_i.data[idx],
-            self.shape.envelope_waveform_q.data[idx],
+            waveform_i,
+            waveform_q,
             label="envelope",
             c="C2",
         )
@@ -1946,7 +1910,7 @@ class PulseSequence:
                 overlap = True
         return overlap
 
-    def plot(self, savefig_filename=None):
+    def plot(self, savefig_filename=None, sampling_rate=SAMPLING_RATE):
         """Plots the sequence of pulses.
 
         Args:
@@ -1975,45 +1939,45 @@ class PulseSequence:
                     for pulse in channel_pulses:
                         if isinstance(pulse, SplitPulse):
                             idx = slice(pulse.window_start - pulse.start, pulse.window_finish - pulse.start)
-                            num_samples = len(pulse.shape.modulated_waveform_i.data[idx])
-                            time = pulse.window_start + np.arange(num_samples) / PulseShape.SAMPLING_RATE * 1e9
-                            ax.plot(time, pulse.shape.modulated_waveform_q.data[idx], c="lightgrey")
+                            num_samples = len(pulse.shape.modulated_waveform_i(sampling_rate).data[idx])
+                            time = pulse.window_start + np.arange(num_samples) / sampling_rate * 1e9
+                            ax.plot(time, pulse.shape.modulated_waveform_q(sampling_rate).data[idx], c="lightgrey")
                             ax.plot(
                                 time,
-                                pulse.shape.modulated_waveform_i.data[idx],
+                                pulse.shape.modulated_waveform_i(sampling_rate).data[idx],
                                 c=f"C{str(n)}",
                             )
                             ax.plot(
                                 time,
-                                pulse.shape.envelope_waveform_i.data[idx],
+                                pulse.shape.envelope_waveform_i(sampling_rate).data[idx],
                                 c=f"C{str(n)}",
                             )
                             ax.plot(
                                 time,
-                                -pulse.shape.envelope_waveform_i.data[idx],
+                                -pulse.shape.envelope_waveform_i(sampling_rate).data[idx],
                                 c=f"C{str(n)}",
                             )
                         else:
-                            num_samples = len(pulse.shape.modulated_waveform_i)
-                            time = pulse.start + np.arange(num_samples) / PulseShape.SAMPLING_RATE * 1e9
+                            num_samples = len(pulse.shape.modulated_waveform_i(sampling_rate))
+                            time = pulse.start + np.arange(num_samples) / sampling_rate * 1e9
                             ax.plot(
                                 time,
-                                pulse.shape.modulated_waveform_q.data,
+                                pulse.shape.modulated_waveform_q(sampling_rate).data,
                                 c="lightgrey",
                             )
                             ax.plot(
                                 time,
-                                pulse.shape.modulated_waveform_i.data,
+                                pulse.shape.modulated_waveform_i(sampling_rate).data,
                                 c=f"C{str(n)}",
                             )
                             ax.plot(
                                 time,
-                                pulse.shape.envelope_waveform_i.data,
+                                pulse.shape.envelope_waveform_i(sampling_rate).data,
                                 c=f"C{str(n)}",
                             )
                             ax.plot(
                                 time,
-                                -pulse.shape.envelope_waveform_i.data,
+                                -pulse.shape.envelope_waveform_i(sampling_rate).data,
                                 c=f"C{str(n)}",
                             )
                         # TODO: if they overlap use different shades

--- a/tests/dummy_qrc/qblox.yml
+++ b/tests/dummy_qrc/qblox.yml
@@ -2,7 +2,6 @@ nqubits: 5
 
 settings:
     nshots: 1024
-    sampling_rate: 1_000_000_000
     relaxation_time: 20_000
 
 qubits: [0, 1, 2, 3, 4]

--- a/tests/dummy_qrc/qm.yml
+++ b/tests/dummy_qrc/qm.yml
@@ -4,7 +4,6 @@ qubits: [0, 1, 2, 3, 4]
 
 settings:
     nshots: 1024
-    sampling_rate: 1000000000
     relaxation_time: 50_000
 
 topology: [[0, 2], [1, 2], [2, 3], [2, 4]]

--- a/tests/dummy_qrc/rfsoc.py
+++ b/tests/dummy_qrc/rfsoc.py
@@ -21,7 +21,7 @@ def create(runcard_path=RUNCARD):
     Used in ``test_instruments_rfsoc.py``.
     """
     # Instantiate QICK instruments
-    controller = RFSoC("tii_rfsoc4x2", "0.0.0.0", 0)
+    controller = RFSoC("tii_rfsoc4x2", "0.0.0.0", 0, sampling_rate=9.8304)
 
     # Create channel objects and map to instrument controllers
     channels = ChannelMap()

--- a/tests/dummy_qrc/rfsoc.yml
+++ b/tests/dummy_qrc/rfsoc.yml
@@ -4,7 +4,6 @@ topology: []
 settings:
     nshots: 1024
     relaxation_time: 100000
-    sampling_rate: 9830400000
 instruments:
     twpa_a:
         frequency: 6_200_000_000

--- a/tests/dummy_qrc/zurich.yml
+++ b/tests/dummy_qrc/zurich.yml
@@ -4,7 +4,6 @@ couplers: [0, 1, 3, 4]
 topology: {0: [0, 2], 1: [1, 2], 3: [2, 3], 4: [2, 4]}
 settings:
     nshots: 4096
-    sampling_rate: 2.e+9
     relaxation_time: 300_000
 
 instruments:

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -125,9 +125,7 @@ def test_dummy_single_sweep_raw(name):
     results = platform.sweep(sequence, options, sweeper)
     assert pulse.serial and pulse.qubit in results
     shape = results[pulse.qubit].magnitude.shape
-    samples = platform.settings.sampling_rate * 1e-9 * pulse.duration
-
-    assert shape == (samples * SWEPT_POINTS,)
+    assert shape == (pulse.duration * SWEPT_POINTS,)
 
 
 @pytest.mark.parametrize("fast_reset", [True, False])

--- a/tests/test_instruments_qm.py
+++ b/tests/test_instruments_qm.py
@@ -205,7 +205,7 @@ def test_qmopx_register_pulse(dummy_qrc, pulse_type, qubit):
         target_pulse = {
             "operation": "control",
             "length": pulse.duration,
-            "waveforms": {"I": pulse.envelope_waveform_i.serial, "Q": pulse.envelope_waveform_q.serial},
+            "waveforms": {"I": pulse.envelope_waveform_i().serial, "Q": pulse.envelope_waveform_q().serial},
         }
 
     else:

--- a/tests/test_instruments_rfsoc.py
+++ b/tests/test_instruments_rfsoc.py
@@ -74,18 +74,18 @@ def test_replace_pulse_shape(dummy_qrc):
 
     pulse = rfsoc_pulses.Pulse(50, 0.9, 0, 0, 0.04, "name", "drive", 4, None)
 
-    new_pulse = replace_pulse_shape(pulse, Rectangular())
+    new_pulse = replace_pulse_shape(pulse, Rectangular(), sampling_rate=1e9)
     assert isinstance(new_pulse, rfsoc_pulses.Rectangular)
     for key in asdict(pulse):
         assert asdict(pulse)[key] == asdict(new_pulse)[key]
 
-    new_pulse = replace_pulse_shape(pulse, Gaussian(5))
+    new_pulse = replace_pulse_shape(pulse, Gaussian(5), sampling_rate=1e9)
     assert isinstance(new_pulse, rfsoc_pulses.Gaussian)
     assert new_pulse.rel_sigma == 5
     for key in asdict(pulse):
         assert asdict(pulse)[key] == asdict(new_pulse)[key]
 
-    new_pulse = replace_pulse_shape(pulse, Drag(5, 7))
+    new_pulse = replace_pulse_shape(pulse, Drag(5, 7), sampling_rate=1e9)
     assert isinstance(new_pulse, rfsoc_pulses.Drag)
     assert new_pulse.rel_sigma == 5
     assert new_pulse.beta == 7
@@ -108,15 +108,15 @@ def test_convert_pulse(dummy_qrc):
 
     pulse = Pulse(0, 40, 0.9, 50e6, 0, Drag(5, 2), 0, PulseType.DRIVE, 0)
     targ = rfsoc_pulses.Drag(50, 0.9, 0, 0, 0.04, pulse.serial, "drive", 4, None, rel_sigma=5, beta=2)
-    assert convert(pulse, platform.qubits, 0) == targ
+    assert convert(pulse, platform.qubits, 0, sampling_rate=1e9) == targ
 
     pulse = Pulse(0, 40, 0.9, 50e6, 0, Gaussian(2), 0, PulseType.DRIVE, 0)
     targ = rfsoc_pulses.Gaussian(50, 0.9, 0, 0, 0.04, pulse.serial, "drive", 4, None, rel_sigma=2)
-    assert convert(pulse, platform.qubits, 0) == targ
+    assert convert(pulse, platform.qubits, 0, sampling_rate=1e9) == targ
 
     pulse = Pulse(0, 40, 0.9, 50e6, 0, Rectangular(), 0, PulseType.READOUT, 0)
     targ = rfsoc_pulses.Rectangular(49, 0.9, 0, 0, 0.04, pulse.serial, "readout", 2, 1)
-    assert convert(pulse, platform.qubits, 0) == targ
+    assert convert(pulse, platform.qubits, 0, sampling_rate=1e9) == targ
 
 
 def test_convert_units_sweeper(dummy_qrc):

--- a/tests/test_instruments_rfsoc.py
+++ b/tests/test_instruments_rfsoc.py
@@ -74,18 +74,18 @@ def test_replace_pulse_shape(dummy_qrc):
 
     pulse = rfsoc_pulses.Pulse(50, 0.9, 0, 0, 0.04, "name", "drive", 4, None)
 
-    new_pulse = replace_pulse_shape(pulse, Rectangular(), sampling_rate=1e9)
+    new_pulse = replace_pulse_shape(pulse, Rectangular(), sampling_rate=1)
     assert isinstance(new_pulse, rfsoc_pulses.Rectangular)
     for key in asdict(pulse):
         assert asdict(pulse)[key] == asdict(new_pulse)[key]
 
-    new_pulse = replace_pulse_shape(pulse, Gaussian(5), sampling_rate=1e9)
+    new_pulse = replace_pulse_shape(pulse, Gaussian(5), sampling_rate=1)
     assert isinstance(new_pulse, rfsoc_pulses.Gaussian)
     assert new_pulse.rel_sigma == 5
     for key in asdict(pulse):
         assert asdict(pulse)[key] == asdict(new_pulse)[key]
 
-    new_pulse = replace_pulse_shape(pulse, Drag(5, 7), sampling_rate=1e9)
+    new_pulse = replace_pulse_shape(pulse, Drag(5, 7), sampling_rate=1)
     assert isinstance(new_pulse, rfsoc_pulses.Drag)
     assert new_pulse.rel_sigma == 5
     assert new_pulse.beta == 7
@@ -108,15 +108,15 @@ def test_convert_pulse(dummy_qrc):
 
     pulse = Pulse(0, 40, 0.9, 50e6, 0, Drag(5, 2), 0, PulseType.DRIVE, 0)
     targ = rfsoc_pulses.Drag(50, 0.9, 0, 0, 0.04, pulse.serial, "drive", 4, None, rel_sigma=5, beta=2)
-    assert convert(pulse, platform.qubits, 0, sampling_rate=1e9) == targ
+    assert convert(pulse, platform.qubits, 0, sampling_rate=1) == targ
 
     pulse = Pulse(0, 40, 0.9, 50e6, 0, Gaussian(2), 0, PulseType.DRIVE, 0)
     targ = rfsoc_pulses.Gaussian(50, 0.9, 0, 0, 0.04, pulse.serial, "drive", 4, None, rel_sigma=2)
-    assert convert(pulse, platform.qubits, 0, sampling_rate=1e9) == targ
+    assert convert(pulse, platform.qubits, 0, sampling_rate=1) == targ
 
     pulse = Pulse(0, 40, 0.9, 50e6, 0, Rectangular(), 0, PulseType.READOUT, 0)
     targ = rfsoc_pulses.Rectangular(49, 0.9, 0, 0, 0.04, pulse.serial, "readout", 2, 1)
-    assert convert(pulse, platform.qubits, 0, sampling_rate=1e9) == targ
+    assert convert(pulse, platform.qubits, 0, sampling_rate=1) == targ
 
 
 def test_convert_units_sweeper(dummy_qrc):

--- a/tests/test_instruments_zhinst.py
+++ b/tests/test_instruments_zhinst.py
@@ -38,7 +38,7 @@ def test_zhpulse(shape):
     zhpulse = ZhPulse(pulse)
     assert zhpulse.pulse.serial == pulse.serial
     if shape == "SNZ" or shape == "IIR":
-        assert len(zhpulse.zhpulse.samples) == 40 / 1e9 * 1e9  # * 2e9 When pulses stop hardcoding SamplingRate
+        assert len(zhpulse.zhpulse.samples) == 80
     else:
         assert zhpulse.zhpulse.length == 40e-9
 

--- a/tests/test_pulses.py
+++ b/tests/test_pulses.py
@@ -322,8 +322,8 @@ def test_pulses_pulse_serial():
 @pytest.mark.parametrize("shape", [Rectangular(), Gaussian(5), Drag(5, 1)])
 def test_pulses_pulseshape_sampling_rate(shape):
     pulse = Pulse(0, 40, 0.9, 100e6, 0, shape, 0, PulseType.DRIVE)
-    assert len(pulse.envelope_waveform_i(sampling_rate=1e9).data) == 40
-    assert len(pulse.envelope_waveform_i(sampling_rate=100e9).data) == 4000
+    assert len(pulse.envelope_waveform_i(sampling_rate=1).data) == 40
+    assert len(pulse.envelope_waveform_i(sampling_rate=100).data) == 4000
 
 
 def test_raise_shapeiniterror():
@@ -367,7 +367,7 @@ def test_raise_shapeiniterror():
 def test_pulses_pulseshape_drag_shape():
     pulse = Pulse(0, 2, 1, 4e9, 0, Drag(2, 1), 0, PulseType.DRIVE)
     # envelope i & envelope q should cross nearly at 0 and at 2
-    waveform = pulse.envelope_waveform_i(sampling_rate=10e9).data
+    waveform = pulse.envelope_waveform_i(sampling_rate=10).data
     target_waveform = np.array(
         [
             0.63683161,
@@ -753,8 +753,8 @@ def test_pulses_pulseshape_rectangular():
     assert isinstance(pulse.shape.modulated_waveform_i(), Waveform)
     assert isinstance(pulse.shape.modulated_waveform_q(), Waveform)
 
-    sampling_rate = 1e9
-    num_samples = int(pulse.duration / 1e9 * sampling_rate)
+    sampling_rate = 1
+    num_samples = int(pulse.duration / sampling_rate)
     i, q = pulse.amplitude * np.ones(num_samples), pulse.amplitude * np.zeros(num_samples)
     global_phase = 2 * np.pi * pulse._if * pulse.start / 1e9  # pulse start, duration and finish are in ns
     mod_i, mod_q = modulate(i, q, num_samples, pulse._if, global_phase + pulse.relative_phase, sampling_rate)
@@ -804,8 +804,8 @@ def test_pulses_pulseshape_gaussian():
     assert isinstance(pulse.shape.modulated_waveform_i(), Waveform)
     assert isinstance(pulse.shape.modulated_waveform_q(), Waveform)
 
-    sampling_rate = 1e9
-    num_samples = int(pulse.duration / 1e9 * sampling_rate)
+    sampling_rate = 1
+    num_samples = int(pulse.duration / sampling_rate)
     x = np.arange(0, num_samples, 1)
     i = pulse.amplitude * np.exp(
         -(1 / 2) * (((x - (num_samples - 1) / 2) ** 2) / (((num_samples) / pulse.shape.rel_sigma) ** 2))
@@ -860,8 +860,8 @@ def test_pulses_pulseshape_drag():
     assert isinstance(pulse.shape.modulated_waveform_i(), Waveform)
     assert isinstance(pulse.shape.modulated_waveform_q(), Waveform)
 
-    sampling_rate = 1e9
-    num_samples = int(pulse.duration / 1e9 * sampling_rate)
+    sampling_rate = 1
+    num_samples = int(pulse.duration / 1 * sampling_rate)
     x = np.arange(0, num_samples, 1)
     i = pulse.amplitude * np.exp(
         -(1 / 2) * (((x - (num_samples - 1) / 2) ** 2) / (((num_samples) / pulse.shape.rel_sigma) ** 2))
@@ -871,7 +871,6 @@ def test_pulses_pulseshape_drag():
         * (-(x - (num_samples - 1) / 2) / ((num_samples / pulse.shape.rel_sigma) ** 2))
         * i
         * sampling_rate
-        / 1e9
     )
     global_phase = 2 * np.pi * pulse._if * pulse.start / 1e9  # pulse start, duration and finish are in ns
     mod_i, mod_q = modulate(i, q, num_samples, pulse._if, global_phase + pulse.relative_phase, sampling_rate)


### PR DESCRIPTION
Fixes #448 as requested by @sorewachigauyo. The sampling rate cannot be hardcoded in the pulses which should be instrument agnostic, since we provide drevers for instruments with different sampling rates. I also removed the sampling rate from the platform settings as it is more of an instrument rather than a platform settting (this is up to discussion).

I hardcoded the sampling rate in the drivers for qblox, Zurich and QM, while for rfsoc I let the user pass it during instrument initialization as I guess different boards may have different specs.

The two main changes are:
1. All `pulse.envelope_waveform_i` etc. methods have been changed from properties to functions because the sampling rate is now needed as argument. I tried to propagate this to all places these are used, however it is likely I missed something.
2. Sampling rate should be removed from all runcards (moved in `create` for rfsoc) in the platforms repo.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
