### PR TITLE
PulseSequence to list

### DIFF
--- a/doc/source/getting-started/experiment.rst
+++ b/doc/source/getting-started/experiment.rst
@@ -151,7 +151,7 @@ We leave to the dedicated tutorial a full explanation of the experiment, but her
     # define the pulse sequence
     sequence = PulseSequence()
     ro_pulse = platform.create_MZ_pulse(qubit=0, start=0)
-    sequence.add(ro_pulse)
+    sequence.append(ro_pulse)
 
     # define a sweeper for a frequency scan
     sweeper = Sweeper(

--- a/doc/source/main-documentation/qibolab.rst
+++ b/doc/source/main-documentation/qibolab.rst
@@ -64,9 +64,9 @@ Now we can create a simple sequence (again, without explicitly giving any qubit 
    from qibolab.pulses import PulseSequence
 
    ps = PulseSequence()
-   ps.add(platform.create_RX_pulse(qubit=0, start=0))  # start time is in ns
-   ps.add(platform.create_RX_pulse(qubit=0, start=100))
-   ps.add(platform.create_MZ_pulse(qubit=0, start=200))
+   ps.append(platform.create_RX_pulse(qubit=0, start=0))  # start time is in ns
+   ps.append(platform.create_RX_pulse(qubit=0, start=100))
+   ps.append(platform.create_MZ_pulse(qubit=0, start=200))
 
 Now we can execute the sequence on hardware:
 
@@ -354,15 +354,15 @@ To organize pulses into sequences, Qibolab provides the :class:`qibolab.pulses.P
         channel="channel",
         qubit=0,
     )
-    sequence.add(pulse1)
-    sequence.add(pulse2)
-    sequence.add(pulse3)
-    sequence.add(pulse4)
+    sequence.append(pulse1)
+    sequence.append(pulse2)
+    sequence.append(pulse3)
+    sequence.append(pulse4)
 
     print(f"Total duration: {sequence.duration}")
 
     sequence_ch1 = sequence.get_channel_pulses("channel1")  # Selecting pulses on channel 1
-    print(f"We have {sequence_ch1.count} pulses on channel 1.")
+    print(f"We have {len(sequence_ch1)} pulses on channel 1.")
 
 .. testoutput:: python
     :hide:
@@ -390,8 +390,8 @@ Typical experiments may include both pre-defined pulses and new ones:
     from qibolab.pulses import Rectangular
 
     sequence = PulseSequence()
-    sequence.add(platform.create_RX_pulse(0))
-    sequence.add(
+    sequence.append(platform.create_RX_pulse(0))
+    sequence.append(
         DrivePulse(
             start=0,
             duration=10,
@@ -402,7 +402,7 @@ Typical experiments may include both pre-defined pulses and new ones:
             channel="0",
         )
     )
-    sequence.add(platform.create_MZ_pulse(0, start=0))
+    sequence.append(platform.create_MZ_pulse(0, start=0))
 
     results = platform.execute_pulse_sequence(sequence, options=options)
 
@@ -474,9 +474,15 @@ A tipical resonator spectroscopy experiment could be defined with:
     from qibolab.sweeper import Parameter, Sweeper, SweeperType
 
     sequence = PulseSequence()
-    sequence.add(platform.create_MZ_pulse(0, start=0))  # readout pulse for qubit 0 at 4 GHz
-    sequence.add(platform.create_MZ_pulse(1, start=0))  # readout pulse for qubit 1 at 5 GHz
-    sequence.add(platform.create_MZ_pulse(2, start=0))  # readout pulse for qubit 2 at 6 GHz
+    sequence.append(
+        platform.create_MZ_pulse(0, start=0)
+    )  # readout pulse for qubit 0 at 4 GHz
+    sequence.append(
+        platform.create_MZ_pulse(1, start=0)
+    )  # readout pulse for qubit 1 at 5 GHz
+    sequence.append(
+        platform.create_MZ_pulse(2, start=0)
+    )  # readout pulse for qubit 2 at 6 GHz
 
     sweeper = Sweeper(
         parameter=Parameter.frequency,
@@ -511,8 +517,8 @@ For example:
 
     sequence = PulseSequence()
 
-    sequence.add(platform.create_RX_pulse(0))
-    sequence.add(platform.create_MZ_pulse(0, start=sequence[0].finish))
+    sequence.append(platform.create_RX_pulse(0))
+    sequence.append(platform.create_MZ_pulse(0, start=sequence[0].finish))
 
     sweeper_freq = Sweeper(
         parameter=Parameter.frequency,
@@ -609,8 +615,8 @@ Let's now delve into a typical use case for result objects within the qibolab fr
     measurement_pulse = platform.create_qubit_readout_pulse(0, start=0)
 
     sequence = PulseSequence()
-    sequence.add(drive_pulse_1)
-    sequence.add(measurement_pulse)
+    sequence.append(drive_pulse_1)
+    sequence.append(measurement_pulse)
 
     options = ExecutionParameters(
         nshots=1000,

--- a/doc/source/tutorials/calibration.rst
+++ b/doc/source/tutorials/calibration.rst
@@ -44,7 +44,7 @@ around the pre-defined frequency.
     # create pulse sequence and add pulse
     sequence = PulseSequence()
     readout_pulse = platform.create_MZ_pulse(qubit=0, start=0)
-    sequence.add(readout_pulse)
+    sequence.append(readout_pulse)
 
     # allocate frequency sweeper
     sweeper = Sweeper(
@@ -127,8 +127,8 @@ complex pulse sequence. Therefore with start with that:
     drive_pulse.duration = 2000
     drive_pulse.amplitude = 0.01
     readout_pulse = platform.create_MZ_pulse(qubit=0, start=drive_pulse.finish)
-    sequence.add(drive_pulse)
-    sequence.add(readout_pulse)
+    sequence.append(drive_pulse)
+    sequence.append(readout_pulse)
 
     # allocate frequency sweeper
     sweeper = Sweeper(
@@ -220,13 +220,13 @@ and its impact on qubit states in the IQ plane.
     one_sequence = PulseSequence()
     drive_pulse = platform.create_RX_pulse(qubit=0, start=0)
     readout_pulse1 = platform.create_MZ_pulse(qubit=0, start=drive_pulse.finish)
-    one_sequence.add(drive_pulse)
-    one_sequence.add(readout_pulse1)
+    one_sequence.append(drive_pulse)
+    one_sequence.append(readout_pulse1)
 
     # create pulse sequence 2 and add pulses
     zero_sequence = PulseSequence()
     readout_pulse2 = platform.create_MZ_pulse(qubit=0, start=0)
-    zero_sequence.add(readout_pulse2)
+    zero_sequence.append(readout_pulse2)
 
     options = ExecutionParameters(
         nshots=1000,

--- a/doc/source/tutorials/pulses.rst
+++ b/doc/source/tutorials/pulses.rst
@@ -4,7 +4,7 @@ Pulses execution
 First, we create the pulse sequence that will be executed. We can do this by
 defining a :class:`qibolab.pulses.PulseSequence` object and adding different
 pulses (:class:`qibolab.pulses.Pulse`) through the
-:func:`qibolab.pulses.PulseSequence.add()` method:
+:func:`qibolab.pulses.PulseSequence.append()` method:
 
 .. testcode::  python
 
@@ -20,7 +20,7 @@ pulses (:class:`qibolab.pulses.Pulse`) through the
     sequence = PulseSequence()
 
     # Add some pulses to the pulse sequence
-    sequence.add(
+    sequence.append(
         DrivePulse(
             start=0,
             frequency=200000000,
@@ -31,7 +31,7 @@ pulses (:class:`qibolab.pulses.Pulse`) through the
             qubit=0,
         )
     )
-    sequence.add(
+    sequence.append(
         ReadoutPulse(
             start=70,
             frequency=20000000.0,

--- a/doc/source/tutorials/transpiler.rst
+++ b/doc/source/tutorials/transpiler.rst
@@ -112,7 +112,7 @@ The following example shows how to modify the transpiler and compiler in order t
         """X gate applied with a single pi-pulse."""
         qubit = gate.target_qubits[0]
         sequence = PulseSequence()
-        sequence.add(platform.create_RX_pulse(qubit, start=0))
+        sequence.append(platform.create_RX_pulse(qubit, start=0))
         return sequence, {}
 
 

--- a/examples/minimum_working_example.py
+++ b/examples/minimum_working_example.py
@@ -5,7 +5,7 @@ from qibolab.pulses import Pulse, PulseSequence, ReadoutPulse
 # Define PulseSequence
 sequence = PulseSequence()
 # Add some pulses to the pulse sequence
-sequence.add(
+sequence.append(
     Pulse(
         start=0,
         amplitude=0.3,
@@ -18,7 +18,7 @@ sequence.add(
     )
 )
 
-sequence.add(
+sequence.append(
     ReadoutPulse(
         start=4004,
         amplitude=0.9,

--- a/src/qibolab/backends.py
+++ b/src/qibolab/backends.py
@@ -64,7 +64,7 @@ class QibolabBackend(NumpyBackend):
                 containing the readout measurement shots. This is created in ``execute_circuit``.
         """
         for gate, sequence in measurement_map.items():
-            _samples = (readout[pulse.serial].samples for pulse in sequence.pulses)
+            _samples = (readout[pulse.serial].samples for pulse in sequence)
             samples = list(filter(lambda x: x is not None, _samples))
             gate.result.backend = self
             gate.result.register_samples(np.array(samples).T)
@@ -157,7 +157,7 @@ class QibolabBackend(NumpyBackend):
             )
             for gate, sequence in measurement_map.items():
                 samples = [
-                    readout[pulse.serial].popleft().samples for pulse in sequence.pulses
+                    readout[pulse.serial].popleft().samples for pulse in sequence
                 ]
                 gate.result.backend = self
                 gate.result.register_samples(np.array(samples).T)

--- a/src/qibolab/compilers/compiler.py
+++ b/src/qibolab/compilers/compiler.py
@@ -117,7 +117,7 @@ class Compiler:
             pulse.start += start
             if not isinstance(pulse, ReadoutPulse):
                 pulse.relative_phase += virtual_z_phases[pulse.qubit]
-            sequence.add(pulse)
+            sequence.append(pulse)
 
         return gate_sequence, gate_phases
 

--- a/src/qibolab/compilers/default.py
+++ b/src/qibolab/compilers/default.py
@@ -30,7 +30,7 @@ def gpi2_rule(gate, platform):
     theta = gate.parameters[0]
     sequence = PulseSequence()
     pulse = platform.create_RX90_pulse(qubit, start=0, relative_phase=theta)
-    sequence.add(pulse)
+    sequence.append(pulse)
     return sequence, {}
 
 
@@ -47,7 +47,7 @@ def u3_rule(gate, platform):
         qubit, start=0, relative_phase=virtual_z_phases[qubit]
     )
     # apply RX(pi/2)
-    sequence.add(RX90_pulse_1)
+    sequence.append(RX90_pulse_1)
     # apply RZ(theta)
     virtual_z_phases[qubit] += theta
     # Fetch pi/2 pulse from calibration
@@ -57,7 +57,7 @@ def u3_rule(gate, platform):
         relative_phase=virtual_z_phases[qubit] - math.pi,
     )
     # apply RX(-pi/2)
-    sequence.add(RX90_pulse_2)
+    sequence.append(RX90_pulse_2)
     # apply RZ(phi)
     virtual_z_phases[qubit] += phi
 
@@ -78,5 +78,5 @@ def measurement_rule(gate, platform):
     sequence = PulseSequence()
     for qubit in gate.target_qubits:
         MZ_pulse = platform.create_MZ_pulse(qubit, start=0)
-        sequence.add(MZ_pulse)
+        sequence.append(MZ_pulse)
     return sequence, {}

--- a/src/qibolab/instruments/qblox/cluster_qcm_bb.py
+++ b/src/qibolab/instruments/qblox/cluster_qcm_bb.py
@@ -357,7 +357,7 @@ class ClusterQCM_BB(ClusterModule):
                             sequencer.waveforms_buffer.add_waveforms(
                                 pulse, self._ports[port].hardware_mod_en, sweepers
                             )
-                            sequencer.pulses.add(pulse)
+                            sequencer.pulses.append(pulse)
                             pulses_to_be_processed.remove(pulse)
 
                         # if there is not enough memory in the current sequencer, use another one

--- a/src/qibolab/instruments/qblox/cluster_qcm_rf.py
+++ b/src/qibolab/instruments/qblox/cluster_qcm_rf.py
@@ -382,7 +382,7 @@ class ClusterQCM_RF(ClusterModule):
                             sequencer.waveforms_buffer.add_waveforms(
                                 pulse, self._ports[port].hardware_mod_en, sweepers
                             )
-                            sequencer.pulses.add(pulse)
+                            sequencer.pulses.append(pulse)
                             pulses_to_be_processed.remove(pulse)
 
                         # if there is not enough memory in the current sequencer, use another one

--- a/src/qibolab/instruments/qblox/cluster_qrm_rf.py
+++ b/src/qibolab/instruments/qblox/cluster_qrm_rf.py
@@ -442,7 +442,7 @@ class ClusterQRM_RF(ClusterModule):
                         sequencer.waveforms_buffer.add_waveforms(
                             pulse, self._ports[port].hardware_mod_en, sweepers
                         )
-                        sequencer.pulses.add(pulse)
+                        sequencer.pulses.append(pulse)
                         pulses_to_be_processed.remove(pulse)
 
                     # if there is not enough memory in the current sequencer, use another one

--- a/src/qibolab/instruments/qm/sequence.py
+++ b/src/qibolab/instruments/qm/sequence.py
@@ -266,9 +266,7 @@ class Sequence:
         # like we do for readout multiplex
         duration_sweep_pulses = find_duration_sweeper_pulses(sweepers)
         qmsequence = cls()
-        for pulse in sorted(
-            sequence.pulses, key=lambda pulse: (pulse.start, pulse.duration)
-        ):
+        for pulse in sorted(sequence, key=lambda pulse: (pulse.start, pulse.duration)):
             config.register_element(
                 qubits[pulse.qubit], pulse, time_of_flight, smearing
             )

--- a/src/qibolab/instruments/rfsoc/convert.py
+++ b/src/qibolab/instruments/rfsoc/convert.py
@@ -93,7 +93,7 @@ def _(
     """Convert PulseSequence to list of rfosc pulses with relative time."""
     last_pulse_start = 0
     list_sequence = []
-    for pulse in sorted(sequence.pulses, key=lambda item: item.start):
+    for pulse in sorted(sequence, key=lambda item: item.start):
         start_delay = (pulse.start - last_pulse_start) * NS_TO_US
         pulse_dict = asdict(convert(pulse, qubits, start_delay, sampling_rate))
         list_sequence.append(pulse_dict)

--- a/src/qibolab/native.py
+++ b/src/qibolab/native.py
@@ -247,12 +247,12 @@ class NativeSequence:
 
         for pulse in self.pulses:
             if isinstance(pulse, NativePulse):
-                sequence.add(pulse.pulse(start=start))
+                sequence.append(pulse.pulse(start=start))
             else:
                 virtual_z_phases[pulse.qubit.name] += pulse.phase
 
         for coupler_pulse in self.coupler_pulses:
-            sequence.add(coupler_pulse.pulse(start=start))
+            sequence.append(coupler_pulse.pulse(start=start))
         # TODO: Maybe ``virtual_z_phases`` should be an attribute of ``PulseSequence``
         return sequence, virtual_z_phases
 

--- a/src/qibolab/platform.py
+++ b/src/qibolab/platform.py
@@ -47,7 +47,7 @@ def unroll_sequences(
         for pulse in sequence:
             new_pulse = pulse.copy()
             new_pulse.start += start
-            total_sequence.add(new_pulse)
+            total_sequence.append(new_pulse)
             if isinstance(pulse, ReadoutPulse):
                 readout_map[pulse.serial].append(new_pulse.serial)
         start = total_sequence.finish + relaxation_time

--- a/src/qibolab/platform.py
+++ b/src/qibolab/platform.py
@@ -288,7 +288,7 @@ class Platform:
                 sequence = PulseSequence()
                 parameter = Parameter.frequency
                 pulse = platform.create_qubit_readout_pulse(qubit=0, start=0)
-                sequence.add(pulse)
+                sequence.append(pulse)
                 parameter_range = np.random.randint(10, size=10)
                 sweeper = Sweeper(parameter, parameter_range, [pulse])
                 platform.sweep(sequence, ExecutionParameters(), sweeper)

--- a/src/qibolab/pulses.py
+++ b/src/qibolab/pulses.py
@@ -1234,15 +1234,19 @@ class PulseSequence(list):
     """
 
     def __add__(self, other):
+        """Return self+value."""
         return type(self)(super().__add__(other))
 
     def __mul__(self, other):
+        """Return self*value."""
         return type(self)(super().__mul__(other))
 
     def __repr__(self):
+        """Return repr(self)."""
         return f"{type(self).__name__}({super().__repr__()})"
 
     def copy(self):
+        """Return a shallow copy of the sequence."""
         return type(self)(super().copy())
 
     @property

--- a/src/qibolab/pulses.py
+++ b/src/qibolab/pulses.py
@@ -881,7 +881,7 @@ class Pulse:
         if isinstance(other, Pulse):
             return PulseSequence(self, other)
         if isinstance(other, PulseSequence):
-            return PulseSequence(self, *other.pulses)
+            return PulseSequence(self, *other)
         raise TypeError(f"Expected Pulse or PulseSequence; got {type(other).__name__}")
 
     def __mul__(self, n):
@@ -1234,16 +1234,7 @@ class PulseSequence(list):
     """
 
     def __repr__(self):
-        return self.serial
-
-    @property
-    def serial(self):
-        """Returns a string representation of the pulse sequence."""
-
-        return "PulseSequence\n" + "\n".join(f"{pulse.serial}" for pulse in self.pulses)
-
-    def __hash__(self):
-        return hash(self.serial)
+        return f"{type(self).__name__}({super().__repr__()})"
 
     @property
     def ro_pulses(self):
@@ -1252,7 +1243,7 @@ class PulseSequence(list):
         new_pc = PulseSequence()
         for pulse in self.pulses:
             if pulse.type == PulseType.READOUT:
-                new_pc.add(pulse)
+                new_pc.append(pulse)
         return new_pc
 
     @property
@@ -1261,9 +1252,9 @@ class PulseSequence(list):
         pulses."""
 
         new_pc = PulseSequence()
-        for pulse in self.pulses:
+        for pulse in self:
             if pulse.type == PulseType.DRIVE:
-                new_pc.add(pulse)
+                new_pc.append(pulse)
         return new_pc
 
     @property
@@ -1272,9 +1263,9 @@ class PulseSequence(list):
         pulses."""
 
         new_pc = PulseSequence()
-        for pulse in self.pulses:
+        for pulse in self:
             if pulse.type == PulseType.FLUX:
-                new_pc.add(pulse)
+                new_pc.append(pulse)
         return new_pc
 
     @property
@@ -1283,9 +1274,9 @@ class PulseSequence(list):
         pulses."""
 
         new_pc = PulseSequence()
-        for pulse in self.pulses:
+        for pulse in self:
             if pulse.type is PulseType.COUPLERFLUX:
-                new_pc.add(pulse)
+                new_pc.append(pulse)
         return new_pc
 
     def get_channel_pulses(self, *channels):
@@ -1293,9 +1284,9 @@ class PulseSequence(list):
         set of channels."""
 
         new_pc = PulseSequence()
-        for pulse in self.pulses:
+        for pulse in self:
             if pulse.channel in channels:
-                new_pc.add(pulse)
+                new_pc.append(pulse)
         return new_pc
 
     def get_qubit_pulses(self, *qubits):
@@ -1303,10 +1294,10 @@ class PulseSequence(list):
         set of qubits."""
 
         new_pc = PulseSequence()
-        for pulse in self.pulses:
+        for pulse in self:
             if not isinstance(pulse, CouplerFluxPulse):
                 if pulse.qubit in qubits:
-                    new_pc.add(pulse)
+                    new_pc.append(pulse)
         return new_pc
 
     def coupler_pulses(self, *couplers):
@@ -1314,10 +1305,10 @@ class PulseSequence(list):
         set of couplers."""
 
         new_pc = PulseSequence()
-        for pulse in self.pulses:
+        for pulse in self:
             if isinstance(pulse, CouplerFluxPulse):
                 if pulse.qubit in couplers:
-                    new_pc.add(pulse)
+                    new_pc.append(pulse)
         return new_pc
 
     @property
@@ -1325,7 +1316,7 @@ class PulseSequence(list):
         """Returns the time when the last pulse of the sequence finishes."""
 
         t: int = 0
-        for pulse in self.pulses:
+        for pulse in self:
             if pulse.finish > t:
                 t = pulse.finish
         return t
@@ -1335,7 +1326,7 @@ class PulseSequence(list):
         """Returns the start time of the first pulse of the sequence."""
 
         t = self.finish
-        for pulse in self.pulses:
+        for pulse in self:
             if pulse.start < t:
                 t = pulse.start
         return t
@@ -1352,7 +1343,7 @@ class PulseSequence(list):
         sequence."""
 
         channels = []
-        for pulse in self.pulses:
+        for pulse in self:
             if not pulse.channel in channels:
                 channels.append(pulse.channel)
         channels.sort()
@@ -1364,7 +1355,7 @@ class PulseSequence(list):
         sequence."""
 
         qubits = []
-        for pulse in self.pulses:
+        for pulse in self:
             if not pulse.qubit in qubits:
                 qubits.append(pulse.qubit)
         qubits.sort()
@@ -1375,7 +1366,7 @@ class PulseSequence(list):
         times) where pulses overlap."""
 
         times = []
-        for pulse in self.pulses:
+        for pulse in self:
             if not pulse.start in times:
                 times.append(pulse.start)
             if not pulse.finish in times:
@@ -1385,7 +1376,7 @@ class PulseSequence(list):
         overlaps = {}
         for n in range(len(times) - 1):
             overlaps[(times[n], times[n + 1])] = PulseSequence()
-            for pulse in self.pulses:
+            for pulse in self:
                 if (pulse.start <= times[n]) & (pulse.finish >= times[n + 1]):
                     overlaps[(times[n], times[n + 1])] += pulse
         return overlaps
@@ -1398,7 +1389,7 @@ class PulseSequence(list):
         # but it does not check if the frequencies of the pulses within a set have the same frequency
 
         separated_pulses = []
-        for new_pulse in self.pulses:
+        for new_pulse in self:
             stored = False
             for ps in separated_pulses:
                 overlaps = False
@@ -1410,7 +1401,7 @@ class PulseSequence(list):
                         overlaps = True
                         break
                 if not overlaps:
-                    ps.add(new_pulse)
+                    ps.append(new_pulse)
                     stored = True
                     break
             if not stored:
@@ -1436,14 +1427,14 @@ class PulseSequence(list):
             savefig_filename (str): a file path. If provided the plot is save to a file.
         """
 
-        if not self.is_empty:
+        if len(self) > 0:
             import matplotlib.pyplot as plt
             from matplotlib import gridspec
 
             fig = plt.figure(figsize=(14, 2 * self.count), dpi=200)
             gs = gridspec.GridSpec(ncols=1, nrows=self.count)
             vertical_lines = []
-            for pulse in self.pulses:
+            for pulse in self:
                 vertical_lines.append(pulse.start)
                 vertical_lines.append(pulse.finish)
 

--- a/src/qibolab/pulses.py
+++ b/src/qibolab/pulses.py
@@ -1233,6 +1233,12 @@ class PulseSequence(list):
     modify any of the properties of its pulses.
     """
 
+    def __add__(self, other):
+        return PulseSequence(super().__add__(other))
+
+    def __mul__(self, other):
+        return PulseSequence(super().__mul__(other))
+
     def __repr__(self):
         return f"{type(self).__name__}({super().__repr__()})"
 
@@ -1378,7 +1384,7 @@ class PulseSequence(list):
             overlaps[(times[n], times[n + 1])] = PulseSequence()
             for pulse in self:
                 if (pulse.start <= times[n]) & (pulse.finish >= times[n + 1]):
-                    overlaps[(times[n], times[n + 1])] += pulse
+                    overlaps[(times[n], times[n + 1])] += [pulse]
         return overlaps
 
     def separate_overlapping_pulses(self):  # -> dict((int,int): PulseSequence):
@@ -1405,7 +1411,7 @@ class PulseSequence(list):
                     stored = True
                     break
             if not stored:
-                separated_pulses.append(PulseSequence(new_pulse))
+                separated_pulses.append(PulseSequence([new_pulse]))
         return separated_pulses
 
     # TODO: Implement separate_different_frequency_pulses()
@@ -1416,8 +1422,9 @@ class PulseSequence(list):
 
         overlap = False
         for pc in self.get_pulse_overlaps().values():
-            if pc.count > 1:
+            if len(pc) > 1:
                 overlap = True
+                break
         return overlap
 
     def plot(self, savefig_filename=None, sampling_rate=SAMPLING_RATE):
@@ -1431,8 +1438,8 @@ class PulseSequence(list):
             import matplotlib.pyplot as plt
             from matplotlib import gridspec
 
-            fig = plt.figure(figsize=(14, 2 * self.count), dpi=200)
-            gs = gridspec.GridSpec(ncols=1, nrows=self.count)
+            fig = plt.figure(figsize=(14, 2 * len(self)), dpi=200)
+            gs = gridspec.GridSpec(ncols=1, nrows=len(self))
             vertical_lines = []
             for pulse in self:
                 vertical_lines.append(pulse.start)

--- a/src/qibolab/pulses.py
+++ b/src/qibolab/pulses.py
@@ -1234,13 +1234,16 @@ class PulseSequence(list):
     """
 
     def __add__(self, other):
-        return PulseSequence(super().__add__(other))
+        return type(self)(super().__add__(other))
 
     def __mul__(self, other):
-        return PulseSequence(super().__mul__(other))
+        return type(self)(super().__mul__(other))
 
     def __repr__(self):
         return f"{type(self).__name__}({super().__repr__()})"
+
+    def copy(self):
+        return type(self)(super().copy())
 
     @property
     def ro_pulses(self):

--- a/src/qibolab/pulses.py
+++ b/src/qibolab/pulses.py
@@ -1223,7 +1223,7 @@ class PulseConstructor(Enum):
     FLUX = FluxPulse
 
 
-class PulseSequence:
+class PulseSequence(list):
     """A collection of scheduled pulses.
 
     A quantum circuit can be translated into a set of scheduled pulses
@@ -1232,30 +1232,6 @@ class PulseSequence:
     these collections of pulses. None of the methods of PulseSequence
     modify any of the properties of its pulses.
     """
-
-    def __init__(self, *pulses):
-        self.pulses = []  #: list[Pulse] = []
-        """Pulses (list): a list containing the pulses, ordered by their
-        channel and start times."""
-        self.add(*pulses)
-
-    def __len__(self):
-        return len(self.pulses)
-
-    def __iter__(self):
-        return iter(self.pulses)
-
-    def __getitem__(self, index):
-        return self.pulses[index]
-
-    def __setitem__(self, index, value):
-        self.pulses[index] = value
-
-    def __delitem__(self, index):
-        del self.pulses[index]
-
-    def __contains__(self, pulse):
-        return pulse in self.pulses
 
     def __repr__(self):
         return self.serial
@@ -1266,127 +1242,8 @@ class PulseSequence:
 
         return "PulseSequence\n" + "\n".join(f"{pulse.serial}" for pulse in self.pulses)
 
-    def __eq__(self, other):
-        if not isinstance(other, PulseSequence):
-            raise TypeError(f"Expected PulseSequence; got {type(other).__name__}")
-        return self.serial == other.serial
-
-    def __ne__(self, other):
-        if not isinstance(other, PulseSequence):
-            raise TypeError(f"Expected PulseSequence; got {type(other).__name__}")
-        return self.serial != other.serial
-
     def __hash__(self):
         return hash(self.serial)
-
-    def __add__(self, other):
-        if isinstance(other, PulseSequence):
-            return PulseSequence(*self.pulses, *other.pulses)
-        if isinstance(other, Pulse):
-            return PulseSequence(*self.pulses, other)
-        raise TypeError(f"Expected PulseSequence or Pulse; got {type(other).__name__}")
-
-    def __radd__(self, other):
-        if isinstance(other, PulseSequence):
-            return PulseSequence(*other.pulses, *self.pulses)
-        if isinstance(other, Pulse):
-            return PulseSequence(other, *self.pulses)
-        raise TypeError(f"Expected PulseSequence or Pulse; got {type(other).__name__}")
-
-    def __iadd__(self, other):
-        if isinstance(other, PulseSequence):
-            self.add(*other.pulses)
-        elif isinstance(other, Pulse):
-            self.add(other)
-        else:
-            raise TypeError(
-                f"Expected PulseSequence or Pulse; got {type(other).__name__}"
-            )
-        return self
-
-    def __mul__(self, n):
-        if not isinstance(n, int):
-            raise TypeError(f"Expected int; got {type(n).__name__}")
-        if n < 0:
-            raise TypeError(f"argument n should be >=0, got {n}")
-        return PulseSequence(*(self.pulses * n))
-
-    def __rmul__(self, n):
-        if not isinstance(n, int):
-            raise TypeError(f"Expected int; got {type(n).__name__}")
-        if n < 0:
-            raise TypeError(f"argument n should be >=0, got {n}")
-        return PulseSequence(*(self.pulses * n))
-
-    def __imul__(self, n):
-        if not isinstance(n, int):
-            raise TypeError(f"Expected int; got {type(n).__name__}")
-        if n < 1:
-            raise TypeError(f"argument n should be >=1, got {n}")
-        original_set = self.shallow_copy()
-        for x in range(n - 1):
-            self.add(*original_set.pulses)
-        return self
-
-    @property
-    def count(self):
-        """Returns the number of pulses in the sequence."""
-
-        return len(self.pulses)
-
-    def add(self, *items):
-        """Adds pulses to the sequence and sorts them by channel and start
-        time."""
-
-        for item in items:
-            if isinstance(item, Pulse):
-                pulse = item
-                self.pulses.append(pulse)
-            elif isinstance(item, PulseSequence):
-                ps = item
-                for pulse in ps.pulses:
-                    self.pulses.append(pulse)
-        self.pulses.sort(key=lambda item: (item.start, item.channel))
-
-    def index(self, pulse):
-        """Returns the index of a pulse in the sequence."""
-
-        return self.pulses.index(pulse)
-
-    def pop(self, index=-1):
-        """Returns the pulse with the index provided and removes it from the
-        sequence."""
-
-        return self.pulses.pop(index)
-
-    def remove(self, pulse):
-        """Removes a pulse from the sequence."""
-
-        while pulse in self.pulses:
-            self.pulses.remove(pulse)
-
-    def clear(self):
-        """Removes all pulses from the sequence."""
-
-        self.pulses.clear()
-
-    def shallow_copy(self):
-        """Returns a shallow copy of the sequence.
-
-        It returns a new PulseSequence object with references to the
-        same Pulse objects.
-        """
-
-        return PulseSequence(*self.pulses)
-
-    def copy(self):
-        """Returns a deep copy of the sequence.
-
-        It returns a new PulseSequence with replicates of each of the
-        pulses contained in the original sequence.
-        """
-
-        return PulseSequence(*[pulse.copy() for pulse in self.pulses])
 
     @property
     def ro_pulses(self):
@@ -1462,12 +1319,6 @@ class PulseSequence:
                 if pulse.qubit in couplers:
                     new_pc.add(pulse)
         return new_pc
-
-    @property
-    def is_empty(self):
-        """Returns True if the sequence does not contain any pulses."""
-
-        return len(self.pulses) == 0
 
     @property
     def finish(self) -> int:

--- a/src/qibolab/pulses.py
+++ b/src/qibolab/pulses.py
@@ -1241,7 +1241,7 @@ class PulseSequence(list):
         """Returns a new PulseSequence containing only its readout pulses."""
 
         new_pc = PulseSequence()
-        for pulse in self.pulses:
+        for pulse in self:
             if pulse.type == PulseType.READOUT:
                 new_pc.append(pulse)
         return new_pc

--- a/src/qibolab/sweeper.py
+++ b/src/qibolab/sweeper.py
@@ -65,7 +65,7 @@ class Sweeper:
             sequence = PulseSequence()
             parameter = Parameter.frequency
             pulse = platform.create_qubit_readout_pulse(qubit=0, start=0)
-            sequence.add(pulse)
+            sequence.append(pulse)
             parameter_range = np.random.randint(10, size=10)
             sweeper = Sweeper(parameter, parameter_range, [pulse])
             platform.sweep(sequence, ExecutionParameters(), sweeper)

--- a/tests/test_compilers_default.py
+++ b/tests/test_compilers_default.py
@@ -77,7 +77,7 @@ def test_compile_two_gates(platform):
     circuit = transpile_circuit(circuit, platform)
     sequence = compile_circuit(circuit, platform)
 
-    assert len(sequence.pulses) == 5
+    assert len(sequence) == 5
     assert len(sequence.qd_pulses) == 4
     assert len(sequence.ro_pulses) == 1
 
@@ -107,14 +107,14 @@ def test_gpi2_to_sequence(platform):
     circuit = Circuit(1)
     circuit.add(gates.GPI2(0, phi=0.2))
     sequence = compile_circuit(circuit, platform)
-    assert len(sequence.pulses) == 1
+    assert len(sequence) == 1
     assert len(sequence.qd_pulses) == 1
 
-    RX90_pulse = platform.create_RX90_pulse(0, start=0, relative_phase=0.2)
-    s = PulseSequence(RX90_pulse)
+    rx90_pulse = platform.create_RX90_pulse(0, start=0, relative_phase=0.2)
+    s = PulseSequence([rx90_pulse])
 
-    np.testing.assert_allclose(sequence.duration, RX90_pulse.duration)
-    assert sequence.serial == s.serial
+    np.testing.assert_allclose(sequence.duration, rx90_pulse.duration)
+    assert sequence == s
 
 
 def test_u3_to_sequence(platform):
@@ -122,19 +122,19 @@ def test_u3_to_sequence(platform):
     circuit.add(gates.U3(0, 0.1, 0.2, 0.3))
 
     sequence = compile_circuit(circuit, platform)
-    assert len(sequence.pulses) == 2
+    assert len(sequence) == 2
     assert len(sequence.qd_pulses) == 2
 
-    RX90_pulse1 = platform.create_RX90_pulse(0, start=0, relative_phase=0.3)
-    RX90_pulse2 = platform.create_RX90_pulse(
-        0, start=RX90_pulse1.finish, relative_phase=0.4 - np.pi
+    rx90_pulse1 = platform.create_RX90_pulse(0, start=0, relative_phase=0.3)
+    rx90_pulse2 = platform.create_RX90_pulse(
+        0, start=rx90_pulse1.finish, relative_phase=0.4 - np.pi
     )
-    s = PulseSequence(RX90_pulse1, RX90_pulse2)
+    s = PulseSequence([rx90_pulse1, rx90_pulse2])
 
     np.testing.assert_allclose(
-        sequence.duration, RX90_pulse1.duration + RX90_pulse2.duration
+        sequence.duration, rx90_pulse1.duration + rx90_pulse2.duration
     )
-    assert sequence.serial == s.serial
+    assert sequence == s
 
 
 def test_two_u3_to_sequence(platform):
@@ -143,25 +143,25 @@ def test_two_u3_to_sequence(platform):
     circuit.add(gates.U3(0, 0.4, 0.6, 0.5))
 
     sequence = compile_circuit(circuit, platform)
-    assert len(sequence.pulses) == 4
+    assert len(sequence) == 4
     assert len(sequence.qd_pulses) == 4
 
-    RX90_pulse = platform.create_RX90_pulse(0)
+    rx90_pulse = platform.create_RX90_pulse(0)
 
-    np.testing.assert_allclose(sequence.duration, 2 * 2 * RX90_pulse.duration)
+    np.testing.assert_allclose(sequence.duration, 2 * 2 * rx90_pulse.duration)
 
-    RX90_pulse1 = platform.create_RX90_pulse(0, start=0, relative_phase=0.3)
-    RX90_pulse2 = platform.create_RX90_pulse(
-        0, start=RX90_pulse1.finish, relative_phase=0.4 - np.pi
+    rx90_pulse1 = platform.create_RX90_pulse(0, start=0, relative_phase=0.3)
+    rx90_pulse2 = platform.create_RX90_pulse(
+        0, start=rx90_pulse1.finish, relative_phase=0.4 - np.pi
     )
-    RX90_pulse3 = platform.create_RX90_pulse(
-        0, start=RX90_pulse2.finish, relative_phase=1.1
+    rx90_pulse3 = platform.create_RX90_pulse(
+        0, start=rx90_pulse2.finish, relative_phase=1.1
     )
-    RX90_pulse4 = platform.create_RX90_pulse(
-        0, start=RX90_pulse3.finish, relative_phase=1.5 - np.pi
+    rx90_pulse4 = platform.create_RX90_pulse(
+        0, start=rx90_pulse3.finish, relative_phase=1.5 - np.pi
     )
-    s = PulseSequence(RX90_pulse1, RX90_pulse2, RX90_pulse3, RX90_pulse4)
-    assert sequence.serial == s.serial
+    s = PulseSequence([rx90_pulse1, rx90_pulse2, rx90_pulse3, rx90_pulse4])
+    assert sequence == s
 
 
 def test_cz_to_sequence(platform):
@@ -177,7 +177,7 @@ def test_cz_to_sequence(platform):
     circuit = transpile_circuit(circuit, platform)
     sequence = compile_circuit(circuit, platform)
     test_sequence, virtual_z_phases = platform.create_CZ_pulse_sequence((2, 1))
-    assert len(sequence.pulses) == len(test_sequence) + 2
+    assert len(sequence) == len(test_sequence) + 2
 
 
 def test_add_measurement_to_sequence(platform):
@@ -186,17 +186,17 @@ def test_add_measurement_to_sequence(platform):
     circuit.add(gates.M(0))
 
     sequence = compile_circuit(circuit, platform)
-    assert len(sequence.pulses) == 3
+    assert len(sequence) == 3
     assert len(sequence.qd_pulses) == 2
     assert len(sequence.ro_pulses) == 1
 
-    RX90_pulse1 = platform.create_RX90_pulse(0, start=0, relative_phase=0.3)
-    RX90_pulse2 = platform.create_RX90_pulse(
-        0, start=RX90_pulse1.finish, relative_phase=0.4 - np.pi
+    rx90_pulse1 = platform.create_RX90_pulse(0, start=0, relative_phase=0.3)
+    rx90_pulse2 = platform.create_RX90_pulse(
+        0, start=rx90_pulse1.finish, relative_phase=0.4 - np.pi
     )
-    MZ_pulse = platform.create_MZ_pulse(0, start=RX90_pulse2.finish)
-    s = PulseSequence(RX90_pulse1, RX90_pulse2, MZ_pulse)
-    assert sequence.serial == s.serial
+    mz_pulse = platform.create_MZ_pulse(0, start=rx90_pulse2.finish)
+    s = PulseSequence([rx90_pulse1, rx90_pulse2, mz_pulse])
+    assert sequence == s
 
 
 @pytest.mark.parametrize("delay", [0, 100])
@@ -206,9 +206,9 @@ def test_align_delay_measurement(platform, delay):
     circuit.add(gates.M(0))
 
     sequence = compile_circuit(circuit, platform)
-    assert len(sequence.pulses) == 1
+    assert len(sequence) == 1
     assert len(sequence.ro_pulses) == 1
 
-    MZ_pulse = platform.create_MZ_pulse(0, start=delay)
-    s = PulseSequence(MZ_pulse)
-    assert sequence.serial == s.serial
+    mz_pulse = platform.create_MZ_pulse(0, start=delay)
+    s = PulseSequence([mz_pulse])
+    assert sequence == s

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -64,18 +64,16 @@ def test_dummy_execute_pulse_sequence_couplers():
         qubits=(qubit_ordered_pair.qubit1.name, qubit_ordered_pair.qubit2.name),
         start=0,
     )
-    sequence.append(cz.get_qubit_pulses(qubit_ordered_pair.qubit1.name))
-    sequence.append(cz.get_qubit_pulses(qubit_ordered_pair.qubit2.name))
-    sequence.append(cz.coupler_pulses(qubit_ordered_pair.coupler.name))
+    sequence.extend(cz.get_qubit_pulses(qubit_ordered_pair.qubit1.name))
+    sequence.extend(cz.get_qubit_pulses(qubit_ordered_pair.qubit2.name))
+    sequence.extend(cz.coupler_pulses(qubit_ordered_pair.coupler.name))
     sequence.append(platform.create_qubit_readout_pulse(0, 40))
     sequence.append(platform.create_qubit_readout_pulse(2, 40))
     options = ExecutionParameters(nshots=None)
     result = platform.execute_pulse_sequence(sequence, options)
 
-    test_pulses = "PulseSequence\nFluxPulse(0, 30, 0.05, GaussianSquare(5, 0.75), flux-2, 2)\nCouplerFluxPulse(0, 30, 0.05, GaussianSquare(5, 0.75), flux_coupler-1, 1)"
     test_phases = {1: 0.0, 2: 0.0}
 
-    assert test_pulses == cz.serial
     assert test_phases == cz_phases
 
 

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -26,8 +26,8 @@ def test_dummy_execute_pulse_sequence(name, acquisition):
     platform = create_platform(name)
     ro_pulse = platform.create_qubit_readout_pulse(0, 0)
     sequence = PulseSequence()
-    sequence.add(platform.create_qubit_readout_pulse(0, 0))
-    sequence.add(platform.create_RX12_pulse(0, 0))
+    sequence.append(platform.create_qubit_readout_pulse(0, 0))
+    sequence.append(platform.create_RX12_pulse(0, 0))
     options = ExecutionParameters(nshots=100, acquisition_type=acquisition)
     result = platform.execute_pulse_sequence(sequence, options)
     if acquisition is AcquisitionType.INTEGRATION:
@@ -41,7 +41,7 @@ def test_dummy_execute_coupler_pulse():
     sequence = PulseSequence()
 
     pulse = platform.create_coupler_pulse(coupler=0, start=0)
-    sequence.add(pulse)
+    sequence.append(pulse)
 
     options = ExecutionParameters(nshots=None)
     result = platform.execute_pulse_sequence(sequence, options)
@@ -64,11 +64,11 @@ def test_dummy_execute_pulse_sequence_couplers():
         qubits=(qubit_ordered_pair.qubit1.name, qubit_ordered_pair.qubit2.name),
         start=0,
     )
-    sequence.add(cz.get_qubit_pulses(qubit_ordered_pair.qubit1.name))
-    sequence.add(cz.get_qubit_pulses(qubit_ordered_pair.qubit2.name))
-    sequence.add(cz.coupler_pulses(qubit_ordered_pair.coupler.name))
-    sequence.add(platform.create_qubit_readout_pulse(0, 40))
-    sequence.add(platform.create_qubit_readout_pulse(2, 40))
+    sequence.append(cz.get_qubit_pulses(qubit_ordered_pair.qubit1.name))
+    sequence.append(cz.get_qubit_pulses(qubit_ordered_pair.qubit2.name))
+    sequence.append(cz.coupler_pulses(qubit_ordered_pair.coupler.name))
+    sequence.append(platform.create_qubit_readout_pulse(0, 40))
+    sequence.append(platform.create_qubit_readout_pulse(2, 40))
     options = ExecutionParameters(nshots=None)
     result = platform.execute_pulse_sequence(sequence, options)
 
@@ -83,7 +83,7 @@ def test_dummy_execute_pulse_sequence_couplers():
 def test_dummy_execute_pulse_sequence_fast_reset(name):
     platform = create_platform(name)
     sequence = PulseSequence()
-    sequence.add(platform.create_qubit_readout_pulse(0, 0))
+    sequence.append(platform.create_qubit_readout_pulse(0, 0))
     options = ExecutionParameters(nshots=None, fast_reset=True)
     result = platform.execute_pulse_sequence(sequence, options)
 
@@ -100,7 +100,7 @@ def test_dummy_execute_pulse_sequence_unrolling(name, acquisition, batch_size):
     platform.instruments["dummy"].UNROLLING_BATCH_SIZE = batch_size
     sequences = []
     sequence = PulseSequence()
-    sequence.add(platform.create_qubit_readout_pulse(0, 0))
+    sequence.append(platform.create_qubit_readout_pulse(0, 0))
     for _ in range(nsequences):
         sequences.append(sequence)
     options = ExecutionParameters(nshots=nshots, acquisition_type=acquisition)
@@ -120,7 +120,7 @@ def test_dummy_single_sweep_raw(name):
     pulse = platform.create_qubit_readout_pulse(qubit=0, start=0)
 
     parameter_range = np.random.randint(SWEPT_POINTS, size=SWEPT_POINTS)
-    sequence.add(pulse)
+    sequence.append(pulse)
     sweeper = Sweeper(Parameter.frequency, parameter_range, pulses=[pulse])
     options = ExecutionParameters(
         nshots=10,
@@ -160,7 +160,7 @@ def test_dummy_single_sweep_coupler(
         parameter_range = np.random.rand(SWEPT_POINTS)
     else:
         parameter_range = np.random.randint(SWEPT_POINTS, size=SWEPT_POINTS)
-    sequence.add(ro_pulse)
+    sequence.append(ro_pulse)
     if parameter in QubitParameter:
         sweeper = Sweeper(parameter, parameter_range, couplers=[platform.couplers[0]])
     else:
@@ -207,7 +207,7 @@ def test_dummy_single_sweep(name, fast_reset, parameter, average, acquisition, n
         parameter_range = np.random.rand(SWEPT_POINTS)
     else:
         parameter_range = np.random.randint(SWEPT_POINTS, size=SWEPT_POINTS)
-    sequence.add(pulse)
+    sequence.append(pulse)
     if parameter in QubitParameter:
         sweeper = Sweeper(parameter, parameter_range, qubits=[platform.qubits[0]])
     else:
@@ -250,8 +250,8 @@ def test_dummy_double_sweep(name, parameter1, parameter2, average, acquisition, 
     sequence = PulseSequence()
     pulse = platform.create_qubit_drive_pulse(qubit=0, start=0, duration=1000)
     ro_pulse = platform.create_qubit_readout_pulse(qubit=0, start=pulse.finish)
-    sequence.add(pulse)
-    sequence.add(ro_pulse)
+    sequence.append(pulse)
+    sequence.append(ro_pulse)
     parameter_range_1 = (
         np.random.rand(SWEPT_POINTS)
         if parameter1 is Parameter.amplitude
@@ -315,7 +315,7 @@ def test_dummy_single_sweep_multiplex(name, parameter, average, acquisition, nsh
     ro_pulses = {}
     for qubit in platform.qubits:
         ro_pulses[qubit] = platform.create_qubit_readout_pulse(qubit=qubit, start=0)
-        sequence.add(ro_pulses[qubit])
+        sequence.append(ro_pulses[qubit])
     parameter_range = (
         np.random.rand(SWEPT_POINTS)
         if parameter is Parameter.amplitude

--- a/tests/test_instruments_qblox.py
+++ b/tests/test_instruments_qblox.py
@@ -285,13 +285,13 @@ It supports:
 #     instrument_pulses[name] = PulseSequence()
 #     if "QCM" in instrument.__class__.__name__:
 #         for channel in instrument.channel_port_map:
-#             instrument_pulses[name].add(Pulse(0, 200, 1, 10e6, np.pi / 2, "Gaussian(5)", str(channel)))
+#             instrument_pulses[name].append(Pulse(0, 200, 1, 10e6, np.pi / 2, "Gaussian(5)", str(channel)))
 #         instrument.process_pulse_sequence(instrument_pulses[name], nshots=5, relaxation_time=relaxation_time)
 #         instrument.upload()
 #         instrument.play_sequence()
 #     if "QRM" in instrument.__class__.__name__:
 #         channel = instrument._port_channel_map["o1"]
-#         instrument_pulses[name].add(
+#         instrument_pulses[name].append(
 #             Pulse(0, 200, 1, 10e6, np.pi / 2, "Gaussian(5)", channel),
 #             ReadoutPulse(200, 2000, 1, 10e6, np.pi / 2, "Rectangular()", channel),
 #         )

--- a/tests/test_instruments_qblox_cluster_qcm_bb.py
+++ b/tests/test_instruments_qblox_cluster_qcm_bb.py
@@ -136,10 +136,10 @@ def test_connect(connected_qcm_bb: ClusterQCM_BB):
 @pytest.mark.qpu
 def test_pulse_sequence(connected_platform, connected_qcm_bb: ClusterQCM_BB):
     ps = PulseSequence()
-    ps.add(FluxPulse(40, 70, 0.5, "Rectangular", O1_OUTPUT_CHANNEL))
-    ps.add(FluxPulse(0, 50, 0.3, "Rectangular", O2_OUTPUT_CHANNEL))
-    ps.add(FluxPulse(20, 100, 0.02, "Rectangular", O3_OUTPUT_CHANNEL))
-    ps.add(FluxPulse(32, 48, 0.4, "Rectangular", O4_OUTPUT_CHANNEL))
+    ps.append(FluxPulse(40, 70, 0.5, "Rectangular", O1_OUTPUT_CHANNEL))
+    ps.append(FluxPulse(0, 50, 0.3, "Rectangular", O2_OUTPUT_CHANNEL))
+    ps.append(FluxPulse(20, 100, 0.02, "Rectangular", O3_OUTPUT_CHANNEL))
+    ps.append(FluxPulse(32, 48, 0.4, "Rectangular", O4_OUTPUT_CHANNEL))
     qubits = connected_platform.qubits
     connected_qcm_bb._ports["o2"].hardware_mod_en = True
     connected_qcm_bb.process_pulse_sequence(qubits, ps, 1000, 1, 10000)
@@ -155,10 +155,10 @@ def test_pulse_sequence(connected_platform, connected_qcm_bb: ClusterQCM_BB):
 @pytest.mark.qpu
 def test_sweepers(connected_platform, connected_qcm_bb: ClusterQCM_BB):
     ps = PulseSequence()
-    ps.add(FluxPulse(40, 70, 0.5, "Rectangular", O1_OUTPUT_CHANNEL))
-    ps.add(FluxPulse(0, 50, 0.3, "Rectangular", O2_OUTPUT_CHANNEL))
-    ps.add(FluxPulse(20, 100, 0.02, "Rectangular", O3_OUTPUT_CHANNEL))
-    ps.add(FluxPulse(32, 48, 0.4, "Rectangular", O4_OUTPUT_CHANNEL))
+    ps.append(FluxPulse(40, 70, 0.5, "Rectangular", O1_OUTPUT_CHANNEL))
+    ps.append(FluxPulse(0, 50, 0.3, "Rectangular", O2_OUTPUT_CHANNEL))
+    ps.append(FluxPulse(20, 100, 0.02, "Rectangular", O3_OUTPUT_CHANNEL))
+    ps.append(FluxPulse(32, 48, 0.4, "Rectangular", O4_OUTPUT_CHANNEL))
     qubits = connected_platform.qubits
 
     amplitude_range = np.linspace(0, 0.25, 50)

--- a/tests/test_instruments_qblox_cluster_qcm_rf.py
+++ b/tests/test_instruments_qblox_cluster_qcm_rf.py
@@ -151,7 +151,7 @@ def test_connect(connected_qcm_rf: ClusterQCM_RF):
 @pytest.mark.qpu
 def test_pulse_sequence(connected_platform, connected_qcm_rf: ClusterQCM_RF):
     ps = PulseSequence()
-    ps.add(
+    ps.append(
         DrivePulse(
             0,
             200,
@@ -162,7 +162,7 @@ def test_pulse_sequence(connected_platform, connected_qcm_rf: ClusterQCM_RF):
             O1_OUTPUT_CHANNEL,
         )
     )
-    ps.add(
+    ps.append(
         DrivePulse(
             0,
             200,
@@ -189,7 +189,7 @@ def test_pulse_sequence(connected_platform, connected_qcm_rf: ClusterQCM_RF):
 @pytest.mark.qpu
 def test_sweepers(connected_platform, connected_qcm_rf: ClusterQCM_RF):
     ps = PulseSequence()
-    ps.add(
+    ps.append(
         DrivePulse(
             0,
             200,
@@ -200,7 +200,7 @@ def test_sweepers(connected_platform, connected_qcm_rf: ClusterQCM_RF):
             O1_OUTPUT_CHANNEL,
         )
     )
-    ps.add(
+    ps.append(
         DrivePulse(
             0,
             200,

--- a/tests/test_instruments_qblox_cluster_qrm_rf.py
+++ b/tests/test_instruments_qblox_cluster_qrm_rf.py
@@ -145,13 +145,13 @@ def test_connect(connected_qrm_rf: ClusterQRM_RF):
 def test_pulse_sequence(connected_platform, connected_qrm_rf: ClusterQRM_RF):
     ps = PulseSequence()
     for channel in connected_qrm_rf.channel_map:
-        ps.add(DrivePulse(0, 200, 1, 6.8e9, np.pi / 2, "Gaussian(5)", channel))
-        ps.add(
+        ps.append(DrivePulse(0, 200, 1, 6.8e9, np.pi / 2, "Gaussian(5)", channel))
+        ps.append(
             ReadoutPulse(
                 200, 2000, 1, 7.1e9, np.pi / 2, "Rectangular()", channel, qubit=0
             )
         )
-        ps.add(
+        ps.append(
             ReadoutPulse(
                 200, 2000, 1, 7.2e9, np.pi / 2, "Rectangular()", channel, qubit=1
             )
@@ -184,7 +184,7 @@ def test_sweepers(connected_platform, connected_qrm_rf: ClusterQRM_RF):
         ro_pulses[1] = ReadoutPulse(
             200, 2000, 1, 7.2e9, np.pi / 2, "Rectangular()", channel, qubit=1
         )
-        ps.add(qd_pulses[0], ro_pulses[0], ro_pulses[1])
+        ps.append(qd_pulses[0], ro_pulses[0], ro_pulses[1])
 
     qubits = connected_platform.qubits
 

--- a/tests/test_instruments_qm.py
+++ b/tests/test_instruments_qm.py
@@ -367,8 +367,8 @@ def test_qmopx_qubit_spectroscopy(mocker):
         ro_pulses[qubit] = platform.create_qubit_readout_pulse(
             qubit, start=qd_pulses[qubit].finish
         )
-        sequence.add(qd_pulses[qubit])
-        sequence.add(ro_pulses[qubit])
+        sequence.append(qd_pulses[qubit])
+        sequence.append(ro_pulses[qubit])
     options = ExecutionParameters(nshots=1024, relaxation_time=100000)
     result = opx.play(platform.qubits, platform.couplers, sequence, options)
 
@@ -382,8 +382,8 @@ def test_qmopx_duration_sweeper(mocker):
     qubit = 1
     sequence = PulseSequence()
     qd_pulse = platform.create_RX_pulse(qubit, start=0)
-    sequence.add(qd_pulse)
-    sequence.add(platform.create_MZ_pulse(qubit, start=qd_pulse.finish))
+    sequence.append(qd_pulse)
+    sequence.append(platform.create_MZ_pulse(qubit, start=qd_pulse.finish))
     sweeper = Sweeper(Parameter.duration, np.arange(2, 12, 2), pulses=[qd_pulse])
     options = ExecutionParameters(nshots=1024, relaxation_time=100000)
     result = opx.sweep(platform.qubits, platform.couplers, sequence, options, sweeper)

--- a/tests/test_instruments_qmsim.py
+++ b/tests/test_instruments_qmsim.py
@@ -119,7 +119,7 @@ def test_qmsim_resonator_spectroscopy(simulator, folder):
     ro_pulses = {}
     for qubit in qubits:
         ro_pulses[qubit] = simulator.create_qubit_readout_pulse(qubit, start=0)
-        sequence.add(ro_pulses[qubit])
+        sequence.append(ro_pulses[qubit])
     options = ExecutionParameters(nshots=1)
     result = simulator.execute_pulse_sequence(sequence, options)
     samples = result.get_simulated_samples()
@@ -139,8 +139,8 @@ def test_qmsim_qubit_spectroscopy(simulator, folder):
         ro_pulses[qubit] = simulator.create_qubit_readout_pulse(
             qubit, start=qd_pulses[qubit].finish
         )
-        sequence.add(qd_pulses[qubit])
-        sequence.add(ro_pulses[qubit])
+        sequence.append(qd_pulses[qubit])
+        sequence.append(ro_pulses[qubit])
     options = ExecutionParameters(nshots=1)
     result = simulator.execute_pulse_sequence(sequence, options)
     samples = result.get_simulated_samples()
@@ -165,8 +165,8 @@ def test_qmsim_sweep(simulator, folder, parameter, values):
         ro_pulses[qubit] = simulator.create_MZ_pulse(
             qubit, start=qd_pulses[qubit].finish
         )
-        sequence.add(qd_pulses[qubit])
-        sequence.add(ro_pulses[qubit])
+        sequence.append(qd_pulses[qubit])
+        sequence.append(ro_pulses[qubit])
     pulses = [qd_pulses[qubit] for qubit in qubits]
     sweeper = Sweeper(parameter, values, pulses)
     options = ExecutionParameters(
@@ -186,7 +186,7 @@ def test_qmsim_sweep_bias(simulator, folder):
     ro_pulses = {}
     for qubit in qubits:
         ro_pulses[qubit] = simulator.create_MZ_pulse(qubit, start=0)
-        sequence.add(ro_pulses[qubit])
+        sequence.append(ro_pulses[qubit])
     values = [0, 0.005]
     sweeper = Sweeper(
         Parameter.bias, values, qubits=[simulator.qubits[q] for q in qubits]
@@ -212,8 +212,8 @@ def test_qmsim_sweep_start(simulator, folder):
         ro_pulses[qubit] = simulator.create_MZ_pulse(
             qubit, start=qd_pulses[qubit].finish
         )
-        sequence.add(qd_pulses[qubit])
-        sequence.add(ro_pulses[qubit])
+        sequence.append(qd_pulses[qubit])
+        sequence.append(ro_pulses[qubit])
     values = [20, 40]
     pulses = [ro_pulses[qubit] for qubit in qubits]
     sweeper = Sweeper(Parameter.start, values, pulses=pulses)
@@ -242,9 +242,9 @@ def test_qmsim_sweep_start_two_pulses(simulator, folder):
         ro_pulses[qubit] = simulator.create_MZ_pulse(
             qubit, start=qd_pulses2[qubit].finish
         )
-        sequence.add(qd_pulses1[qubit])
-        sequence.add(qd_pulses2[qubit])
-        sequence.add(ro_pulses[qubit])
+        sequence.append(qd_pulses1[qubit])
+        sequence.append(qd_pulses2[qubit])
+        sequence.append(ro_pulses[qubit])
     values = [20, 60]
     pulses = [qd_pulses2[qubit] for qubit in qubits]
     sweeper = Sweeper(Parameter.start, values, pulses=pulses)
@@ -272,8 +272,8 @@ def test_qmsim_sweep_duration(simulator, folder):
         ro_pulses[qubit] = simulator.create_MZ_pulse(
             qubit, start=qd_pulses[qubit].finish
         )
-        sequence.add(qd_pulses[qubit])
-        sequence.add(ro_pulses[qubit])
+        sequence.append(qd_pulses[qubit])
+        sequence.append(ro_pulses[qubit])
     values = [20, 60]
     pulses = [qd_pulses[qubit] for qubit in qubits]
     sweeper = Sweeper(Parameter.duration, values, pulses=pulses)
@@ -306,9 +306,9 @@ def test_qmsim_sweep_duration_two_pulses(simulator, folder):
         ro_pulses[qubit] = simulator.create_MZ_pulse(
             qubit, start=qd_pulses2[qubit].finish
         )
-        sequence.add(qd_pulses1[qubit])
-        sequence.add(qd_pulses2[qubit])
-        sequence.add(ro_pulses[qubit])
+        sequence.append(qd_pulses1[qubit])
+        sequence.append(qd_pulses2[qubit])
+        sequence.append(ro_pulses[qubit])
     values = [20, 60]
     pulses = [qd_pulses1[qubit] for qubit in qubits]
     sweeper = Sweeper(Parameter.duration, values, pulses=pulses)
@@ -372,9 +372,9 @@ def test_qmsim_allxy(simulator, folder, count, gate_pair):
         for gate in gate_pair:
             pulse = allxy_pulses[gate](qubit, start)
             if pulse is not None:
-                sequence.add(pulse)
+                sequence.append(pulse)
                 start += pulse.duration
-        sequence.add(simulator.create_MZ_pulse(qubit, start=start))
+        sequence.append(simulator.create_MZ_pulse(qubit, start=start))
 
     options = ExecutionParameters(nshots=1)
     result = simulator.execute_pulse_sequence(sequence, options)
@@ -402,11 +402,11 @@ def test_qmsim_chevron(simulator, folder, sweep):
         highfreq, start=flux_pulse.finish
     )
     sequence = PulseSequence()
-    sequence.add(initialize_1)
-    sequence.add(initialize_2)
-    sequence.add(flux_pulse)
-    sequence.add(measure_lowfreq)
-    sequence.add(measure_highfreq)
+    sequence.append(initialize_1)
+    sequence.append(initialize_2)
+    sequence.append(flux_pulse)
+    sequence.append(measure_lowfreq)
+    sequence.append(measure_highfreq)
 
     options = ExecutionParameters(
         nshots=1,
@@ -493,9 +493,9 @@ def test_qmsim_snz_pulse(simulator, folder, qubit):
     qd_pulse = simulator.create_RX_pulse(qubit, start=0)
     flux_pulse = FluxPulse(qd_pulse.finish, duration, amplitude, shape, channel, qubit)
     ro_pulse = simulator.create_MZ_pulse(qubit, start=flux_pulse.finish)
-    sequence.add(qd_pulse)
-    sequence.add(flux_pulse)
-    sequence.add(ro_pulse)
+    sequence.append(qd_pulse)
+    sequence.append(flux_pulse)
+    sequence.append(ro_pulse)
     options = ExecutionParameters(nshots=1)
     result = simulator.execute_pulse_sequence(sequence, options)
     samples = result.get_simulated_samples()
@@ -506,9 +506,9 @@ def test_qmsim_snz_pulse(simulator, folder, qubit):
 def test_qmsim_bell_circuit(simulator, folder, qubits):
     backend = QibolabBackend(simulator)
     circuit = Circuit(5)
-    circuit.add(gates.H(qubits[0]))
-    circuit.add(gates.CNOT(*qubits))
-    circuit.add(gates.M(*qubits))
+    circuit.append(gates.H(qubits[0]))
+    circuit.append(gates.CNOT(*qubits))
+    circuit.append(gates.M(*qubits))
     result = backend.execute_circuit(circuit, nshots=1)
     result = result.execution_result
     samples = result.get_simulated_samples()
@@ -519,10 +519,10 @@ def test_qmsim_bell_circuit(simulator, folder, qubits):
 def test_qmsim_ghz_circuit(simulator, folder):
     backend = QibolabBackend(simulator)
     circuit = Circuit(5)
-    circuit.add(gates.H(2))
-    circuit.add(gates.CNOT(2, 1))
-    circuit.add(gates.CNOT(2, 3))
-    circuit.add(gates.M(1, 2, 3))
+    circuit.append(gates.H(2))
+    circuit.append(gates.CNOT(2, 1))
+    circuit.append(gates.CNOT(2, 3))
+    circuit.append(gates.M(1, 2, 3))
     result = backend.execute_circuit(circuit, nshots=1)
     result = result.execution_result
     samples = result.get_simulated_samples()

--- a/tests/test_instruments_rfsoc.py
+++ b/tests/test_instruments_rfsoc.py
@@ -32,7 +32,7 @@ def test_convert_default(dummy_qrc):
     integer = 12
     qubits = platform.qubits
     sequence = PulseSequence()
-    sequence.add(Pulse(0, 40, 0.9, 50e6, 0, Drag(5, 2), 0, PulseType.DRIVE, 0))
+    sequence.append(Pulse(0, 40, 0.9, 50e6, 0, Drag(5, 2), 0, PulseType.DRIVE, 0))
     parameter = Parameter.frequency
 
     with pytest.raises(ValueError):
@@ -140,8 +140,8 @@ def test_convert_units_sweeper(dummy_qrc):
     seq = PulseSequence()
     pulse0 = Pulse(0, 40, 0.9, 50e6, 0, Gaussian(2), 0, PulseType.DRIVE, 0)
     pulse1 = Pulse(40, 40, 0.9, 50e6, 0, Rectangular(), 0, PulseType.READOUT, 0)
-    seq.add(pulse0)
-    seq.add(pulse1)
+    seq.append(pulse0)
+    seq.append(pulse1)
 
     # frequency sweeper
     sweeper = rfsoc.Sweeper(
@@ -208,8 +208,8 @@ def test_convert_sweep(dummy_qrc):
     seq = PulseSequence()
     pulse0 = Pulse(0, 40, 0.9, 50e6, 0, Gaussian(2), 0, PulseType.DRIVE, 0)
     pulse1 = Pulse(40, 40, 0.9, 50e6, 0, Rectangular(), 0, PulseType.READOUT, 0)
-    seq.add(pulse0)
-    seq.add(pulse1)
+    seq.append(pulse0)
+    seq.append(pulse1)
 
     sweeper = Sweeper(
         parameter=Parameter.bias, values=np.arange(-0.5, +0.5, 0.1), qubits=[qubit]
@@ -318,8 +318,8 @@ def test_play(mocker, dummy_qrc):
     seq = PulseSequence()
     pulse0 = Pulse(0, 40, 0.9, 50e6, 0, Gaussian(2), 0, PulseType.DRIVE, 0)
     pulse1 = Pulse(40, 40, 0.9, 50e6, 0, Rectangular(), 0, PulseType.READOUT, 0)
-    seq.add(pulse0)
-    seq.add(pulse1)
+    seq.append(pulse0)
+    seq.append(pulse1)
 
     nshots = 100
     server_results = ([[np.random.rand(nshots)]], [[np.random.rand(nshots)]])
@@ -359,8 +359,8 @@ def test_sweep(mocker, dummy_qrc):
     seq = PulseSequence()
     pulse0 = Pulse(0, 40, 0.9, 50e6, 0, Gaussian(2), 0, PulseType.DRIVE, 0)
     pulse1 = Pulse(40, 40, 0.9, 50e6, 0, Rectangular(), 0, PulseType.READOUT, 0)
-    seq.add(pulse0)
-    seq.add(pulse1)
+    seq.append(pulse0)
+    seq.append(pulse1)
     sweeper0 = Sweeper(
         parameter=Parameter.frequency, values=np.arange(0, 100, 1), pulses=[pulse0]
     )
@@ -409,8 +409,8 @@ def test_validate_input_command(dummy_qrc):
     seq = PulseSequence()
     pulse0 = Pulse(0, 40, 0.9, 50e6, 0, Gaussian(2), 0, PulseType.DRIVE, 0)
     pulse1 = Pulse(40, 40, 0.9, 50e6, 0, Rectangular(), 0, PulseType.READOUT, 0)
-    seq.add(pulse0)
-    seq.add(pulse1)
+    seq.append(pulse0)
+    seq.append(pulse1)
 
     parameters = ExecutionParameters(acquisition_type=AcquisitionType.RAW)
     with pytest.raises(NotImplementedError):
@@ -428,8 +428,8 @@ def test_update_cfg(mocker, dummy_qrc):
     seq = PulseSequence()
     pulse0 = Pulse(0, 40, 0.9, 50e6, 0, Gaussian(2), 0, PulseType.DRIVE, 0)
     pulse1 = Pulse(40, 40, 0.9, 50e6, 0, Rectangular(), 0, PulseType.READOUT, 0)
-    seq.add(pulse0)
-    seq.add(pulse1)
+    seq.append(pulse0)
+    seq.append(pulse1)
 
     nshots = 333
     relax_time = 1e6
@@ -521,8 +521,8 @@ def test_get_if_python_sweep(dummy_qrc):
     instrument = platform.instruments["tii_rfsoc4x2"]
 
     sequence_1 = PulseSequence()
-    sequence_1.add(platform.create_RX_pulse(qubit=0, start=0))
-    sequence_1.add(platform.create_MZ_pulse(qubit=0, start=100))
+    sequence_1.append(platform.create_RX_pulse(qubit=0, start=0))
+    sequence_1.append(platform.create_MZ_pulse(qubit=0, start=100))
 
     sweep1 = Sweeper(
         parameter=Parameter.frequency,
@@ -548,7 +548,7 @@ def test_get_if_python_sweep(dummy_qrc):
     assert not instrument.get_if_python_sweep(sequence_1, sweep3)
 
     sequence_2 = PulseSequence()
-    sequence_2.add(platform.create_RX_pulse(qubit=0, start=0))
+    sequence_2.append(platform.create_RX_pulse(qubit=0, start=0))
 
     sweep1 = Sweeper(
         parameter=Parameter.frequency,
@@ -571,7 +571,7 @@ def test_get_if_python_sweep(dummy_qrc):
     instrument = platform.instruments["tii_rfsoc4x2"]
 
     sequence_1 = PulseSequence()
-    sequence_1.add(platform.create_RX_pulse(qubit=0, start=0))
+    sequence_1.append(platform.create_RX_pulse(qubit=0, start=0))
     sweep1 = Sweeper(
         parameter=Parameter.frequency,
         values=np.arange(10, 100, 10),
@@ -606,9 +606,9 @@ def test_convert_av_sweep_results(dummy_qrc):
     instrument = platform.instruments["tii_rfsoc4x2"]
 
     sequence = PulseSequence()
-    sequence.add(platform.create_RX_pulse(qubit=0, start=0))
-    sequence.add(platform.create_MZ_pulse(qubit=0, start=100))
-    sequence.add(platform.create_MZ_pulse(qubit=0, start=200))
+    sequence.append(platform.create_RX_pulse(qubit=0, start=0))
+    sequence.append(platform.create_MZ_pulse(qubit=0, start=100))
+    sequence.append(platform.create_MZ_pulse(qubit=0, start=200))
     sweep1 = Sweeper(
         parameter=Parameter.frequency,
         values=np.arange(10, 35, 10),
@@ -659,9 +659,9 @@ def test_convert_nav_sweep_results(dummy_qrc):
     instrument = platform.instruments["tii_rfsoc4x2"]
 
     sequence = PulseSequence()
-    sequence.add(platform.create_RX_pulse(qubit=0, start=0))
-    sequence.add(platform.create_MZ_pulse(qubit=0, start=100))
-    sequence.add(platform.create_MZ_pulse(qubit=0, start=200))
+    sequence.append(platform.create_RX_pulse(qubit=0, start=0))
+    sequence.append(platform.create_MZ_pulse(qubit=0, start=100))
+    sequence.append(platform.create_MZ_pulse(qubit=0, start=200))
     sweep1 = Sweeper(
         parameter=Parameter.frequency,
         values=np.arange(10, 35, 10),
@@ -719,8 +719,8 @@ def test_call_executepulsesequence(connected_platform, instrument):
     instrument = platform.instruments["tii_rfsoc4x2"]
 
     sequence = PulseSequence()
-    sequence.add(platform.create_RX_pulse(qubit=0, start=0))
-    sequence.add(platform.create_MZ_pulse(qubit=0, start=100))
+    sequence.append(platform.create_RX_pulse(qubit=0, start=0))
+    sequence.append(platform.create_MZ_pulse(qubit=0, start=100))
 
     instrument.cfg.average = False
     i_vals_nav, q_vals_nav = instrument._execute_pulse_sequence(
@@ -747,8 +747,8 @@ def test_call_execute_sweeps(connected_platform, instrument):
     instrument = platform.instruments["tii_rfsoc4x2"]
 
     sequence = PulseSequence()
-    sequence.add(platform.create_RX_pulse(qubit=0, start=0))
-    sequence.add(platform.create_MZ_pulse(qubit=0, start=100))
+    sequence.append(platform.create_RX_pulse(qubit=0, start=0))
+    sequence.append(platform.create_MZ_pulse(qubit=0, start=100))
     sweep = Sweeper(
         parameter=Parameter.frequency,
         values=np.arange(10, 35, 10),
@@ -778,8 +778,8 @@ def test_play_qpu(connected_platform, instrument):
     instrument = platform.instruments["tii_rfsoc4x2"]
 
     sequence = PulseSequence()
-    sequence.add(platform.create_RX_pulse(qubit=0, start=0))
-    sequence.add(platform.create_MZ_pulse(qubit=0, start=100))
+    sequence.append(platform.create_RX_pulse(qubit=0, start=0))
+    sequence.append(platform.create_MZ_pulse(qubit=0, start=100))
 
     out_dict = instrument.play(
         platform.qubits,
@@ -800,8 +800,8 @@ def test_sweep_qpu(connected_platform, instrument):
     instrument = platform.instruments["tii_rfsoc4x2"]
 
     sequence = PulseSequence()
-    sequence.add(platform.create_RX_pulse(qubit=0, start=0))
-    sequence.add(platform.create_MZ_pulse(qubit=0, start=100))
+    sequence.append(platform.create_RX_pulse(qubit=0, start=0))
+    sequence.append(platform.create_MZ_pulse(qubit=0, start=100))
     sweep = Sweeper(
         parameter=Parameter.frequency,
         values=np.arange(10, 35, 10),
@@ -850,8 +850,8 @@ def test_python_reqursive_sweep(connected_platform, instrument):
     instrument = platform.instruments["tii_rfsoc4x2"]
 
     sequence = PulseSequence()
-    sequence.add(platform.create_RX_pulse(qubit=0, start=0))
-    sequence.add(platform.create_MZ_pulse(qubit=0, start=100))
+    sequence.append(platform.create_RX_pulse(qubit=0, start=0))
+    sequence.append(platform.create_MZ_pulse(qubit=0, start=100))
     sweep1 = Sweeper(
         parameter=Parameter.amplitude,
         values=np.arange(0.01, 0.03, 10),

--- a/tests/test_instruments_zhinst.py
+++ b/tests/test_instruments_zhinst.py
@@ -68,9 +68,9 @@ def test_select_sweeper(dummy_qrc, parameter):
     for qubit in qubits.values():
         q = qubit.name
         qd_pulses[q] = platform.create_RX_pulse(q, start=0)
-        sequence.add(qd_pulses[q])
+        sequence.append(qd_pulses[q])
         ro_pulses[q] = platform.create_qubit_readout_pulse(q, start=qd_pulses[q].finish)
-        sequence.add(ro_pulses[q])
+        sequence.append(ro_pulses[q])
 
         parameter_range = np.random.randint(swept_points, size=swept_points)
         if parameter is Parameter.start:
@@ -92,8 +92,8 @@ def test_zhsequence(dummy_qrc):
     qd_pulse = Pulse(0, 40, 0.05, int(3e9), 0.0, Rectangular(), "ch0", qubit=0)
     ro_pulse = ReadoutPulse(0, 40, 0.05, int(3e9), 0.0, Rectangular(), "ch1", qubit=0)
     sequence = PulseSequence()
-    sequence.add(qd_pulse)
-    sequence.add(ro_pulse)
+    sequence.append(qd_pulse)
+    sequence.append(ro_pulse)
     IQM5q = create_platform("zurich")
     controller = IQM5q.instruments["EL_ZURO"]
 
@@ -113,9 +113,9 @@ def test_zhsequence_couplers(dummy_qrc):
     ro_pulse = ReadoutPulse(0, 40, 0.05, int(3e9), 0.0, Rectangular(), "ch1", qubit=0)
     qc_pulse = CouplerFluxPulse(0, 40, 0.05, Rectangular(), "ch_c0", qubit=3)
     sequence = PulseSequence()
-    sequence.add(qd_pulse)
-    sequence.add(ro_pulse)
-    sequence.add(qc_pulse)
+    sequence.append(qd_pulse)
+    sequence.append(ro_pulse)
+    sequence.append(qc_pulse)
     IQM5q = create_platform("zurich")
     controller = IQM5q.instruments["EL_ZURO"]
 
@@ -134,7 +134,7 @@ def test_zhsequence_couplers(dummy_qrc):
 def test_zhsequence_couplers_sweeper(dummy_qrc):
     ro_pulse = ReadoutPulse(0, 40, 0.05, int(3e9), 0.0, Rectangular(), "ch1", qubit=0)
     sequence = PulseSequence()
-    sequence.add(ro_pulse)
+    sequence.append(ro_pulse)
     IQM5q = create_platform("zurich")
     controller = IQM5q.instruments["EL_ZURO"]
 
@@ -164,11 +164,11 @@ def test_zhsequence_couplers_sweeper(dummy_qrc):
 def test_zhsequence_multiple_ro(dummy_qrc):
     sequence = PulseSequence()
     qd_pulse = Pulse(0, 40, 0.05, int(3e9), 0.0, Rectangular(), "ch0", qubit=0)
-    sequence.add(qd_pulse)
+    sequence.append(qd_pulse)
     ro_pulse = ReadoutPulse(0, 40, 0.05, int(3e9), 0.0, Rectangular(), "ch1", qubit=0)
-    sequence.add(ro_pulse)
+    sequence.append(ro_pulse)
     ro_pulse = ReadoutPulse(0, 5000, 0.05, int(3e9), 0.0, Rectangular(), "ch1", qubit=0)
-    sequence.add(ro_pulse)
+    sequence.append(ro_pulse)
     platform = create_platform("zurich")
 
     controller = platform.instruments["EL_ZURO"]
@@ -245,9 +245,9 @@ def test_experiment_execute_pulse_sequence(dummy_qrc):
             channel=platform.qubits[q].flux.name,
             qubit=q,
         )
-        sequence.add(qf_pulses[q])
+        sequence.append(qf_pulses[q])
         ro_pulses[q] = platform.create_qubit_readout_pulse(q, start=qf_pulses[q].finish)
-        sequence.add(ro_pulses[q])
+        sequence.append(ro_pulses[q])
 
     options = ExecutionParameters(
         relaxation_time=300e-6,
@@ -284,9 +284,9 @@ def test_experiment_execute_pulse_sequence_coupler(dummy_qrc):
             channel=platform.qubits[q].flux.name,
             qubit=q,
         )
-        sequence.add(qf_pulses[q])
+        sequence.append(qf_pulses[q])
         ro_pulses[q] = platform.create_qubit_readout_pulse(q, start=qf_pulses[q].finish)
-        sequence.add(ro_pulses[q])
+        sequence.append(ro_pulses[q])
 
     cf_pulses = {}
     for coupler in couplers.values():
@@ -299,7 +299,7 @@ def test_experiment_execute_pulse_sequence_coupler(dummy_qrc):
             channel=platform.couplers[c].flux.name,
             qubit=c,
         )
-        sequence.add(cf_pulses[c])
+        sequence.append(cf_pulses[c])
 
     options = ExecutionParameters(
         relaxation_time=300e-6,
@@ -328,7 +328,7 @@ def test_experiment_fast_reset_readout(dummy_qrc):
     for qubit in qubits:
         fr_pulses[qubit] = platform.create_RX_pulse(qubit, start=0)
         ro_pulses[qubit] = platform.create_qubit_readout_pulse(qubit, start=0)
-        sequence.add(ro_pulses[qubit])
+        sequence.append(ro_pulses[qubit])
 
     options = ExecutionParameters(
         relaxation_time=300e-6,
@@ -361,11 +361,11 @@ def test_experiment_execute_pulse_sequence(dummy_qrc, fast_reset):
         if fast_reset:
             fr_pulses[qubit] = platform.create_RX_pulse(qubit, start=0)
         qd_pulses[qubit] = platform.create_RX_pulse(qubit, start=0)
-        sequence.add(qd_pulses[qubit])
+        sequence.append(qd_pulses[qubit])
         ro_pulses[qubit] = platform.create_qubit_readout_pulse(
             qubit, start=qd_pulses[qubit].finish
         )
-        sequence.add(ro_pulses[qubit])
+        sequence.append(ro_pulses[qubit])
         qf_pulses[qubit] = FluxPulse(
             start=0,
             duration=ro_pulses[qubit].start,
@@ -374,7 +374,7 @@ def test_experiment_execute_pulse_sequence(dummy_qrc, fast_reset):
             channel=platform.qubits[qubit].flux.name,
             qubit=qubit,
         )
-        sequence.add(qf_pulses[qubit])
+        sequence.append(qf_pulses[qubit])
 
     if fast_reset:
         fast_reset = fr_pulses
@@ -409,11 +409,11 @@ def test_experiment_sweep_single(dummy_qrc, parameter1):
     qd_pulses = {}
     for qubit in qubits:
         qd_pulses[qubit] = platform.create_RX_pulse(qubit, start=0)
-        sequence.add(qd_pulses[qubit])
+        sequence.append(qd_pulses[qubit])
         ro_pulses[qubit] = platform.create_qubit_readout_pulse(
             qubit, start=qd_pulses[qubit].finish
         )
-        sequence.add(ro_pulses[qubit])
+        sequence.append(ro_pulses[qubit])
 
     parameter_range_1 = (
         np.random.rand(swept_points)
@@ -454,11 +454,11 @@ def test_experiment_sweep_single_coupler(dummy_qrc, parameter1):
     qd_pulses = {}
     for qubit in qubits:
         qd_pulses[qubit] = platform.create_RX_pulse(qubit, start=0)
-        sequence.add(qd_pulses[qubit])
+        sequence.append(qd_pulses[qubit])
         ro_pulses[qubit] = platform.create_qubit_readout_pulse(
             qubit, start=qd_pulses[qubit].finish
         )
-        sequence.add(ro_pulses[qubit])
+        sequence.append(ro_pulses[qubit])
 
     cf_pulses = {}
     for coupler in couplers.values():
@@ -471,7 +471,7 @@ def test_experiment_sweep_single_coupler(dummy_qrc, parameter1):
             channel=platform.couplers[c].flux.name,
             qubit=c,
         )
-        sequence.add(cf_pulses[c])
+        sequence.append(cf_pulses[c])
 
     parameter_range_1 = (
         np.random.rand(swept_points)
@@ -523,11 +523,11 @@ def test_experiment_sweep_2d_general(dummy_qrc, parameter1, parameter2):
     qd_pulses = {}
     for qubit in qubits:
         qd_pulses[qubit] = platform.create_RX_pulse(qubit, start=0)
-        sequence.add(qd_pulses[qubit])
+        sequence.append(qd_pulses[qubit])
         ro_pulses[qubit] = platform.create_qubit_readout_pulse(
             qubit, start=qd_pulses[qubit].finish
         )
-        sequence.add(ro_pulses[qubit])
+        sequence.append(ro_pulses[qubit])
 
     parameter_range_1 = (
         np.random.rand(swept_points)
@@ -583,11 +583,11 @@ def test_experiment_sweep_2d_specific(dummy_qrc):
     qd_pulses = {}
     for qubit in qubits:
         qd_pulses[qubit] = platform.create_RX_pulse(qubit, start=0)
-        sequence.add(qd_pulses[qubit])
+        sequence.append(qd_pulses[qubit])
         ro_pulses[qubit] = platform.create_qubit_readout_pulse(
             qubit, start=qd_pulses[qubit].finish
         )
-        sequence.add(ro_pulses[qubit])
+        sequence.append(ro_pulses[qubit])
 
     parameter1 = Parameter.relative_phase
     parameter2 = Parameter.frequency
@@ -650,7 +650,7 @@ def test_experiment_sweep_punchouts(dummy_qrc, parameter):
     ro_pulses = {}
     for qubit in qubits:
         ro_pulses[qubit] = platform.create_qubit_readout_pulse(qubit, start=0)
-        sequence.add(ro_pulses[qubit])
+        sequence.append(ro_pulses[qubit])
 
     parameter_range_1 = (
         np.random.rand(swept_points)
@@ -699,11 +699,11 @@ def test_sim(dummy_qrc):
     qf_pulses = {}
     for qubit in qubits:
         qd_pulses[qubit] = platform.create_RX_pulse(qubit, start=0)
-        sequence.add(qd_pulses[qubit])
+        sequence.append(qd_pulses[qubit])
         ro_pulses[qubit] = platform.create_qubit_readout_pulse(
             qubit, start=qd_pulses[qubit].finish
         )
-        sequence.add(ro_pulses[qubit])
+        sequence.append(ro_pulses[qubit])
         qf_pulses[qubit] = FluxPulse(
             start=0,
             duration=500,
@@ -712,7 +712,7 @@ def test_sim(dummy_qrc):
             channel=platform.qubits[qubit].flux.name,
             qubit=qubit,
         )
-        sequence.add(qf_pulses[qubit])
+        sequence.append(qf_pulses[qubit])
 
 
 def test_split_batches(dummy_qrc):
@@ -720,11 +720,11 @@ def test_split_batches(dummy_qrc):
     instrument = platform.instruments["EL_ZURO"]
 
     sequence = PulseSequence()
-    sequence.add(platform.create_RX_pulse(0, start=0))
-    sequence.add(platform.create_RX_pulse(1, start=0))
+    sequence.append(platform.create_RX_pulse(0, start=0))
+    sequence.append(platform.create_RX_pulse(1, start=0))
     measurement_start = sequence.finish
-    sequence.add(platform.create_MZ_pulse(0, start=measurement_start))
-    sequence.add(platform.create_MZ_pulse(1, start=measurement_start))
+    sequence.append(platform.create_MZ_pulse(0, start=measurement_start))
+    sequence.append(platform.create_MZ_pulse(1, start=measurement_start))
 
     batches = list(instrument.split_batches(200 * [sequence]))
     assert len(batches) == 2
@@ -764,11 +764,11 @@ def test_experiment_execute_pulse_sequence(connected_platform, instrument):
             channel=platform.qubits[q].flux.name,
             qubit=q,
         )
-        sequence.add(qf_pulses[q])
+        sequence.append(qf_pulses[q])
         if qubit.flux_coupler:
             continue
         ro_pulses[q] = platform.create_qubit_readout_pulse(q, start=qf_pulses[q].finish)
-        sequence.add(ro_pulses[q])
+        sequence.append(ro_pulses[q])
 
     options = ExecutionParameters(
         relaxation_time=300e-6,
@@ -796,11 +796,11 @@ def test_experiment_sweep_2d_specific(connected_platform, instrument):
     qd_pulses = {}
     for qubit in qubits:
         qd_pulses[qubit] = platform.create_RX_pulse(qubit, start=0)
-        sequence.add(qd_pulses[qubit])
+        sequence.append(qd_pulses[qubit])
         ro_pulses[qubit] = platform.create_qubit_readout_pulse(
             qubit, start=qd_pulses[qubit].finish
         )
-        sequence.add(ro_pulses[qubit])
+        sequence.append(ro_pulses[qubit])
 
     parameter1 = Parameter.relative_phase
     parameter2 = Parameter.frequency
@@ -879,9 +879,9 @@ def test_experiment_measurement_sequence(dummy_qrc):
         qubit_drive_pulse_2 = platform.create_qubit_drive_pulse(
             qubit, start=readout_pulse_start + 50, duration=40
         )
-        sequence.add(qubit_drive_pulse_1)
-        sequence.add(ro_pulse)
-        sequence.add(qubit_drive_pulse_2)
+        sequence.append(qubit_drive_pulse_1)
+        sequence.append(ro_pulse)
+        sequence.append(qubit_drive_pulse_2)
 
     options = ExecutionParameters(
         relaxation_time=4,

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -28,8 +28,8 @@ def test_unroll_sequences(platform):
     sequence = PulseSequence()
     qd_pulse = platform.create_RX_pulse(qubit, start=0)
     ro_pulse = platform.create_MZ_pulse(qubit, start=qd_pulse.finish)
-    sequence.add(qd_pulse)
-    sequence.add(ro_pulse)
+    sequence.append(qd_pulse)
+    sequence.append(ro_pulse)
     total_sequence, readouts = unroll_sequences(10 * [sequence], relaxation_time=10000)
     assert len(total_sequence) == 20
     assert len(total_sequence.ro_pulses) == 10
@@ -100,7 +100,7 @@ def test_platform_execute_one_drive_pulse(qpu_platform):
     platform = qpu_platform
     qubit = next(iter(platform.qubits))
     sequence = PulseSequence()
-    sequence.add(platform.create_qubit_drive_pulse(qubit, start=0, duration=200))
+    sequence.append(platform.create_qubit_drive_pulse(qubit, start=0, duration=200))
     platform.execute_pulse_sequence(sequence, ExecutionParameters(nshots=nshots))
 
 
@@ -112,7 +112,7 @@ def test_platform_execute_one_coupler_pulse(qpu_platform):
         pytest.skip("The platform does not have couplers")
     coupler = next(iter(platform.couplers))
     sequence = PulseSequence()
-    sequence.add(
+    sequence.append(
         platform.create_coupler_pulse(coupler, start=0, duration=200, amplitude=1)
     )
     platform.execute_pulse_sequence(sequence, ExecutionParameters(nshots=nshots))
@@ -126,7 +126,7 @@ def test_platform_execute_one_long_drive_pulse(qpu_platform):
     qubit = next(iter(platform.qubits))
     pulse = platform.create_qubit_drive_pulse(qubit, start=0, duration=8192 + 200)
     sequence = PulseSequence()
-    sequence.add(pulse)
+    sequence.append(pulse)
     options = ExecutionParameters(nshots=nshots)
     if find_instrument(platform, QbloxController) is not None:
         with pytest.raises(NotImplementedError):
@@ -147,7 +147,7 @@ def test_platform_execute_one_extralong_drive_pulse(qpu_platform):
     qubit = next(iter(platform.qubits))
     pulse = platform.create_qubit_drive_pulse(qubit, start=0, duration=2 * 8192 + 200)
     sequence = PulseSequence()
-    sequence.add(pulse)
+    sequence.append(pulse)
     options = ExecutionParameters(nshots=nshots)
     if find_instrument(platform, QbloxController) is not None:
         with pytest.raises(NotImplementedError):
@@ -167,8 +167,8 @@ def test_platform_execute_one_drive_one_readout(qpu_platform):
     platform = qpu_platform
     qubit = next(iter(platform.qubits))
     sequence = PulseSequence()
-    sequence.add(platform.create_qubit_drive_pulse(qubit, start=0, duration=200))
-    sequence.add(platform.create_qubit_readout_pulse(qubit, start=200))
+    sequence.append(platform.create_qubit_drive_pulse(qubit, start=0, duration=200))
+    sequence.append(platform.create_qubit_readout_pulse(qubit, start=200))
     platform.execute_pulse_sequence(sequence, ExecutionParameters(nshots=nshots))
 
 
@@ -178,10 +178,10 @@ def test_platform_execute_multiple_drive_pulses_one_readout(qpu_platform):
     platform = qpu_platform
     qubit = next(iter(platform.qubits))
     sequence = PulseSequence()
-    sequence.add(platform.create_qubit_drive_pulse(qubit, start=0, duration=200))
-    sequence.add(platform.create_qubit_drive_pulse(qubit, start=204, duration=200))
-    sequence.add(platform.create_qubit_drive_pulse(qubit, start=408, duration=400))
-    sequence.add(platform.create_qubit_readout_pulse(qubit, start=808))
+    sequence.append(platform.create_qubit_drive_pulse(qubit, start=0, duration=200))
+    sequence.append(platform.create_qubit_drive_pulse(qubit, start=204, duration=200))
+    sequence.append(platform.create_qubit_drive_pulse(qubit, start=408, duration=400))
+    sequence.append(platform.create_qubit_readout_pulse(qubit, start=808))
     platform.execute_pulse_sequence(sequence, ExecutionParameters(nshots=nshots))
 
 
@@ -193,10 +193,10 @@ def test_platform_execute_multiple_drive_pulses_one_readout_no_spacing(
     platform = qpu_platform
     qubit = next(iter(platform.qubits))
     sequence = PulseSequence()
-    sequence.add(platform.create_qubit_drive_pulse(qubit, start=0, duration=200))
-    sequence.add(platform.create_qubit_drive_pulse(qubit, start=200, duration=200))
-    sequence.add(platform.create_qubit_drive_pulse(qubit, start=400, duration=400))
-    sequence.add(platform.create_qubit_readout_pulse(qubit, start=800))
+    sequence.append(platform.create_qubit_drive_pulse(qubit, start=0, duration=200))
+    sequence.append(platform.create_qubit_drive_pulse(qubit, start=200, duration=200))
+    sequence.append(platform.create_qubit_drive_pulse(qubit, start=400, duration=400))
+    sequence.append(platform.create_qubit_readout_pulse(qubit, start=800))
     platform.execute_pulse_sequence(sequence, ExecutionParameters(nshots=nshots))
 
 
@@ -208,10 +208,10 @@ def test_platform_execute_multiple_overlaping_drive_pulses_one_readout(
     platform = qpu_platform
     qubit = next(iter(platform.qubits))
     sequence = PulseSequence()
-    sequence.add(platform.create_qubit_drive_pulse(qubit, start=0, duration=200))
-    sequence.add(platform.create_qubit_drive_pulse(qubit, start=200, duration=200))
-    sequence.add(platform.create_qubit_drive_pulse(qubit, start=50, duration=400))
-    sequence.add(platform.create_qubit_readout_pulse(qubit, start=800))
+    sequence.append(platform.create_qubit_drive_pulse(qubit, start=0, duration=200))
+    sequence.append(platform.create_qubit_drive_pulse(qubit, start=200, duration=200))
+    sequence.append(platform.create_qubit_drive_pulse(qubit, start=50, duration=400))
+    sequence.append(platform.create_qubit_readout_pulse(qubit, start=800))
     platform.execute_pulse_sequence(sequence, ExecutionParameters(nshots=nshots))
 
 
@@ -229,10 +229,10 @@ def test_platform_execute_multiple_readout_pulses(qpu_platform):
     ro_pulse2 = platform.create_qubit_readout_pulse(
         qubit, start=(ro_pulse1.start + ro_pulse1.duration + 400)
     )
-    sequence.add(qd_pulse1)
-    sequence.add(ro_pulse1)
-    sequence.add(qd_pulse2)
-    sequence.add(ro_pulse2)
+    sequence.append(qd_pulse1)
+    sequence.append(ro_pulse1)
+    sequence.append(qd_pulse2)
+    sequence.append(ro_pulse2)
     platform.execute_pulse_sequence(sequence, ExecutionParameters(nshots=nshots))
 
 
@@ -249,8 +249,8 @@ def test_excited_state_probabilities_pulses(qpu_platform):
     for qubit in qubits:
         qd_pulse = platform.create_RX_pulse(qubit)
         ro_pulse = platform.create_MZ_pulse(qubit, start=qd_pulse.duration)
-        sequence.add(qd_pulse)
-        sequence.add(ro_pulse)
+        sequence.append(qd_pulse)
+        sequence.append(ro_pulse)
     result = platform.execute_pulse_sequence(sequence, ExecutionParameters(nshots=5000))
 
     nqubits = len(qubits)
@@ -281,7 +281,7 @@ def test_ground_state_probabilities_pulses(qpu_platform, start_zero):
         else:
             qd_pulse = platform.create_RX_pulse(qubit)
             ro_pulse = platform.create_MZ_pulse(qubit, start=qd_pulse.duration)
-        sequence.add(ro_pulse)
+        sequence.append(ro_pulse)
     result = platform.execute_pulse_sequence(sequence, ExecutionParameters(nshots=5000))
 
     nqubits = len(qubits)

--- a/tests/test_pulses.py
+++ b/tests/test_pulses.py
@@ -28,7 +28,7 @@ from qibolab.pulses import (
 HERE = pathlib.Path(__file__).parent
 
 
-def test_pulses_plot_functions():
+def test_plot_functions():
     p0 = Pulse(0, 40, 0.9, 0, 0, Rectangular(), 0, PulseType.FLUX, 0)
     p1 = Pulse(0, 40, 0.9, 50e6, 0, Gaussian(5), 0, PulseType.DRIVE, 2)
     p2 = Pulse(0, 40, 0.9, 50e6, 0, Drag(5, 2), 0, PulseType.DRIVE, 200)
@@ -36,7 +36,7 @@ def test_pulses_plot_functions():
     p4 = FluxPulse(0, 40, 0.9, SNZ(t_idling=10), 0, 200)
     p5 = Pulse(0, 40, 0.9, 400e6, 0, eCap(alpha=2), 0, PulseType.DRIVE)
     p6 = Pulse(0, 40, 0.9, 50e6, 0, GaussianSquare(5, 0.9), 0, PulseType.DRIVE, 2)
-    ps = p0 + p1 + p2 + p3 + p4 + p5 + p6
+    ps = PulseSequence([p0, p1, p2, p3, p4, p5, p6])
     wf = p0.modulated_waveform_i()
 
     plot_file = HERE / "test_plot.png"
@@ -54,7 +54,7 @@ def test_pulses_plot_functions():
     os.remove(plot_file)
 
 
-def test_pulses_pulse_init():
+def test_pulse_init():
     # standard initialisation
     p0 = Pulse(
         start=0,
@@ -190,7 +190,7 @@ def test_pulses_pulse_init():
     assert p12.finish == 5.5 + 34.33
 
 
-def test_pulses_pulse_attributes():
+def test_pulse_attributes():
     channel = 0
     qubit = 0
 
@@ -233,7 +233,7 @@ def test_pulses_pulse_attributes():
     assert p0.finish == 100
 
 
-def test_pulses_is_equal_ignoring_start():
+def test_is_equal_ignoring_start():
     """Checks if two pulses are equal, not looking at start time."""
 
     p1 = Pulse(0, 40, 0.9, 0, 0, Rectangular(), 0, PulseType.FLUX, 0)
@@ -253,7 +253,7 @@ def test_pulses_is_equal_ignoring_start():
     assert not p1.is_equal_ignoring_start(p4)
 
 
-def test_pulses_pulse_serial():
+def test_pulse_serial():
     p11 = Pulse(0, 40, 0.9, 50_000_000, 0, Gaussian(5), 0, PulseType.DRIVE)
     assert (
         p11.serial
@@ -265,13 +265,13 @@ def test_pulses_pulse_serial():
 @pytest.mark.parametrize(
     "shape", [Rectangular(), Gaussian(5), GaussianSquare(5, 0.9), Drag(5, 1)]
 )
-def test_pulses_pulseshape_sampling_rate(shape):
+def test_pulseshape_sampling_rate(shape):
     pulse = Pulse(0, 40, 0.9, 100e6, 0, shape, 0, PulseType.DRIVE)
     assert len(pulse.envelope_waveform_i(sampling_rate=1).data) == 40
     assert len(pulse.envelope_waveform_i(sampling_rate=100).data) == 4000
 
 
-def test_pulseshape_eval():
+def testhape_eval():
     shape = PulseShape.eval("Rectangular()")
     assert isinstance(shape, Rectangular)
     shape = PulseShape.eval("Drag(5, 1)")
@@ -324,7 +324,7 @@ def test_raise_shapeiniterror():
         shape.envelope_waveform_q()
 
 
-def test_pulses_pulseshape_drag_shape():
+def test_pulseshape_drag_shape():
     pulse = Pulse(0, 2, 1, 4e9, 0, Drag(2, 1), 0, PulseType.DRIVE)
     # envelope i & envelope q should cross nearly at 0 and at 2
     waveform = pulse.envelope_waveform_i(sampling_rate=10).data
@@ -355,7 +355,7 @@ def test_pulses_pulseshape_drag_shape():
     np.testing.assert_allclose(waveform, target_waveform)
 
 
-def test_pulses_pulse_hash():
+def test_pulse_hash():
     rp = Pulse(0, 40, 0.9, 100e6, 0, Rectangular(), 0, PulseType.DRIVE)
     dp = Pulse(0, 40, 0.9, 100e6, 0, Drag(5, 1), 0, PulseType.DRIVE)
     hash(rp)
@@ -376,7 +376,7 @@ def test_pulses_pulse_hash():
     assert p1 == p3
 
 
-def test_pulses_pulse_aliases():
+def test_pulse_aliases():
     rop = ReadoutPulse(
         start=0,
         duration=50,
@@ -407,7 +407,7 @@ def test_pulses_pulse_aliases():
     assert repr(fp) == "FluxPulse(0, 300, 0.9, Rectangular(), 0, 0)"
 
 
-def test_pulses_pulsesequence_init():
+def test_pulsesequence_init():
     p1 = Pulse(400, 40, 0.9, 100e6, 0, Drag(5, 1), 3, PulseType.DRIVE)
     p2 = Pulse(500, 40, 0.9, 100e6, 0, Drag(5, 1), 2, PulseType.DRIVE)
     p3 = Pulse(600, 40, 0.9, 100e6, 0, Drag(5, 1), 1, PulseType.DRIVE)
@@ -415,14 +415,14 @@ def test_pulses_pulsesequence_init():
     ps = PulseSequence()
     assert type(ps) == PulseSequence
 
-    ps = PulseSequence(p1, p2, p3)
-    assert ps.count == 3 and len(ps) == 3
+    ps = PulseSequence([p1, p2, p3])
+    assert len(ps) == 3
     assert ps[0] == p1
     assert ps[1] == p2
     assert ps[2] == p3
 
-    other_ps = p1 + p2 + p3
-    assert other_ps.count == 3 and len(other_ps) == 3
+    other_ps = PulseSequence([p1, p2, p3])
+    assert len(other_ps) == 3
     assert other_ps[0] == p1
     assert other_ps[1] == p2
     assert other_ps[2] == p3
@@ -434,11 +434,11 @@ def test_pulses_pulsesequence_init():
         n += 1
 
 
-def test_pulses_pulsesequence_operators():
+def test_pulsesequence_operators():
     ps = PulseSequence()
-    ps += ReadoutPulse(800, 200, 0.9, 20e6, 0, Rectangular(), 1)
-    ps = ps + ReadoutPulse(800, 200, 0.9, 20e6, 0, Rectangular(), 2)
-    ps = ReadoutPulse(800, 200, 0.9, 20e6, 0, Rectangular(), 3) + ps
+    ps += [ReadoutPulse(800, 200, 0.9, 20e6, 0, Rectangular(), 1)]
+    ps = ps + [ReadoutPulse(800, 200, 0.9, 20e6, 0, Rectangular(), 2)]
+    ps = [ReadoutPulse(800, 200, 0.9, 20e6, 0, Rectangular(), 3)] + ps
 
     p4 = Pulse(100, 40, 0.9, 50e6, 0, Gaussian(5), 3, PulseType.DRIVE)
     p5 = Pulse(200, 40, 0.9, 50e6, 0, Gaussian(5), 2, PulseType.DRIVE)
@@ -446,7 +446,7 @@ def test_pulses_pulsesequence_operators():
 
     another_ps = PulseSequence()
     another_ps.append(p4)
-    another_ps.append(p5, p6)
+    another_ps.extend([p5, p6])
 
     assert another_ps[0] == p4
     assert another_ps[1] == p5
@@ -454,59 +454,29 @@ def test_pulses_pulsesequence_operators():
 
     ps += another_ps
 
-    assert ps.count == 6
+    assert len(ps) == 6
     assert p5 in ps
 
     # ps.plot()
 
     p7 = Pulse(600, 40, 0.9, 100e6, 0, Drag(5, 1), 1, PulseType.DRIVE)
-    yet_another_ps = PulseSequence(p7)
-    assert yet_another_ps.count == 1
+    yet_another_ps = PulseSequence([p7])
+    assert len(yet_another_ps) == 1
     yet_another_ps *= 3
-    assert yet_another_ps.count == 3
+    assert len(yet_another_ps) == 3
     yet_another_ps *= 3
-    assert yet_another_ps.count == 9
+    assert len(yet_another_ps) == 9
 
     p8 = Pulse(600, 40, 0.9, 100e6, 0, Drag(5, 1), 1, PulseType.DRIVE)
     p9 = Pulse(600, 40, 0.9, 100e6, 0, Drag(5, 1), 2, PulseType.DRIVE)
-    and_yet_another_ps = 2 * p9 + p8 * 3
-    assert and_yet_another_ps.count == 5
+    and_yet_another_ps = 2 * PulseSequence([p9]) + [p8] * 3
+    assert len(and_yet_another_ps) == 5
 
 
-def test_pulses_pulsesequence_add():
-    p0 = Pulse(0, 40, 0.9, 50e6, 0, Gaussian(5), 10, PulseType.DRIVE, 1)
-    p1 = Pulse(100, 40, 0.9, 50e6, 0, Gaussian(5), 20, PulseType.DRIVE, 2)
-
-    p2 = Pulse(200, 40, 0.9, 50e6, 0, Gaussian(5), 30, PulseType.DRIVE, 3)
-    p3 = Pulse(400, 40, 0.9, 50e6, 0, Gaussian(5), 40, PulseType.DRIVE, 4)
-
-    ps = PulseSequence()
-    ps.append(p0)
-    ps.append(p1)
-    psx = PulseSequence(p2, p3)
-    ps.append(psx)
-
-    assert ps.count == 4
-    assert ps.qubits == [1, 2, 3, 4]
-    assert ps.channels == [10, 20, 30, 40]
-    assert ps.start == 0
-    assert ps.finish == 440
-
-
-def test_pulses_pulsesequence_clear():
-    p1 = Pulse(600, 40, 0.9, 100e6, 0, Drag(5, 1), 1, PulseType.DRIVE)
-    p2 = Pulse(600, 40, 0.9, 100e6, 0, Drag(5, 1), 2, PulseType.DRIVE)
-    ps = 2 * p2 + p1 * 3
-    assert ps.count == 5
-    ps.clear()
-    assert ps.count == 0
-    assert ps.is_empty
-
-
-def test_pulses_pulsesequence_start_finish():
+def test_pulsesequence_start_finish():
     p1 = Pulse(20, 40, 0.9, 200e6, 0, Drag(5, 1), 1, PulseType.DRIVE)
     p2 = Pulse(60, 1000, 0.9, 20e6, 0, Rectangular(), 2, PulseType.READOUT)
-    ps = p1 + p2
+    ps = PulseSequence([p1]) + [p2]
     assert ps.start == p1.start
     assert ps.finish == p2.finish
 
@@ -516,7 +486,7 @@ def test_pulses_pulsesequence_start_finish():
     assert p2.finish is None
 
 
-def test_pulses_pulsesequence_get_channel_pulses():
+def test_pulsesequence_get_channel_pulses():
     p1 = DrivePulse(0, 400, 0.9, 20e6, 0, Gaussian(5), 10)
     p2 = ReadoutPulse(100, 400, 0.9, 20e6, 0, Rectangular(), 30)
     p3 = DrivePulse(300, 400, 0.9, 20e6, 0, Drag(5, 50), 20)
@@ -524,15 +494,15 @@ def test_pulses_pulsesequence_get_channel_pulses():
     p5 = ReadoutPulse(500, 400, 0.9, 20e6, 0, Rectangular(), 20)
     p6 = DrivePulse(600, 400, 0.9, 20e6, 0, Gaussian(5), 30)
 
-    ps = PulseSequence(p1, p2, p3, p4, p5, p6)
+    ps = PulseSequence([p1, p2, p3, p4, p5, p6])
     assert ps.channels == [10, 20, 30]
-    assert ps.get_channel_pulses(10).count == 1
-    assert ps.get_channel_pulses(20).count == 2
-    assert ps.get_channel_pulses(30).count == 3
-    assert ps.get_channel_pulses(20, 30).count == 5
+    assert len(ps.get_channel_pulses(10)) == 1
+    assert len(ps.get_channel_pulses(20)) == 2
+    assert len(ps.get_channel_pulses(30)) == 3
+    assert len(ps.get_channel_pulses(20, 30)) == 5
 
 
-def test_pulses_pulsesequence_get_qubit_pulses():
+def test_pulsesequence_get_qubit_pulses():
     p1 = DrivePulse(0, 400, 0.9, 20e6, 0, Gaussian(5), 10, 0)
     p2 = ReadoutPulse(100, 400, 0.9, 20e6, 0, Rectangular(), 30, 0)
     p3 = DrivePulse(300, 400, 0.9, 20e6, 0, Drag(5, 50), 20, 1)
@@ -541,15 +511,15 @@ def test_pulses_pulsesequence_get_qubit_pulses():
     p6 = FluxPulse(600, 400, 0.9, Rectangular(), 40, 1)
     p7 = FluxPulse(900, 400, 0.9, Rectangular(), 40, 2)
 
-    ps = PulseSequence(p1, p2, p3, p4, p5, p6, p7)
+    ps = PulseSequence([p1, p2, p3, p4, p5, p6, p7])
     assert ps.qubits == [0, 1, 2]
-    assert ps.get_qubit_pulses(0).count == 2
-    assert ps.get_qubit_pulses(1).count == 4
-    assert ps.get_qubit_pulses(2).count == 1
-    assert ps.get_qubit_pulses(0, 1).count == 6
+    assert len(ps.get_qubit_pulses(0)) == 2
+    assert len(ps.get_qubit_pulses(1)) == 4
+    assert len(ps.get_qubit_pulses(2)) == 1
+    assert len(ps.get_qubit_pulses(0, 1)) == 6
 
 
-def test_pulses_pulsesequence_pulses_overlap():
+def test_pulsesequence_pulses_overlap():
     p1 = DrivePulse(0, 400, 0.9, 20e6, 0, Gaussian(5), 10)
     p2 = ReadoutPulse(100, 400, 0.9, 20e6, 0, Rectangular(), 30)
     p3 = DrivePulse(300, 400, 0.9, 20e6, 0, Drag(5, 50), 20)
@@ -557,14 +527,14 @@ def test_pulses_pulsesequence_pulses_overlap():
     p5 = ReadoutPulse(500, 400, 0.9, 20e6, 0, Rectangular(), 20)
     p6 = DrivePulse(600, 400, 0.9, 20e6, 0, Gaussian(5), 30)
 
-    ps = PulseSequence(p1, p2, p3, p4, p5, p6)
-    assert ps.pulses_overlap == True
-    assert ps.get_channel_pulses(10).pulses_overlap == False
-    assert ps.get_channel_pulses(20).pulses_overlap == True
-    assert ps.get_channel_pulses(30).pulses_overlap == True
+    ps = PulseSequence([p1, p2, p3, p4, p5, p6])
+    assert ps.pulses_overlap
+    assert not ps.get_channel_pulses(10).pulses_overlap
+    assert ps.get_channel_pulses(20).pulses_overlap
+    assert ps.get_channel_pulses(30).pulses_overlap
 
 
-def test_pulses_pulsesequence_separate_overlapping_pulses():
+def test_pulsesequence_separate_overlapping_pulses():
     p1 = DrivePulse(0, 400, 0.9, 20e6, 0, Gaussian(5), 10)
     p2 = ReadoutPulse(100, 400, 0.9, 20e6, 0, Rectangular(), 30)
     p3 = DrivePulse(300, 400, 0.9, 20e6, 0, Drag(5, 50), 20)
@@ -572,7 +542,7 @@ def test_pulses_pulsesequence_separate_overlapping_pulses():
     p5 = ReadoutPulse(500, 400, 0.9, 20e6, 0, Rectangular(), 20)
     p6 = DrivePulse(600, 400, 0.9, 20e6, 0, Gaussian(5), 30)
 
-    ps = PulseSequence(p1, p2, p3, p4, p5, p6)
+    ps = PulseSequence([p1, p2, p3, p4, p5, p6])
     n = 70
     for segregated_ps in ps.separate_overlapping_pulses():
         n += 1
@@ -580,19 +550,22 @@ def test_pulses_pulsesequence_separate_overlapping_pulses():
             pulse.channel = n
 
 
-def test_pulses_pulse_pulse_order():
+def test_pulse_pulse_order():
     t0 = 0
     t = 0
     p1 = DrivePulse(t0, 400, 0.9, 20e6, 0, Gaussian(5), 10)
     p2 = ReadoutPulse(p1.finish + t, 400, 0.9, 20e6, 0, Rectangular(), 30)
     p3 = DrivePulse(p2.finish, 400, 0.9, 20e6, 0, Drag(5, 50), 20)
-    ps1 = p1 + p2 + p3
-    ps2 = p3 + p1 + p2
-    assert ps1 == ps2
-    assert hash(ps1) == hash(ps2)
+    ps1 = PulseSequence([p1, p2, p3])
+    ps2 = PulseSequence([p3, p1, p2])
+
+    def sortseq(sequence):
+        return sorted(sequence, key=lambda item: (item.start, item.channel))
+
+    assert sortseq(ps1) == sortseq(ps2)
 
 
-def test_pulses_waveform():
+def test_waveform():
     wf1 = Waveform(np.ones(100))
     wf2 = Waveform(np.zeros(100))
     wf3 = Waveform(np.ones(100))
@@ -623,7 +596,7 @@ def modulate(
     return mod_signals[:, 0], mod_signals[:, 1]
 
 
-def test_pulses_pulseshape_rectangular():
+def test_pulseshape_rectangular():
     pulse = Pulse(
         start=0,
         duration=50,
@@ -684,7 +657,7 @@ def test_pulses_pulseshape_rectangular():
     )
 
 
-def test_pulses_pulseshape_gaussian():
+def test_pulseshape_gaussian():
     pulse = Pulse(
         start=0,
         duration=50,
@@ -751,7 +724,7 @@ def test_pulses_pulseshape_gaussian():
     )
 
 
-def test_pulses_pulseshape_drag():
+def test_pulseshape_drag():
     pulse = Pulse(
         start=0,
         duration=50,
@@ -824,7 +797,7 @@ def test_pulses_pulseshape_drag():
     )
 
 
-def test_pulses_pulseshape_eq():
+def test_pulseshape_eq():
     """Checks == operator for pulse shapes."""
 
     shape1 = Rectangular()
@@ -924,100 +897,6 @@ def test_readout_pulse():
     assert repr(pulse) == target
 
 
-def test_pulse_sequence_add():
-    sequence = PulseSequence()
-    sequence.append(
-        Pulse(
-            start=0,
-            frequency=200_000_000,
-            amplitude=0.3,
-            duration=60,
-            relative_phase=0,
-            shape="Gaussian(5)",
-            channel=1,
-        )
-    )
-    sequence.append(
-        Pulse(
-            start=64,
-            frequency=200_000_000,
-            amplitude=0.3,
-            duration=30,
-            relative_phase=0,
-            shape="Gaussian(5)",
-            channel=1,
-        )
-    )
-    assert len(sequence.pulses) == 2
-    assert len(sequence.qd_pulses) == 2
-
-
-def test_pulse_sequence__add__():
-    sequence = PulseSequence()
-    sequence.append(
-        Pulse(
-            start=0,
-            frequency=200_000_000,
-            amplitude=0.3,
-            duration=60,
-            relative_phase=0,
-            shape="Gaussian(5)",
-            channel=1,
-        )
-    )
-    sequence.append(
-        Pulse(
-            start=64,
-            frequency=200_000_000,
-            amplitude=0.3,
-            duration=30,
-            relative_phase=0,
-            shape="Gaussian(5)",
-            channel=1,
-        )
-    )
-    with pytest.raises(TypeError):
-        sequence + 2
-    with pytest.raises(TypeError):
-        2 + sequence
-
-
-def test_pulse_sequence__mul__():
-    sequence = PulseSequence()
-    sequence.append(
-        Pulse(
-            start=0,
-            frequency=200_000_000,
-            amplitude=0.3,
-            duration=60,
-            relative_phase=0,
-            shape="Gaussian(5)",
-            channel=1,
-        )
-    )
-    sequence.append(
-        Pulse(
-            start=64,
-            frequency=200_000_000,
-            amplitude=0.3,
-            duration=30,
-            relative_phase=0,
-            shape="Gaussian(5)",
-            channel=1,
-        )
-    )
-    with pytest.raises(TypeError):
-        sequence * 2.5
-    with pytest.raises(TypeError):
-        sequence *= 2.5
-    with pytest.raises(TypeError):
-        sequence *= -1
-    with pytest.raises(TypeError):
-        sequence * -1
-    with pytest.raises(TypeError):
-        2.5 * sequence
-
-
 def test_pulse_sequence_add_readout():
     sequence = PulseSequence()
     sequence.append(
@@ -1056,7 +935,7 @@ def test_pulse_sequence_add_readout():
             channel=11,
         )
     )
-    assert len(sequence.pulses) == 3
+    assert len(sequence) == 3
     assert len(sequence.ro_pulses) == 1
     assert len(sequence.qd_pulses) == 1
     assert len(sequence.qf_pulses) == 1

--- a/tests/test_pulses.py
+++ b/tests/test_pulses.py
@@ -445,8 +445,8 @@ def test_pulses_pulsesequence_operators():
     p6 = Pulse(300, 40, 0.9, 50e6, 0, Gaussian(5), 1, PulseType.DRIVE)
 
     another_ps = PulseSequence()
-    another_ps.add(p4)
-    another_ps.add(p5, p6)
+    another_ps.append(p4)
+    another_ps.append(p5, p6)
 
     assert another_ps[0] == p4
     assert another_ps[1] == p5
@@ -481,10 +481,10 @@ def test_pulses_pulsesequence_add():
     p3 = Pulse(400, 40, 0.9, 50e6, 0, Gaussian(5), 40, PulseType.DRIVE, 4)
 
     ps = PulseSequence()
-    ps.add(p0)
-    ps.add(p1)
+    ps.append(p0)
+    ps.append(p1)
     psx = PulseSequence(p2, p3)
-    ps.add(psx)
+    ps.append(psx)
 
     assert ps.count == 4
     assert ps.qubits == [1, 2, 3, 4]
@@ -926,7 +926,7 @@ def test_readout_pulse():
 
 def test_pulse_sequence_add():
     sequence = PulseSequence()
-    sequence.add(
+    sequence.append(
         Pulse(
             start=0,
             frequency=200_000_000,
@@ -937,7 +937,7 @@ def test_pulse_sequence_add():
             channel=1,
         )
     )
-    sequence.add(
+    sequence.append(
         Pulse(
             start=64,
             frequency=200_000_000,
@@ -954,7 +954,7 @@ def test_pulse_sequence_add():
 
 def test_pulse_sequence__add__():
     sequence = PulseSequence()
-    sequence.add(
+    sequence.append(
         Pulse(
             start=0,
             frequency=200_000_000,
@@ -965,7 +965,7 @@ def test_pulse_sequence__add__():
             channel=1,
         )
     )
-    sequence.add(
+    sequence.append(
         Pulse(
             start=64,
             frequency=200_000_000,
@@ -984,7 +984,7 @@ def test_pulse_sequence__add__():
 
 def test_pulse_sequence__mul__():
     sequence = PulseSequence()
-    sequence.add(
+    sequence.append(
         Pulse(
             start=0,
             frequency=200_000_000,
@@ -995,7 +995,7 @@ def test_pulse_sequence__mul__():
             channel=1,
         )
     )
-    sequence.add(
+    sequence.append(
         Pulse(
             start=64,
             frequency=200_000_000,
@@ -1020,7 +1020,7 @@ def test_pulse_sequence__mul__():
 
 def test_pulse_sequence_add_readout():
     sequence = PulseSequence()
-    sequence.add(
+    sequence.append(
         Pulse(
             start=0,
             frequency=200_000_000,
@@ -1032,7 +1032,7 @@ def test_pulse_sequence_add_readout():
         )
     )
 
-    sequence.add(
+    sequence.append(
         Pulse(
             start=64,
             frequency=200_000_000,
@@ -1045,7 +1045,7 @@ def test_pulse_sequence_add_readout():
         )
     )
 
-    sequence.add(
+    sequence.append(
         ReadoutPulse(
             start=128,
             frequency=20_000_000,

--- a/tests/test_result_shapes.py
+++ b/tests/test_result_shapes.py
@@ -22,8 +22,8 @@ def execute(platform, acquisition_type, averaging_mode, sweep=False):
     qd_pulse = platform.create_RX_pulse(qubit, start=0)
     ro_pulse = platform.create_MZ_pulse(qubit, start=qd_pulse.finish)
     sequence = PulseSequence()
-    sequence.add(qd_pulse)
-    sequence.add(ro_pulse)
+    sequence.append(qd_pulse)
+    sequence.append(ro_pulse)
 
     options = ExecutionParameters(
         nshots=NSHOTS, acquisition_type=acquisition_type, averaging_mode=averaging_mode


### PR DESCRIPTION
Since `PulseSequence` is implementing an extended portion of the `list` API, and not
holding any other attribute, it is more convenient to directly make it a `list`.

The remotion of some methods will require some additional work, and it might break the
compatibility with Qibocal as well:

- [x] `__init__` can not be called with multiple arguments
  - they just have to be wrapped in a list literal
- [x] `__eq__` and `__ne__` are not checking any longer if it's an actual
`PulseSequence`
  - this is not breaking compatibility, just tests
- [x] `__add__` does not support adding `Pulse`
  - `.append()` will have to be used for this, as with regular lists
  - this will be defined anyhow, just as `return PulseSequence(super().__add__(self, other))`,
     to fix the return object
  - no need for `__radd__` (we support only homogeneous sum) and `__iadd__` (works out
  of the box)
- `__getitem__` should support the broader slice semantics, but it was not, and I won't do
   it as well
- [x] `.add()` has been dropped, in favor of `.append()`, `.extend()`, and `__add__()`
(as for regular lists)
  - I should check that no one was relying on the sorting happening in there
- [x] the semantics of `.copy()` has changed
  - it is now a shallow copy, and the user is encouraged to use `copy.deepcopy()` for
  the other one
  - this will couple with a different PR, ditching `Pulse.copy()`, in favor of a plain
  copy

Since it was not appropriate for a mutable object to be hashable, `__hash__` has been dropped.
`PulseSequence.serial` was mostly used for sequences comparison. But, in the optics of `PulseSequence` being a mere list, two sequences are the same if every pulse of the sequence is the same. It makes sense that the equality relation used is the default `Pulse.__eq__`. Anything more elaborate should be made explicit in user's code. 