### PR TITLE
Drop `pyyaml` dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -5446,4 +5446,4 @@ zh = ["laboneq"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.12"
-content-hash = "d0466649f0511c2f842fe31ab436a7fea8b0448fcfaca51de277c4770b922351"
+content-hash = "34951554284321424eabcd128ea6a2950028ed2b528d5aedcabf9a7f7c8b01d2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ qibo = ">=0.2.3"
 networkx = "^3.0"
 numpy = "==1.24.4"
 more-itertools = "^9.1.0"
-pyyaml = "^6.0"
 qblox-instruments = { version = "0.11.0", optional = true }
 qcodes = { version = "^0.37.0", optional = true }
 qcodes_contrib_drivers = { version = "0.18.0", optional = true }


### PR DESCRIPTION
There was no usage left of PyYAML inside Qibolab. This PR is just dropping the dependency declaration.
