### PR TITLE
Drop `pulse._if` dependence in Qblox

### DIFF
--- a/src/qibolab/instruments/qblox/controller.py
+++ b/src/qibolab/instruments/qblox/controller.py
@@ -170,11 +170,6 @@ class QbloxController(Controller):
             module_channels = self._set_module_channel_map(module, qubits)
             module_pulses[name] = sequence.get_channel_pulses(*module_channels)
 
-            if isinstance(module, (ClusterQRM_RF, ClusterQCM_RF)):
-                for pulse in module_pulses[name]:
-                    pulse_channel = module.channel_map[pulse.channel]
-                    pulse._if = int(pulse.frequency - pulse_channel.lo_frequency)
-
             #  ask each module to generate waveforms & program and upload them to the device
             module.process_pulse_sequence(
                 qubits,
@@ -229,9 +224,6 @@ class QbloxController(Controller):
             acquisition = options.results_type(np.squeeze(_res))
             data[ro_pulse.serial] = data[ro_pulse.qubit] = acquisition
 
-            # data[ro_pulse.serial] = ExecutionResults.from_components(*acquisition_results[ro_pulse.serial])
-            # data[ro_pulse.serial] = IntegratedResults(acquisition_results[ro_pulse.serial])
-            # data[ro_pulse.qubit] = copy.copy(data[ro_pulse.serial])
         return data
 
     def play(self, qubits, couplers, sequence, options):


### PR DESCRIPTION
`Pulse._if` was assigned in `_execute_pulse_sequence` of the controller but never actually used anywhere, so I just dropped it.
Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
