### PR TITLE
Replace `pulse.start` with delays and refactor native.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,31 +26,36 @@ A simple example on how to connect to a platform and use it execute a pulse sequ
 
 ```python
 from qibolab import create_platform, ExecutionParameters
-from qibolab.pulses import DrivePulse, ReadoutPulse, PulseSequence
+from qibolab.pulses import Pulse, Delay, PulseType
 
 # Define PulseSequence
 sequence = PulseSequence()
 # Add some pulses to the pulse sequence
-sequence.add(
-    DrivePulse(
-        start=0,
+sequence.append(
+    Pulse(
         amplitude=0.3,
         duration=4000,
         frequency=200_000_000,
         relative_phase=0,
         shape="Gaussian(5)",  # Gaussian shape with std = duration / 5
+        type=PulseType.DRIVE,
         channel=1,
     )
 )
-
-sequence.add(
+sequence.append(
+    Delay(
+        duration=4000,
+        channel=2,
+    )
+)
+sequence.append(
     ReadoutPulse(
-        start=4004,
         amplitude=0.9,
         duration=2000,
         frequency=20_000_000,
         relative_phase=0,
         shape="Rectangular",
+        type=PulseType.READOUT,
         channel=2,
     )
 )

--- a/doc/source/getting-started/experiment.rst
+++ b/doc/source/getting-started/experiment.rst
@@ -102,8 +102,6 @@ And the we can define the runcard ``my_platform/parameters.json``:
                     "frequency": 5500000000,
                     "shape": "Gaussian(3)",
                     "type": "qd",
-                    "start": 0,
-                    "phase": 0
                 },
                 "MZ": {
                     "duration": 2000,
@@ -111,8 +109,6 @@ And the we can define the runcard ``my_platform/parameters.json``:
                     "frequency": 7370000000,
                     "shape": "Rectangular()",
                     "type": "ro",
-                    "start": 0,
-                    "phase": 0
                 }
             }
         },
@@ -193,7 +189,7 @@ We leave to the dedicated tutorial a full explanation of the experiment, but her
 
     # define the pulse sequence
     sequence = PulseSequence()
-    ro_pulse = platform.create_MZ_pulse(qubit=0, start=0)
+    ro_pulse = platform.create_MZ_pulse(qubit=0)
     sequence.append(ro_pulse)
 
     # define a sweeper for a frequency scan

--- a/doc/source/tutorials/calibration.rst
+++ b/doc/source/tutorials/calibration.rst
@@ -43,7 +43,7 @@ around the pre-defined frequency.
 
     # create pulse sequence and add pulse
     sequence = PulseSequence()
-    readout_pulse = platform.create_MZ_pulse(qubit=0, start=0)
+    readout_pulse = platform.create_MZ_pulse(qubit=0)
     sequence.append(readout_pulse)
 
     # allocate frequency sweeper
@@ -110,7 +110,7 @@ complex pulse sequence. Therefore with start with that:
     import numpy as np
     import matplotlib.pyplot as plt
     from qibolab import create_platform
-    from qibolab.pulses import PulseSequence
+    from qibolab.pulses import PulseSequence, Delay
     from qibolab.sweeper import Sweeper, SweeperType, Parameter
     from qibolab.execution_parameters import (
         ExecutionParameters,
@@ -123,11 +123,12 @@ complex pulse sequence. Therefore with start with that:
 
     # create pulse sequence and add pulses
     sequence = PulseSequence()
-    drive_pulse = platform.create_RX_pulse(qubit=0, start=0)
+    drive_pulse = platform.create_RX_pulse(qubit=0)
     drive_pulse.duration = 2000
     drive_pulse.amplitude = 0.01
-    readout_pulse = platform.create_MZ_pulse(qubit=0, start=drive_pulse.finish)
+    readout_pulse = platform.create_MZ_pulse(qubit=0)
     sequence.append(drive_pulse)
+    sequence.append(Delay(drive_pulse.duration, readout_pulse.channel))
     sequence.append(readout_pulse)
 
     # allocate frequency sweeper
@@ -205,7 +206,7 @@ and its impact on qubit states in the IQ plane.
     import numpy as np
     import matplotlib.pyplot as plt
     from qibolab import create_platform
-    from qibolab.pulses import PulseSequence
+    from qibolab.pulses import PulseSequence, Delay
     from qibolab.sweeper import Sweeper, SweeperType, Parameter
     from qibolab.execution_parameters import (
         ExecutionParameters,
@@ -218,14 +219,15 @@ and its impact on qubit states in the IQ plane.
 
     # create pulse sequence 1 and add pulses
     one_sequence = PulseSequence()
-    drive_pulse = platform.create_RX_pulse(qubit=0, start=0)
-    readout_pulse1 = platform.create_MZ_pulse(qubit=0, start=drive_pulse.finish)
+    drive_pulse = platform.create_RX_pulse(qubit=0)
+    readout_pulse1 = platform.create_MZ_pulse(qubit=0)
     one_sequence.append(drive_pulse)
+    one_sequence.append(Delay(drive_pulse.duration, readout_pulse1.channel))
     one_sequence.append(readout_pulse1)
 
     # create pulse sequence 2 and add pulses
     zero_sequence = PulseSequence()
-    readout_pulse2 = platform.create_MZ_pulse(qubit=0, start=0)
+    readout_pulse2 = platform.create_MZ_pulse(qubit=0)
     zero_sequence.append(readout_pulse2)
 
     options = ExecutionParameters(

--- a/doc/source/tutorials/compiler.rst
+++ b/doc/source/tutorials/compiler.rst
@@ -87,7 +87,7 @@ The following example shows how to modify the transpiler and compiler in order t
         qubit = gate.target_qubits[0]
         sequence = PulseSequence()
         sequence.append(platform.create_RX_pulse(qubit))
-        return sequence, {}
+        return sequence
 
 
     # the empty dictionary is needed because the X gate does not require any virtual Z-phases

--- a/doc/source/tutorials/compiler.rst
+++ b/doc/source/tutorials/compiler.rst
@@ -86,7 +86,7 @@ The following example shows how to modify the transpiler and compiler in order t
         """X gate applied with a single pi-pulse."""
         qubit = gate.target_qubits[0]
         sequence = PulseSequence()
-        sequence.append(platform.create_RX_pulse(qubit, start=0))
+        sequence.append(platform.create_RX_pulse(qubit))
         return sequence, {}
 
 

--- a/doc/source/tutorials/compiler.rst
+++ b/doc/source/tutorials/compiler.rst
@@ -82,19 +82,14 @@ The following example shows how to modify the transpiler and compiler in order t
 
 
     # define a compiler rule that translates X to the pi-pulse
-    def x_rule(gate, platform):
+    def x_rule(gate, qubit):
         """X gate applied with a single pi-pulse."""
-        qubit = gate.target_qubits[0]
-        sequence = PulseSequence()
-        sequence.append(platform.create_RX_pulse(qubit))
-        return sequence
+        return PulseSequence([qubit.native_gates.RX])
 
 
     # the empty dictionary is needed because the X gate does not require any virtual Z-phases
 
     backend = QibolabBackend(platform="dummy")
-    # disable the transpiler
-    backend.transpiler = None
     # register the new X rule in the compiler
     backend.compiler[gates.X] = x_rule
 

--- a/doc/source/tutorials/lab.rst
+++ b/doc/source/tutorials/lab.rst
@@ -24,9 +24,9 @@ using different Qibolab primitives.
 
     from qibolab import Platform
     from qibolab.qubits import Qubit
-    from qibolab.pulses import PulseType
+    from qibolab.pulses import Pulse, PulseType
     from qibolab.channels import ChannelMap, Channel
-    from qibolab.native import NativePulse, SingleQubitNatives
+    from qibolab.native import SingleQubitNatives
     from qibolab.instruments.dummy import DummyInstrument
 
 
@@ -45,21 +45,19 @@ using different Qibolab primitives.
 
         # assign native gates to the qubit
         qubit.native_gates = SingleQubitNatives(
-            RX=NativePulse(
-                name="RX",
+            RX=Pulse(
                 duration=40,
                 amplitude=0.05,
                 shape="Gaussian(5)",
-                pulse_type=PulseType.DRIVE,
+                type=PulseType.DRIVE,
                 qubit=qubit,
                 frequency=int(4.5e9),
             ),
-            MZ=NativePulse(
-                name="MZ",
+            MZ=Pulse(
                 duration=1000,
                 amplitude=0.005,
                 shape="Rectangular()",
-                pulse_type=PulseType.READOUT,
+                type=PulseType.READOUT,
                 qubit=qubit,
                 frequency=int(7e9),
             ),
@@ -99,10 +97,8 @@ hold the parameters of the two-qubit gates.
 .. testcode::  python
 
     from qibolab.qubits import Qubit, QubitPair
-    from qibolab.pulses import PulseType
+    from qibolab.pulses import PulseType, Pulse, PulseSequence
     from qibolab.native import (
-        NativePulse,
-        NativeSequence,
         SingleQubitNatives,
         TwoQubitNatives,
     )
@@ -113,41 +109,37 @@ hold the parameters of the two-qubit gates.
 
     # assign single-qubit native gates to each qubit
     qubit0.native_gates = SingleQubitNatives(
-        RX=NativePulse(
-            name="RX",
+        RX=Pulse(
             duration=40,
             amplitude=0.05,
             shape="Gaussian(5)",
-            pulse_type=PulseType.DRIVE,
+            type=PulseType.DRIVE,
             qubit=qubit0,
             frequency=int(4.7e9),
         ),
-        MZ=NativePulse(
-            name="MZ",
+        MZ=Pulse(
             duration=1000,
             amplitude=0.005,
             shape="Rectangular()",
-            pulse_type=PulseType.READOUT,
+            type=PulseType.READOUT,
             qubit=qubit0,
             frequency=int(7e9),
         ),
     )
     qubit1.native_gates = SingleQubitNatives(
-        RX=NativePulse(
-            name="RX",
+        RX=Pulse(
             duration=40,
             amplitude=0.05,
             shape="Gaussian(5)",
-            pulse_type=PulseType.DRIVE,
+            type=PulseType.DRIVE,
             qubit=qubit1,
             frequency=int(5.1e9),
         ),
-        MZ=NativePulse(
-            name="MZ",
+        MZ=Pulse(
             duration=1000,
             amplitude=0.005,
             shape="Rectangular()",
-            pulse_type=PulseType.READOUT,
+            type=PulseType.READOUT,
             qubit=qubit1,
             frequency=int(7.5e9),
         ),
@@ -156,15 +148,13 @@ hold the parameters of the two-qubit gates.
     # define the pair of qubits
     pair = QubitPair(qubit0, qubit1)
     pair.native_gates = TwoQubitNatives(
-        CZ=NativeSequence(
-            name="CZ",
-            pulses=[
-                NativePulse(
-                    name="CZ1",
+        CZ=PulseSequence(
+            [
+                Pulse(
                     duration=30,
                     amplitude=0.005,
                     shape="Rectangular()",
-                    pulse_type=PulseType.FLUX,
+                    type=PulseType.FLUX,
                     qubit=qubit1,
                 )
             ],
@@ -182,10 +172,8 @@ coupler but qibolab will take them into account when calling :class:`qibolab.nat
 
     from qibolab.couplers import Coupler
     from qibolab.qubits import Qubit, QubitPair
-    from qibolab.pulses import PulseType
+    from qibolab.pulses import PulseType, Pulse, PulseSequence
     from qibolab.native import (
-        NativePulse,
-        NativeSequence,
         SingleQubitNatives,
         TwoQubitNatives,
     )
@@ -201,15 +189,13 @@ coupler but qibolab will take them into account when calling :class:`qibolab.nat
     # define the pair of qubits
     pair = QubitPair(qubit0, qubit1, coupler_01)
     pair.native_gates = TwoQubitNatives(
-        CZ=NativeSequence(
-            name="CZ",
-            pulses=[
-                NativePulse(
-                    name="CZ1",
+        CZ=PulseSequence(
+            [
+                Pulse(
                     duration=30,
                     amplitude=0.005,
                     shape="Rectangular()",
-                    pulse_type=PulseType.FLUX,
+                    type=PulseType.FLUX,
                     qubit=qubit1,
                 )
             ],
@@ -285,8 +271,6 @@ a two-qubit system:
                         "frequency": 4855663000,
                         "shape": "Drag(5, -0.02)",
                         "type": "qd",
-                        "start": 0,
-                        "phase": 0
                     },
                     "MZ": {
                         "duration": 620,
@@ -294,8 +278,6 @@ a two-qubit system:
                         "frequency": 7453265000,
                         "shape": "Rectangular()",
                         "type": "ro",
-                        "start": 0,
-                        "phase": 0
                     }
                 },
                 "1": {
@@ -305,8 +287,6 @@ a two-qubit system:
                         "frequency": 5800563000,
                         "shape": "Drag(5, -0.04)",
                         "type": "qd",
-                        "start": 0,
-                        "phase": 0
                     },
                     "MZ": {
                         "duration": 960,
@@ -314,8 +294,6 @@ a two-qubit system:
                         "frequency": 7655107000,
                         "shape": "Rectangular()",
                         "type": "ro",
-                        "start": 0,
-                        "phase": 0
                     }
                 }
             },
@@ -327,7 +305,6 @@ a two-qubit system:
                             "amplitude": 0.055,
                             "shape": "Rectangular()",
                             "qubit": 1,
-                            "relative_start": 0,
                             "type": "qf"
                         },
                         {
@@ -396,7 +373,6 @@ we need the following changes to the previous runcard:
                             "amplitude": 0.6025,
                             "shape": "Rectangular()",
                             "qubit": 1,
-                            "relative_start": 0,
                             "type": "qf"
                         },
                         {
@@ -410,12 +386,11 @@ we need the following changes to the previous runcard:
                             "qubit": 1
                         },
                         {
-                            "type": "coupler",
+                            "type": "cf",
                             "duration": 40,
                             "amplitude": 0.1,
                             "shape": "Rectangular()",
                             "coupler": 0,
-                            "relative_start": 0
                         }
                     ]
                 }
@@ -591,8 +566,6 @@ The runcard can contain an ``instruments`` section that provides these parameter
                         "frequency": 4855663000,
                         "shape": "Drag(5, -0.02)",
                         "type": "qd",
-                        "start": 0,
-                        "phase": 0
                     },
                     "MZ": {
                         "duration": 620,
@@ -600,8 +573,6 @@ The runcard can contain an ``instruments`` section that provides these parameter
                         "frequency": 7453265000,
                         "shape": "Rectangular()",
                         "type": "ro",
-                        "start": 0,
-                        "phase": 0
                     }
                 },
                 "1": {
@@ -611,8 +582,6 @@ The runcard can contain an ``instruments`` section that provides these parameter
                         "frequency": 5800563000,
                         "shape": "Drag(5, -0.04)",
                         "type": "qd",
-                        "start": 0,
-                        "phase": 0
                     },
                     "MZ": {
                         "duration": 960,
@@ -620,8 +589,6 @@ The runcard can contain an ``instruments`` section that provides these parameter
                         "frequency": 7655107000,
                         "shape": "Rectangular()",
                         "type": "ro",
-                        "start": 0,
-                        "phase": 0
                     }
                 }
             },
@@ -633,7 +600,6 @@ The runcard can contain an ``instruments`` section that provides these parameter
                             "amplitude": 0.055,
                             "shape": "Rectangular()",
                             "qubit": 1,
-                            "relative_start": 0,
                             "type": "qf"
                         },
                         {

--- a/doc/source/tutorials/pulses.rst
+++ b/doc/source/tutorials/pulses.rst
@@ -8,7 +8,7 @@ pulses (:class:`qibolab.pulses.Pulse`) through the
 
 .. testcode::  python
 
-    from qibolab.pulses import Pulse, PulseSequence, PulseType, Rectangular, Gaussian
+    from qibolab.pulses import Pulse, PulseSequence, PulseType, Rectangular, Gaussian, Delay
 
     # Define PulseSequence
     sequence = PulseSequence()
@@ -16,18 +16,19 @@ pulses (:class:`qibolab.pulses.Pulse`) through the
     # Add some pulses to the pulse sequence
     sequence.append(
         Pulse(
-            start=0,
             frequency=200000000,
             amplitude=0.3,
             duration=60,
             relative_phase=0,
             shape=Gaussian(5),
             qubit=0,
+            type=PulseType.DRIVE,
+            channel=0,
         )
     )
+    sequence.append(Delay(100, channel=1))
     sequence.append(
         Pulse(
-            start=70,
             frequency=20000000.0,
             amplitude=0.5,
             duration=3000,
@@ -35,6 +36,7 @@ pulses (:class:`qibolab.pulses.Pulse`) through the
             shape=Rectangular(),
             qubit=0,
             type=PulseType.READOUT,
+            channel=1,
         )
     )
 

--- a/src/qibolab/compilers/default.py
+++ b/src/qibolab/compilers/default.py
@@ -31,24 +31,20 @@ def rz_rule(gate, qubit):
 def gpi2_rule(gate, qubit):
     """Rule for GPI2."""
     theta = gate.parameters[0]
-    sequence = PulseSequence()
-    pulse = qubit.native_gates.RX90
-    pulse.relative_phase = theta
-    sequence.append(pulse)
+    pulse = replace(qubit.native_gates.RX90, relative_phase=theta)
+    sequence = PulseSequence([pulse])
     return sequence
 
 
 def gpi_rule(gate, qubit):
     """Rule for GPI."""
     theta = gate.parameters[0]
-    sequence = PulseSequence()
     # the following definition has a global phase difference compare to
     # to the matrix representation. See
     # https://github.com/qiboteam/qibolab/pull/804#pullrequestreview-1890205509
     # for more detail.
-    pulse = qubit.native_gates.RX
-    pulse.relative_phase = theta
-    sequence.append(pulse)
+    pulse = replace(qubit.native_gates.RX, relative_phase=theta)
+    sequence = PulseSequence([pulse])
     return sequence
 
 

--- a/src/qibolab/compilers/default.py
+++ b/src/qibolab/compilers/default.py
@@ -83,13 +83,13 @@ def cz_rule(gate, platform):
     Applying the CZ gate may involve sending pulses on qubits that the
     gate is not directly acting on.
     """
-    pair = platform.pairs[tuple(platform.get_qubit(q) for q in gate.qubits)]
+    pair = platform.pairs[tuple(platform.get_qubit(q).name for q in gate.qubits)]
     return pair.native_gates.CZ
 
 
 def cnot_rule(gate, platform):
     """CNOT applied as defined in the platform runcard."""
-    pair = platform.pairs[tuple(platform.get_qubit(q) for q in gate.qubits)]
+    pair = platform.pairs[tuple(platform.get_qubit(q).name for q in gate.qubits)]
     return pair.native_gates.CNOT
 
 

--- a/src/qibolab/couplers.py
+++ b/src/qibolab/couplers.py
@@ -22,7 +22,7 @@ class Coupler:
 
     sweetspot: float = 0
     "Coupler sweetspot to center it's flux dependence if needed."
-    native_pulse: SingleQubitNatives = field(default_factory=SingleQubitNatives)
+    native_gates: SingleQubitNatives = field(default_factory=SingleQubitNatives)
     "For now this only contains the calibrated pulse to activate the coupler."
 
     _flux: Optional[Channel] = None

--- a/src/qibolab/couplers.py
+++ b/src/qibolab/couplers.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass, field
 from typing import Dict, Optional, Union
 
 from qibolab.channels import Channel
-from qibolab.native import CouplerNatives
+from qibolab.native import SingleQubitNatives
 
 QubitId = Union[str, int]
 """Type for Coupler names."""
@@ -22,7 +22,7 @@ class Coupler:
 
     sweetspot: float = 0
     "Coupler sweetspot to center it's flux dependence if needed."
-    native_pulse: CouplerNatives = field(default_factory=CouplerNatives)
+    native_pulse: SingleQubitNatives = field(default_factory=SingleQubitNatives)
     "For now this only contains the calibrated pulse to activate the coupler."
 
     _flux: Optional[Channel] = None

--- a/src/qibolab/dummy/parameters.json
+++ b/src/qibolab/dummy/parameters.json
@@ -77,14 +77,14 @@
                 "RX": {
                     "duration": 40,
                     "amplitude": 0.3,
-                    "shape": "Drag(5, -0.02)",
+                    "shape": "Drag(5, 0.02)",
                     "frequency": 4200000000.0,
                     "type": "qd"
                 },
                 "RX12": {
                     "duration": 40,
                     "amplitude": 0.0484,
-                    "shape": "Drag(5, -0.02)",
+                    "shape": "Drag(5, 0.02)",
                     "frequency": 4855663000,
                     "type": "qd"
                 },
@@ -100,7 +100,7 @@
                 "RX": {
                     "duration": 40,
                     "amplitude": 0.3,
-                    "shape": "Drag(5, -0.02)",
+                    "shape": "Drag(5, 0.02)",
                     "frequency": 4500000000.0,
                     "type": "qd"
                 },
@@ -123,14 +123,14 @@
                 "RX": {
                     "duration": 40,
                     "amplitude": 0.3,
-                    "shape": "Drag(5, -0.02)",
+                    "shape": "Drag(5, 0.02)",
                     "frequency": 4150000000.0,
                     "type": "qd"
                 },
                 "RX12": {
                     "duration": 40,
                     "amplitude": 0.0484,
-                    "shape": "Drag(5, -0.02)",
+                    "shape": "Drag(5, 0.02)",
                     "frequency": 5855663000,
                     "type": "qd"
                 },
@@ -146,14 +146,14 @@
                 "RX": {
                     "duration": 40,
                     "amplitude": 0.3,
-                    "shape": "Drag(5, -0.02)",
+                    "shape": "Drag(5, 0.02)",
                     "frequency": 4155663000,
                     "type": "qd"
                 },
                 "RX12": {
                     "duration": 40,
                     "amplitude": 0.0484,
-                    "shape": "Drag(5, -0.02)",
+                    "shape": "Drag(5, 0.02)",
                     "frequency": 5855663000,
                     "type": "qd"
                 },
@@ -366,7 +366,7 @@
                     {
                         "duration": 40,
                         "amplitude": 0.3,
-                        "shape": "Drag(5, -0.02)",
+                        "shape": "Drag(5, 0.02)",
                         "frequency": 4150000000.0,
                         "type": "qd",
                         "qubit": 2

--- a/src/qibolab/dummy/parameters.json
+++ b/src/qibolab/dummy/parameters.json
@@ -56,7 +56,6 @@
                     "amplitude": 0.1,
                     "shape": "Gaussian(5)",
                     "frequency": 4000000000.0,
-                    "phase": 0,
                     "type": "qd"
                 },
                 "RX12": {
@@ -64,7 +63,6 @@
                     "amplitude": 0.005,
                     "shape": "Gaussian(5)",
                     "frequency": 4700000000,
-                    "phase": 0,
                     "type": "qd"
                 },
                 "MZ": {
@@ -72,7 +70,6 @@
                     "amplitude": 0.1,
                     "shape": "GaussianSquare(5, 0.75)",
                     "frequency": 5200000000.0,
-                    "phase": 0,
                     "type": "ro"
                 }
             },
@@ -82,7 +79,6 @@
                     "amplitude": 0.3,
                     "shape": "Drag(5, -0.02)",
                     "frequency": 4200000000.0,
-                    "phase": 0,
                     "type": "qd"
                 },
                 "RX12": {
@@ -90,7 +86,6 @@
                     "amplitude": 0.0484,
                     "shape": "Drag(5, -0.02)",
                     "frequency": 4855663000,
-                    "phase": 0,
                     "type": "qd"
                 },
                 "MZ": {
@@ -98,7 +93,6 @@
                     "amplitude": 0.1,
                     "shape": "GaussianSquare(5, 0.75)",
                     "frequency": 4900000000.0,
-                    "phase": 0,
                     "type": "ro"
                 }
             },
@@ -108,7 +102,6 @@
                     "amplitude": 0.3,
                     "shape": "Drag(5, -0.02)",
                     "frequency": 4500000000.0,
-                    "phase": 0,
                     "type": "qd"
                 },
                 "RX12": {
@@ -116,7 +109,6 @@
                     "amplitude": 0.005,
                     "shape": "Gaussian(5)",
                     "frequency": 2700000000,
-                    "phase": 0,
                     "type": "qd"
                 },
                 "MZ": {
@@ -124,7 +116,6 @@
                     "amplitude": 0.1,
                     "shape": "GaussianSquare(5, 0.75)",
                     "frequency": 6100000000.0,
-                    "phase": 0,
                     "type": "ro"
                 }
             },
@@ -134,7 +125,6 @@
                     "amplitude": 0.3,
                     "shape": "Drag(5, -0.02)",
                     "frequency": 4150000000.0,
-                    "phase": 0,
                     "type": "qd"
                 },
                 "RX12": {
@@ -142,7 +132,6 @@
                     "amplitude": 0.0484,
                     "shape": "Drag(5, -0.02)",
                     "frequency": 5855663000,
-                    "phase": 0,
                     "type": "qd"
                 },
                 "MZ": {
@@ -150,7 +139,6 @@
                     "amplitude": 0.1,
                     "shape": "GaussianSquare(5, 0.75)",
                     "frequency": 5800000000.0,
-                    "phase": 0,
                     "type": "ro"
                 }
             },
@@ -160,7 +148,6 @@
                     "amplitude": 0.3,
                     "shape": "Drag(5, -0.02)",
                     "frequency": 4155663000,
-                    "phase": 0,
                     "type": "qd"
                 },
                 "RX12": {
@@ -168,7 +155,6 @@
                     "amplitude": 0.0484,
                     "shape": "Drag(5, -0.02)",
                     "frequency": 5855663000,
-                    "phase": 0,
                     "type": "qd"
                 },
                 "MZ": {
@@ -176,7 +162,6 @@
                     "amplitude": 0.1,
                     "shape": "GaussianSquare(5, 0.75)",
                     "frequency": 5500000000.0,
-                    "phase": 0,
                     "type": "ro"
                 }
             }
@@ -387,7 +372,6 @@
                         "amplitude": 0.3,
                         "shape": "Drag(5, -0.02)",
                         "frequency": 4150000000.0,
-                            "phase": 0,
                         "type": "qd",
                         "qubit": 2
                     },

--- a/src/qibolab/dummy/parameters.json
+++ b/src/qibolab/dummy/parameters.json
@@ -172,8 +172,7 @@
                     "duration": 30,
                     "amplitude": 0.05,
                     "shape": "GaussianSquare(5, 0.75)",
-                    "type": "coupler",
-                    "coupler": 0
+                    "type": "cf"
                 }
             },
             "1": {
@@ -181,8 +180,7 @@
                     "duration": 30,
                     "amplitude": 0.05,
                     "shape": "GaussianSquare(5, 0.75)",
-                    "type": "coupler",
-                    "coupler": 1
+                    "type": "cf"
                 }
             },
             "3": {
@@ -190,8 +188,7 @@
                     "duration": 30,
                     "amplitude": 0.05,
                     "shape": "GaussianSquare(5, 0.75)",
-                    "type": "coupler",
-                    "coupler": 3
+                    "type": "cf"
                 }
             },
             "4": {
@@ -199,8 +196,7 @@
                     "duration": 30,
                     "amplitude": 0.05,
                     "shape": "GaussianSquare(5, 0.75)",
-                    "type": "coupler",
-                    "coupler": 4
+                    "type": "cf"
                 }
             }
         },
@@ -229,7 +225,7 @@
                         "amplitude": 0.05,
                         "shape": "GaussianSquare(5, 0.75)",
                         "coupler": 0,
-                        "type": "coupler"
+                        "type": "cf"
                     }
                 ],
                 "iSWAP": [
@@ -255,7 +251,7 @@
                         "amplitude": 0.05,
                         "shape": "GaussianSquare(5, 0.75)",
                         "coupler": 0,
-                        "type": "coupler"
+                        "type": "cf"
                     }
                 ]
             },
@@ -283,7 +279,7 @@
                         "amplitude": 0.05,
                         "shape": "GaussianSquare(5, 0.75)",
                         "coupler": 1,
-                        "type": "coupler"
+                        "type": "cf"
                     }
                 ],
                 "iSWAP": [
@@ -309,7 +305,7 @@
                         "amplitude": 0.05,
                         "shape": "GaussianSquare(5, 0.75)",
                         "coupler": 1,
-                        "type": "coupler"
+                        "type": "cf"
                     }
                 ]
             },
@@ -337,7 +333,7 @@
                         "amplitude": 0.05,
                         "shape": "GaussianSquare(5, 0.75)",
                         "coupler": 3,
-                        "type": "coupler"
+                        "type": "cf"
                     }
                 ],
                 "iSWAP": [
@@ -363,7 +359,7 @@
                         "amplitude": 0.05,
                         "shape": "GaussianSquare(5, 0.75)",
                         "coupler": 3,
-                        "type": "coupler"
+                        "type": "cf"
                     }
                 ],
                 "CNOT": [
@@ -411,7 +407,7 @@
                         "amplitude": 0.05,
                         "shape": "GaussianSquare(5, 0.75)",
                         "coupler": 4,
-                        "type": "coupler"
+                        "type": "cf"
                     }
                 ],
                 "iSWAP": [
@@ -437,7 +433,7 @@
                         "amplitude": 0.05,
                         "shape": "GaussianSquare(5, 0.75)",
                         "coupler": 4,
-                        "type": "coupler"
+                        "type": "cf"
                     }
                 ]
             }

--- a/src/qibolab/dummy/parameters.json
+++ b/src/qibolab/dummy/parameters.json
@@ -56,7 +56,6 @@
                     "amplitude": 0.1,
                     "shape": "Gaussian(5)",
                     "frequency": 4000000000.0,
-                    "relative_start": 0,
                     "phase": 0,
                     "type": "qd"
                 },
@@ -65,7 +64,6 @@
                     "amplitude": 0.005,
                     "shape": "Gaussian(5)",
                     "frequency": 4700000000,
-                    "relative_start": 0,
                     "phase": 0,
                     "type": "qd"
                 },
@@ -74,7 +72,6 @@
                     "amplitude": 0.1,
                     "shape": "GaussianSquare(5, 0.75)",
                     "frequency": 5200000000.0,
-                    "relative_start": 0,
                     "phase": 0,
                     "type": "ro"
                 }
@@ -85,7 +82,6 @@
                     "amplitude": 0.3,
                     "shape": "Drag(5, -0.02)",
                     "frequency": 4200000000.0,
-                    "relative_start": 0,
                     "phase": 0,
                     "type": "qd"
                 },
@@ -94,7 +90,6 @@
                     "amplitude": 0.0484,
                     "shape": "Drag(5, -0.02)",
                     "frequency": 4855663000,
-                    "relative_start": 0,
                     "phase": 0,
                     "type": "qd"
                 },
@@ -103,7 +98,6 @@
                     "amplitude": 0.1,
                     "shape": "GaussianSquare(5, 0.75)",
                     "frequency": 4900000000.0,
-                    "relative_start": 0,
                     "phase": 0,
                     "type": "ro"
                 }
@@ -114,7 +108,6 @@
                     "amplitude": 0.3,
                     "shape": "Drag(5, -0.02)",
                     "frequency": 4500000000.0,
-                    "relative_start": 0,
                     "phase": 0,
                     "type": "qd"
                 },
@@ -123,7 +116,6 @@
                     "amplitude": 0.005,
                     "shape": "Gaussian(5)",
                     "frequency": 2700000000,
-                    "relative_start": 0,
                     "phase": 0,
                     "type": "qd"
                 },
@@ -132,7 +124,6 @@
                     "amplitude": 0.1,
                     "shape": "GaussianSquare(5, 0.75)",
                     "frequency": 6100000000.0,
-                    "relative_start": 0,
                     "phase": 0,
                     "type": "ro"
                 }
@@ -143,7 +134,6 @@
                     "amplitude": 0.3,
                     "shape": "Drag(5, -0.02)",
                     "frequency": 4150000000.0,
-                    "relative_start": 0,
                     "phase": 0,
                     "type": "qd"
                 },
@@ -152,7 +142,6 @@
                     "amplitude": 0.0484,
                     "shape": "Drag(5, -0.02)",
                     "frequency": 5855663000,
-                    "relative_start": 0,
                     "phase": 0,
                     "type": "qd"
                 },
@@ -161,7 +150,6 @@
                     "amplitude": 0.1,
                     "shape": "GaussianSquare(5, 0.75)",
                     "frequency": 5800000000.0,
-                    "relative_start": 0,
                     "phase": 0,
                     "type": "ro"
                 }
@@ -172,7 +160,6 @@
                     "amplitude": 0.3,
                     "shape": "Drag(5, -0.02)",
                     "frequency": 4155663000,
-                    "relative_start": 0,
                     "phase": 0,
                     "type": "qd"
                 },
@@ -181,7 +168,6 @@
                     "amplitude": 0.0484,
                     "shape": "Drag(5, -0.02)",
                     "frequency": 5855663000,
-                    "relative_start": 0,
                     "phase": 0,
                     "type": "qd"
                 },
@@ -190,7 +176,6 @@
                     "amplitude": 0.1,
                     "shape": "GaussianSquare(5, 0.75)",
                     "frequency": 5500000000.0,
-                    "relative_start": 0,
                     "phase": 0,
                     "type": "ro"
                 }
@@ -202,7 +187,6 @@
                     "duration": 30,
                     "amplitude": 0.05,
                     "shape": "GaussianSquare(5, 0.75)",
-                    "relative_start": 0,
                     "type": "coupler",
                     "coupler": 0
                 }
@@ -212,7 +196,6 @@
                     "duration": 30,
                     "amplitude": 0.05,
                     "shape": "GaussianSquare(5, 0.75)",
-                    "relative_start": 0,
                     "type": "coupler",
                     "coupler": 1
                 }
@@ -222,7 +205,6 @@
                     "duration": 30,
                     "amplitude": 0.05,
                     "shape": "GaussianSquare(5, 0.75)",
-                    "relative_start": 0,
                     "type": "coupler",
                     "coupler": 3
                 }
@@ -232,7 +214,6 @@
                     "duration": 30,
                     "amplitude": 0.05,
                     "shape": "GaussianSquare(5, 0.75)",
-                    "relative_start": 0,
                     "type": "coupler",
                     "coupler": 4
                 }
@@ -246,7 +227,6 @@
                         "amplitude": 0.05,
                         "shape": "GaussianSquare(5, 0.75)",
                         "qubit": 2,
-                        "relative_start": 0,
                         "type": "qf"
                     },
                     {
@@ -264,7 +244,6 @@
                         "amplitude": 0.05,
                         "shape": "GaussianSquare(5, 0.75)",
                         "coupler": 0,
-                        "relative_start": 0,
                         "type": "coupler"
                     }
                 ],
@@ -274,7 +253,6 @@
                         "amplitude": 0.05,
                         "shape": "GaussianSquare(5, 0.75)",
                         "qubit": 2,
-                        "relative_start": 0,
                         "type": "qf"
                     },
                     {
@@ -292,7 +270,6 @@
                         "amplitude": 0.05,
                         "shape": "GaussianSquare(5, 0.75)",
                         "coupler": 0,
-                        "relative_start": 0,
                         "type": "coupler"
                     }
                 ]
@@ -304,7 +281,6 @@
                         "amplitude": 0.05,
                         "shape": "GaussianSquare(5, 0.75)",
                         "qubit": 2,
-                        "relative_start": 0,
                         "type": "qf"
                     },
                     {
@@ -322,7 +298,6 @@
                         "amplitude": 0.05,
                         "shape": "GaussianSquare(5, 0.75)",
                         "coupler": 1,
-                        "relative_start": 0,
                         "type": "coupler"
                     }
                 ],
@@ -332,7 +307,6 @@
                         "amplitude": 0.05,
                         "shape": "GaussianSquare(5, 0.75)",
                         "qubit": 2,
-                        "relative_start": 0,
                         "type": "qf"
                     },
                     {
@@ -350,7 +324,6 @@
                         "amplitude": 0.05,
                         "shape": "GaussianSquare(5, 0.75)",
                         "coupler": 1,
-                        "relative_start": 0,
                         "type": "coupler"
                     }
                 ]
@@ -362,7 +335,6 @@
                         "amplitude": 0.05,
                         "shape": "GaussianSquare(5, 0.75)",
                         "qubit": 2,
-                        "relative_start": 0,
                         "type": "qf"
                     },
                     {
@@ -380,7 +352,6 @@
                         "amplitude": 0.05,
                         "shape": "GaussianSquare(5, 0.75)",
                         "coupler": 3,
-                        "relative_start": 0,
                         "type": "coupler"
                     }
                 ],
@@ -390,7 +361,6 @@
                         "amplitude": 0.05,
                         "shape": "GaussianSquare(5, 0.75)",
                         "qubit": 2,
-                        "relative_start": 0,
                         "type": "qf"
                     },
                     {
@@ -408,7 +378,6 @@
                         "amplitude": 0.05,
                         "shape": "GaussianSquare(5, 0.75)",
                         "coupler": 3,
-                        "relative_start": 0,
                         "type": "coupler"
                     }
                 ],
@@ -418,8 +387,7 @@
                         "amplitude": 0.3,
                         "shape": "Drag(5, -0.02)",
                         "frequency": 4150000000.0,
-                        "relative_start": 0,
-                        "phase": 0,
+                            "phase": 0,
                         "type": "qd",
                         "qubit": 2
                     },
@@ -442,7 +410,6 @@
                         "amplitude": 0.05,
                         "shape": "GaussianSquare(5, 0.75)",
                         "qubit": 2,
-                        "relative_start": 0,
                         "type": "qf"
                     },
                     {
@@ -460,7 +427,6 @@
                         "amplitude": 0.05,
                         "shape": "GaussianSquare(5, 0.75)",
                         "coupler": 4,
-                        "relative_start": 0,
                         "type": "coupler"
                     }
                 ],
@@ -470,7 +436,6 @@
                         "amplitude": 0.05,
                         "shape": "GaussianSquare(5, 0.75)",
                         "qubit": 2,
-                        "relative_start": 0,
                         "type": "qf"
                     },
                     {
@@ -488,7 +453,6 @@
                         "amplitude": 0.05,
                         "shape": "GaussianSquare(5, 0.75)",
                         "coupler": 4,
-                        "relative_start": 0,
                         "type": "coupler"
                     }
                 ]

--- a/src/qibolab/dummy/platform.py
+++ b/src/qibolab/dummy/platform.py
@@ -20,7 +20,7 @@ def remove_couplers(runcard):
     two_qubit = runcard["native_gates"]["two_qubit"]
     for i, gates in two_qubit.items():
         for j, gate in gates.items():
-            two_qubit[i][j] = [pulse for pulse in gate if pulse["type"] != "coupler"]
+            two_qubit[i][j] = [pulse for pulse in gate if "coupler" not in pulse]
     return runcard
 
 

--- a/src/qibolab/instruments/icarusqfpga.py
+++ b/src/qibolab/instruments/icarusqfpga.py
@@ -199,7 +199,6 @@ class RFSOC_RO(RFSOC):
         Parameter.duration,
         Parameter.frequency,
         Parameter.relative_phase,
-        Parameter.start,
     }
 
     def __init__(

--- a/src/qibolab/instruments/qblox/cluster_qcm_bb.py
+++ b/src/qibolab/instruments/qblox/cluster_qcm_bb.py
@@ -423,7 +423,6 @@ class QcmBb(ClusterModule):
                     Parameter.amplitude,
                     Parameter.duration,
                     Parameter.relative_phase,
-                    Parameter.start,
                 ]
 
                 for sweeper in sweepers:

--- a/src/qibolab/instruments/qblox/cluster_qcm_rf.py
+++ b/src/qibolab/instruments/qblox/cluster_qcm_rf.py
@@ -438,7 +438,6 @@ class QcmRf(ClusterModule):
                     Parameter.amplitude,
                     Parameter.duration,
                     Parameter.relative_phase,
-                    Parameter.start,
                 ]
 
                 for sweeper in sweepers:

--- a/src/qibolab/instruments/qblox/cluster_qrm_rf.py
+++ b/src/qibolab/instruments/qblox/cluster_qrm_rf.py
@@ -498,7 +498,6 @@ class QrmRf(ClusterModule):
                     Parameter.amplitude,
                     Parameter.duration,
                     Parameter.relative_phase,
-                    Parameter.start,
                 ]
 
                 for sweeper in sweepers:

--- a/src/qibolab/instruments/qblox/cluster_qrm_rf.py
+++ b/src/qibolab/instruments/qblox/cluster_qrm_rf.py
@@ -993,9 +993,9 @@ class QrmRf(ClusterModule):
                     if len(sequencer.pulses.ro_pulses) == 1:
                         pulse = sequencer.pulses.ro_pulses[0]
                         frequency = self.get_if(pulse)
-                        acquisitions[pulse.qubit] = acquisitions[pulse.id] = (
-                            AveragedAcquisition(scope, duration, frequency)
-                        )
+                        acquisitions[pulse.qubit] = acquisitions[
+                            pulse.id
+                        ] = AveragedAcquisition(scope, duration, frequency)
                     else:
                         raise RuntimeError(
                             "Software Demodulation only supports one acquisition per channel. "
@@ -1005,9 +1005,9 @@ class QrmRf(ClusterModule):
                     results = self.device.get_acquisitions(sequencer.number)
                     for pulse in sequencer.pulses.ro_pulses:
                         bins = results[pulse.id]["acquisition"]["bins"]
-                        acquisitions[pulse.qubit] = acquisitions[pulse.id] = (
-                            DemodulatedAcquisition(scope, bins, duration)
-                        )
+                        acquisitions[pulse.qubit] = acquisitions[
+                            pulse.id
+                        ] = DemodulatedAcquisition(scope, bins, duration)
 
         # TODO: to be updated once the functionality of ExecutionResults is extended
         return {key: acquisition for key, acquisition in acquisitions.items()}

--- a/src/qibolab/instruments/qblox/cluster_qrm_rf.py
+++ b/src/qibolab/instruments/qblox/cluster_qrm_rf.py
@@ -1,4 +1,5 @@
 """Qblox Cluster QRM-RF driver."""
+
 import copy
 import json
 import time
@@ -992,9 +993,9 @@ class QrmRf(ClusterModule):
                     if len(sequencer.pulses.ro_pulses) == 1:
                         pulse = sequencer.pulses.ro_pulses[0]
                         frequency = self.get_if(pulse)
-                        acquisitions[pulse.qubit] = acquisitions[
-                            pulse.id
-                        ] = AveragedAcquisition(scope, duration, frequency)
+                        acquisitions[pulse.qubit] = acquisitions[pulse.id] = (
+                            AveragedAcquisition(scope, duration, frequency)
+                        )
                     else:
                         raise RuntimeError(
                             "Software Demodulation only supports one acquisition per channel. "
@@ -1004,9 +1005,9 @@ class QrmRf(ClusterModule):
                     results = self.device.get_acquisitions(sequencer.number)
                     for pulse in sequencer.pulses.ro_pulses:
                         bins = results[pulse.id]["acquisition"]["bins"]
-                        acquisitions[pulse.qubit] = acquisitions[
-                            pulse.id
-                        ] = DemodulatedAcquisition(scope, bins, duration)
+                        acquisitions[pulse.qubit] = acquisitions[pulse.id] = (
+                            DemodulatedAcquisition(scope, bins, duration)
+                        )
 
         # TODO: to be updated once the functionality of ExecutionResults is extended
         return {key: acquisition for key, acquisition in acquisitions.items()}

--- a/src/qibolab/instruments/qblox/controller.py
+++ b/src/qibolab/instruments/qblox/controller.py
@@ -397,7 +397,6 @@ class QbloxController(Controller):
                 Parameter.gain,
                 Parameter.bias,
                 Parameter.amplitude,
-                Parameter.start,
                 Parameter.duration,
                 Parameter.relative_phase,
             ]

--- a/src/qibolab/instruments/qblox/sweeper.py
+++ b/src/qibolab/instruments/qblox/sweeper.py
@@ -224,7 +224,6 @@ class QbloxSweeper:
             Parameter.gain: QbloxSweeperType.gain,
             Parameter.amplitude: QbloxSweeperType.gain,
             Parameter.bias: QbloxSweeperType.offset,
-            Parameter.start: QbloxSweeperType.start,
             Parameter.duration: QbloxSweeperType.duration,
             Parameter.relative_phase: QbloxSweeperType.relative_phase,
         }

--- a/src/qibolab/instruments/rfsoc/convert.py
+++ b/src/qibolab/instruments/rfsoc/convert.py
@@ -165,14 +165,14 @@ def _(
             idx_sweep = sequence.index(pulse)
             indexes.append(idx_sweep)
             base_value = getattr(pulse, sweeper.parameter.name)
-            if idx_sweep != 0 and sweeper.parameter is START:
+            if idx_sweep != 0 and sweeper.parameter is START:  # pylint: disable=E0602
                 # do the conversion from start to delay
                 base_value = base_value - sequence[idx_sweep - 1].start
             values = sweeper.get_values(base_value)
             starts.append(values[0])
             stops.append(values[-1])
 
-            if sweeper.parameter is START:
+            if sweeper.parameter is START:  # pylint: disable=E0602
                 parameters.append(rfsoc.Parameter.DELAY)
             elif sweeper.parameter is DURATION:
                 parameters.append(rfsoc.Parameter.DURATION)

--- a/src/qibolab/instruments/rfsoc/convert.py
+++ b/src/qibolab/instruments/rfsoc/convert.py
@@ -9,7 +9,7 @@ import qibosoq.components.pulses as rfsoc_pulses
 
 from qibolab.platform import Qubit
 from qibolab.pulses import Pulse, PulseSequence, PulseShape
-from qibolab.sweeper import BIAS, DURATION, START, Parameter, Sweeper
+from qibolab.sweeper import BIAS, DURATION, Parameter, Sweeper
 
 HZ_TO_MHZ = 1e-6
 NS_TO_US = 1e-3

--- a/src/qibolab/instruments/zhinst/pulse.py
+++ b/src/qibolab/instruments/zhinst/pulse.py
@@ -86,7 +86,7 @@ class ZhPulse:
         """Laboneq sweep parameter if the delay of the pulse should be
         swept."""
 
-    # pylint: disable=R0903
+    # pylint: disable=R0903,E1101
     def add_sweeper(self, param: Parameter, sweeper: lo.SweepParameter):
         """Add sweeper to list of sweepers associated with this pulse."""
         if param in {
@@ -97,6 +97,7 @@ class ZhPulse:
         }:
             self.zhsweepers.append((param, sweeper))
         elif param is Parameter.start:
+            # TODO: Change this case to ``Delay.duration``
             if self.delay_sweeper:
                 raise ValueError(
                     "Cannot have multiple delay sweepers for a single pulse"

--- a/src/qibolab/instruments/zhinst/sweep.py
+++ b/src/qibolab/instruments/zhinst/sweep.py
@@ -62,7 +62,7 @@ class ProcessedSweeps:
         parallel_sweeps = []
         for sweeper in sweepers:
             for pulse in sweeper.pulses or []:
-                if sweeper.parameter in (Parameter.duration, Parameter.start):
+                if sweeper.parameter is Parameter.duration:
                     sweep_param = lo.SweepParameter(
                         values=sweeper.values * NANO_TO_SECONDS
                     )

--- a/src/qibolab/native.py
+++ b/src/qibolab/native.py
@@ -29,15 +29,21 @@ class TwoQubitNatives:
     """Container with the native two-qubit gates acting on a specific pair of
     qubits."""
 
-    CZ: Optional[PulseSequence] = field(default=None, metadata={"symmetric": True})
-    CNOT: Optional[PulseSequence] = field(default=None, metadata={"symmetric": False})
-    iSWAP: Optional[PulseSequence] = field(default=None, metadata={"symmetric": True})
+    CZ: PulseSequence = field(
+        default_factory=lambda: PulseSequence(), metadata={"symmetric": True}
+    )
+    CNOT: PulseSequence = field(
+        default_factory=lambda: PulseSequence(), metadata={"symmetric": False}
+    )
+    iSWAP: PulseSequence = field(
+        default_factory=lambda: PulseSequence(), metadata={"symmetric": True}
+    )
 
     @property
     def symmetric(self):
         """Check if the defined two-qubit gates are symmetric between target
         and control qubits."""
         return all(
-            fld.metadata["symmetric"] or getattr(self, fld.name) is None
+            fld.metadata["symmetric"] or len(getattr(self, fld.name)) == 0
             for fld in fields(self)
         )

--- a/src/qibolab/native.py
+++ b/src/qibolab/native.py
@@ -1,256 +1,7 @@
-import copy
-from collections import defaultdict
 from dataclasses import dataclass, field, fields, replace
-from typing import List, Optional, Union
+from typing import Dict, Optional, Tuple
 
-from qibolab.pulses import Pulse, PulseSequence, PulseType
-
-
-@dataclass
-class NativePulse:
-    """Container with parameters required to generate a pulse implementing a
-    native gate."""
-
-    name: str
-    """Name of the gate that the pulse implements."""
-    duration: int
-    amplitude: float
-    shape: str
-    pulse_type: PulseType
-    qubit: "qubits.Qubit"
-    frequency: int = 0
-    relative_start: int = 0
-    """Relative start is relevant for two-qubit gate operations which
-    correspond to a pulse sequence."""
-
-    # used for qblox
-    if_frequency: Optional[int] = None
-    # TODO: Note sure if the following parameters are useful to be in the runcard
-    start: int = 0
-    phase: float = 0.0
-
-    @classmethod
-    def from_dict(cls, name, pulse, qubit):
-        """Parse the dictionary provided by the runcard.
-
-        Args:
-            name (str): Name of the native gate (dictionary key).
-            pulse (dict): Dictionary containing the parameters of the pulse implementing
-                the gate, as loaded from the runcard.
-            qubits (:class:`qibolab.platforms.abstract.Qubit`): Qubit that the
-                pulse is acting on
-        """
-        kwargs = copy.deepcopy(pulse)
-        kwargs["pulse_type"] = PulseType(kwargs.pop("type"))
-        kwargs["qubit"] = qubit
-        return cls(name, **kwargs)
-
-    @property
-    def raw(self):
-        data = {
-            fld.name: getattr(self, fld.name)
-            for fld in fields(self)
-            if getattr(self, fld.name) is not None
-        }
-        del data["name"]
-        del data["start"]
-        if self.pulse_type is PulseType.FLUX:
-            del data["frequency"]
-            del data["phase"]
-        data["qubit"] = self.qubit.name
-        data["type"] = data.pop("pulse_type").value
-        return data
-
-    def pulse(self, start, relative_phase=0.0):
-        """Construct the :class:`qibolab.pulses.Pulse` object implementing the
-        gate.
-
-        Args:
-            start (int): Start time of the pulse in the sequence.
-            relative_phase (float): Relative phase of the pulse.
-
-        Returns:
-            A :class:`qibolab.pulses.DrivePulse` or :class:`qibolab.pulses.DrivePulse`
-            or :class:`qibolab.pulses.FluxPulse` with the pulse parameters of the gate.
-        """
-        if self.pulse_type is PulseType.FLUX:
-            return Pulse.flux(
-                start + self.relative_start,
-                self.duration,
-                self.amplitude,
-                self.shape,
-                channel=self.qubit.flux.name,
-                qubit=self.qubit.name,
-            )
-
-        channel = getattr(self.qubit, self.pulse_type.name.lower()).name
-        return Pulse(
-            start + self.relative_start,
-            self.duration,
-            self.amplitude,
-            self.frequency,
-            relative_phase,
-            self.shape,
-            type=self.pulse_type,
-            channel=channel,
-            qubit=self.qubit.name,
-        )
-
-
-@dataclass
-class VirtualZPulse:
-    """Container with parameters required to add a virtual Z phase in a pulse
-    sequence."""
-
-    phase: float
-    qubit: "qubits.Qubit"
-
-    @property
-    def raw(self):
-        return {"type": "virtual_z", "phase": self.phase, "qubit": self.qubit.name}
-
-
-@dataclass
-class CouplerPulse:
-    """Container with parameters required to add a coupler pulse in a pulse
-    sequence."""
-
-    duration: int
-    amplitude: float
-    shape: str
-    coupler: "couplers.Coupler"
-    relative_start: int = 0
-
-    @classmethod
-    def from_dict(cls, pulse, coupler):
-        """Parse the dictionary provided by the runcard.
-
-        Args:
-            name (str): Name of the native gate (dictionary key).
-            pulse (dict): Dictionary containing the parameters of the pulse implementing
-                the gate, as loaded from the runcard.
-            coupler (:class:`qibolab.platforms.abstract.Coupler`): Coupler that the
-                pulse is acting on
-        """
-        kwargs = copy.deepcopy(pulse)
-        kwargs["coupler"] = coupler
-        kwargs.pop("type")
-        return cls(**kwargs)
-
-    @property
-    def raw(self):
-        return {
-            "type": "coupler",
-            "duration": self.duration,
-            "amplitude": self.amplitude,
-            "shape": self.shape,
-            "coupler": self.coupler.name,
-            "relative_start": self.relative_start,
-        }
-
-    def pulse(self, start):
-        """Construct the :class:`qibolab.pulses.Pulse` object implementing the
-        gate.
-
-        Args:
-            start (int): Start time of the pulse in the sequence.
-
-        Returns:
-            A :class:`qibolab.pulses.FluxPulse` with the pulse parameters of the gate.
-        """
-        return Pulse(
-            start + self.relative_start,
-            self.duration,
-            self.amplitude,
-            0,
-            0,
-            self.shape,
-            type=PulseType.COUPLERFLUX,
-            channel=self.coupler.flux.name,
-            qubit=self.coupler.name,
-        )
-
-
-@dataclass
-class NativeSequence:
-    """List of :class:`qibolab.platforms.native.NativePulse` objects
-    implementing a gate.
-
-    Relevant for two-qubit gates, which usually require a sequence of
-    pulses to be implemented. These pulses may act on qubits different
-    than the qubits the gate is targeting.
-    """
-
-    name: str
-    pulses: List[Union[NativePulse, VirtualZPulse]] = field(default_factory=list)
-    coupler_pulses: List[CouplerPulse] = field(default_factory=list)
-
-    @classmethod
-    def from_dict(cls, name, sequence, qubits, couplers):
-        """Constructs the native sequence from the dictionaries provided in the
-        runcard.
-
-        Args:
-            name (str): Name of the gate the sequence is applying.
-            sequence (dict): Dictionary describing the sequence as provided in the runcard.
-            qubits (list): List of :class:`qibolab.qubits.Qubit` object for all
-                qubits in the platform. All qubits are required because the sequence may be
-                acting on qubits that the implemented gate is not targeting.
-            couplers (list): List of :class:`qibolab.couplers.Coupler` object for all
-                couplers in the platform. All couplers are required because the sequence may be
-                acting on couplers that the implemented gate is not targeting.
-        """
-        pulses = []
-        coupler_pulses = []
-
-        # If sequence contains only one pulse dictionary, convert it into a list that can be iterated below
-        if isinstance(sequence, dict):
-            sequence = [sequence]
-
-        for i, pulse in enumerate(sequence):
-            pulse = copy.deepcopy(pulse)
-            pulse_type = pulse.pop("type")
-            if pulse_type == "coupler":
-                pulse["coupler"] = couplers[pulse.pop("coupler")]
-                coupler_pulses.append(CouplerPulse(**pulse))
-            else:
-                qubit = qubits[pulse.pop("qubit")]
-                if pulse_type == "virtual_z":
-                    phase = pulse["phase"]
-                    pulses.append(VirtualZPulse(phase, qubit))
-                else:
-                    pulses.append(
-                        NativePulse(
-                            f"{name}{i}",
-                            **pulse,
-                            pulse_type=PulseType(pulse_type),
-                            qubit=qubit,
-                        )
-                    )
-        return cls(name, pulses, coupler_pulses)
-
-    @property
-    def raw(self):
-        pulses = [pulse.raw for pulse in self.pulses]
-        coupler_pulses = [pulse.raw for pulse in self.coupler_pulses]
-        return pulses + coupler_pulses
-
-    def sequence(self, start=0):
-        """Creates a :class:`qibolab.pulses.PulseSequence` object implementing
-        the sequence."""
-        sequence = PulseSequence()
-        virtual_z_phases = defaultdict(int)
-
-        for pulse in self.pulses:
-            if isinstance(pulse, NativePulse):
-                sequence.append(pulse.pulse(start=start))
-            else:
-                virtual_z_phases[pulse.qubit.name] += pulse.phase
-
-        for coupler_pulse in self.coupler_pulses:
-            sequence.append(coupler_pulse.pulse(start=start))
-        # TODO: Maybe ``virtual_z_phases`` should be an attribute of ``PulseSequence``
-        return sequence, virtual_z_phases
+from qibolab.pulses import Pulse, PulseSequence
 
 
 @dataclass
@@ -258,85 +9,22 @@ class SingleQubitNatives:
     """Container with the native single-qubit gates acting on a specific
     qubit."""
 
-    RX: Optional[NativePulse] = None
+    RX: Optional[Pulse] = None
     """Pulse to drive the qubit from state 0 to state 1."""
-    RX12: Optional[NativePulse] = None
+    RX12: Optional[Pulse] = None
     """Pulse to drive to qubit from state 1 to state 2."""
-    MZ: Optional[NativePulse] = None
+    MZ: Optional[Pulse] = None
     """Measurement pulse."""
+    CP: Optional[Pulse] = None
+    """Pulse to activate a coupler."""
 
     @property
-    def RX90(self) -> NativePulse:
+    def RX90(self) -> Pulse:
         """RX90 native pulse is inferred from RX by halving its amplitude."""
-        return replace(self.RX, name="RX90", amplitude=self.RX.amplitude / 2.0)
-
-    @classmethod
-    def from_dict(cls, qubit, native_gates):
-        """Parse native gates of the qubit from the runcard.
-
-        Args:
-            qubit (:class:`qibolab.qubits.Qubit`): Qubit object that the
-                native gates are acting on.
-            native_gates (dict): Dictionary with native gate pulse parameters as loaded
-                from the runcard.
-        """
-        pulses = {
-            n: NativePulse.from_dict(n, pulse, qubit=qubit)
-            for n, pulse in native_gates.items()
-        }
-        return cls(**pulses)
-
-    @property
-    def raw(self):
-        """Serialize native gate pulses.
-
-        ``None`` gates are not included.
-        """
-        data = {}
-        for fld in fields(self):
-            attr = getattr(self, fld.name)
-            if attr is not None:
-                data[fld.name] = attr.raw
-                del data[fld.name]["qubit"]
-        return data
+        return replace(self.RX, amplitude=self.RX.amplitude / 2.0)
 
 
-@dataclass
-class CouplerNatives:
-    """Container with the native single-qubit gates acting on a specific
-    qubit."""
-
-    CP: Optional[NativePulse] = None
-    """Pulse to activate the coupler."""
-
-    @classmethod
-    def from_dict(cls, coupler, native_gates):
-        """Parse coupler native gates from the runcard.
-
-        Args:
-            coupler (:class:`qibolab.couplers.Coupler`): Coupler object that the
-                native pulses are acting on.
-            native_gates (dict): Dictionary with native gate pulse parameters as loaded
-                from the runcard [Reusing the dict from qubits].
-        """
-        pulses = {
-            n: CouplerPulse.from_dict(pulse, coupler=coupler)
-            for n, pulse in native_gates.items()
-        }
-        return cls(**pulses)
-
-    @property
-    def raw(self):
-        """Serialize native gate pulses.
-
-        ``None`` gates are not included.
-        """
-        data = {}
-        for fld in fields(self):
-            attr = getattr(self, fld.name)
-            if attr is not None:
-                data[fld.name] = attr.raw
-        return data
+TwoQubitNativeType = Tuple[PulseSequence, Dict["QubitId", float]]
 
 
 @dataclass
@@ -344,9 +32,13 @@ class TwoQubitNatives:
     """Container with the native two-qubit gates acting on a specific pair of
     qubits."""
 
-    CZ: Optional[NativeSequence] = field(default=None, metadata={"symmetric": True})
-    CNOT: Optional[NativeSequence] = field(default=None, metadata={"symmetric": False})
-    iSWAP: Optional[NativeSequence] = field(default=None, metadata={"symmetric": True})
+    CZ: Optional[TwoQubitNativeType] = field(default=None, metadata={"symmetric": True})
+    CNOT: Optional[TwoQubitNativeType] = field(
+        default=None, metadata={"symmetric": False}
+    )
+    iSWAP: Optional[TwoQubitNativeType] = field(
+        default=None, metadata={"symmetric": True}
+    )
 
     @property
     def symmetric(self):
@@ -356,20 +48,3 @@ class TwoQubitNatives:
             fld.metadata["symmetric"] or getattr(self, fld.name) is None
             for fld in fields(self)
         )
-
-    @classmethod
-    def from_dict(cls, qubits, couplers, native_gates):
-        sequences = {
-            n: NativeSequence.from_dict(n, seq, qubits, couplers)
-            for n, seq in native_gates.items()
-        }
-        return cls(**sequences)
-
-    @property
-    def raw(self):
-        data = {}
-        for fld in fields(self):
-            gate = getattr(self, fld.name)
-            if gate is not None:
-                data[fld.name] = gate.raw
-        return data

--- a/src/qibolab/native.py
+++ b/src/qibolab/native.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field, fields, replace
-from typing import Dict, Optional, Tuple
+from typing import Optional
 
 from qibolab.pulses import Pulse, PulseSequence
 
@@ -24,21 +24,14 @@ class SingleQubitNatives:
         return replace(self.RX, amplitude=self.RX.amplitude / 2.0)
 
 
-TwoQubitNativeType = Tuple[PulseSequence, Dict["QubitId", float]]
-
-
 @dataclass
 class TwoQubitNatives:
     """Container with the native two-qubit gates acting on a specific pair of
     qubits."""
 
-    CZ: Optional[TwoQubitNativeType] = field(default=None, metadata={"symmetric": True})
-    CNOT: Optional[TwoQubitNativeType] = field(
-        default=None, metadata={"symmetric": False}
-    )
-    iSWAP: Optional[TwoQubitNativeType] = field(
-        default=None, metadata={"symmetric": True}
-    )
+    CZ: Optional[PulseSequence] = field(default=None, metadata={"symmetric": True})
+    CNOT: Optional[PulseSequence] = field(default=None, metadata={"symmetric": False})
+    iSWAP: Optional[PulseSequence] = field(default=None, metadata={"symmetric": True})
 
     @property
     def symmetric(self):

--- a/src/qibolab/platform.py
+++ b/src/qibolab/platform.py
@@ -274,7 +274,7 @@ class Platform:
                 platform = create_dummy()
                 sequence = PulseSequence()
                 parameter = Parameter.frequency
-                pulse = platform.create_qubit_readout_pulse(qubit=0, start=0)
+                pulse = platform.create_qubit_readout_pulse(qubit=0)
                 sequence.append(pulse)
                 parameter_range = np.random.randint(10, size=10)
                 sweeper = Sweeper(parameter, parameter_range, [pulse])
@@ -333,62 +333,68 @@ class Platform:
         except KeyError:
             return list(self.couplers.keys())[coupler]
 
-    def create_RX90_pulse(self, qubit, start=0, relative_phase=0):
+    def create_RX90_pulse(self, qubit, relative_phase=0):
         qubit = self.get_qubit(qubit)
-        return self.qubits[qubit].native_gates.RX90.pulse(start, relative_phase)
+        pulse = self.qubits[qubit].native_gates.RX90
+        pulse.relative_phase = relative_phase
+        return pulse
 
-    def create_RX_pulse(self, qubit, start=0, relative_phase=0):
+    def create_RX_pulse(self, qubit, relative_phase=0):
         qubit = self.get_qubit(qubit)
-        return self.qubits[qubit].native_gates.RX.pulse(start, relative_phase)
+        pulse = self.qubits[qubit].native_gates.RX
+        pulse.relative_phase = relative_phase
+        return pulse
 
-    def create_RX12_pulse(self, qubit, start=0, relative_phase=0):
+    def create_RX12_pulse(self, qubit, relative_phase=0):
         qubit = self.get_qubit(qubit)
-        return self.qubits[qubit].native_gates.RX12.pulse(start, relative_phase)
+        pulse = self.qubits[qubit].native_gates.RX12
+        pulse.relative_phase = relative_phase
+        return pulse
 
-    def create_CZ_pulse_sequence(self, qubits, start=0):
+    def create_CZ_pulse_sequence(self, qubits):
         pair = tuple(self.get_qubit(q) for q in qubits)
         if pair not in self.pairs or self.pairs[pair].native_gates.CZ is None:
             raise_error(
                 ValueError,
                 f"Calibration for CZ gate between qubits {qubits[0]} and {qubits[1]} not found.",
             )
-        return self.pairs[pair].native_gates.CZ.sequence(start)
+        return self.pairs[pair].native_gates.CZ
 
-    def create_iSWAP_pulse_sequence(self, qubits, start=0):
+    def create_iSWAP_pulse_sequence(self, qubits):
         pair = tuple(self.get_qubit(q) for q in qubits)
         if pair not in self.pairs or self.pairs[pair].native_gates.iSWAP is None:
             raise_error(
                 ValueError,
                 f"Calibration for iSWAP gate between qubits {qubits[0]} and {qubits[1]} not found.",
             )
-        return self.pairs[pair].native_gates.iSWAP.sequence(start)
+        return self.pairs[pair].native_gates.iSWAP
 
-    def create_CNOT_pulse_sequence(self, qubits, start=0):
+    def create_CNOT_pulse_sequence(self, qubits):
         pair = tuple(self.get_qubit(q) for q in qubits)
         if pair not in self.pairs or self.pairs[pair].native_gates.CNOT is None:
             raise_error(
                 ValueError,
                 f"Calibration for CNOT gate between qubits {qubits[0]} and {qubits[1]} not found.",
             )
-        return self.pairs[pair].native_gates.CNOT.sequence(start)
+        return self.pairs[pair].native_gates.CNOT
 
-    def create_MZ_pulse(self, qubit, start):
+    def create_MZ_pulse(self, qubit):
         qubit = self.get_qubit(qubit)
-        return self.qubits[qubit].native_gates.MZ.pulse(start)
+        return self.qubits[qubit].native_gates.MZ
 
-    def create_qubit_drive_pulse(self, qubit, start, duration, relative_phase=0):
+    def create_qubit_drive_pulse(self, qubit, duration, relative_phase=0):
         qubit = self.get_qubit(qubit)
-        pulse = self.qubits[qubit].native_gates.RX.pulse(start, relative_phase)
+        pulse = self.qubits[qubit].native_gates.RX
+        pulse.relative_phase = relative_phase
         pulse.duration = duration
         return pulse
 
-    def create_qubit_readout_pulse(self, qubit, start):
-        qubit = self.get_qubit(qubit)
-        return self.create_MZ_pulse(qubit, start)
+    def create_qubit_readout_pulse(self, qubit):
+        return self.create_MZ_pulse(qubit)
 
-    def create_coupler_pulse(self, coupler, start, duration=None, amplitude=None):
+    def create_coupler_pulse(self, coupler, duration=None, amplitude=None):
         coupler = self.get_coupler(coupler)
-        pulse = self.couplers[coupler].native_pulse.CP.pulse(start)
+        pulse = self.couplers[coupler].native_pulse.CP
         if duration is not None:
             pulse.duration = duration
         if amplitude is not None:

--- a/src/qibolab/platform.py
+++ b/src/qibolab/platform.py
@@ -10,7 +10,7 @@ from qibo.config import log, raise_error
 from .couplers import Coupler
 from .execution_parameters import ExecutionParameters
 from .instruments.abstract import Controller, Instrument, InstrumentId
-from .pulses import Drag, PulseSequence, PulseType
+from .pulses import Delay, Drag, PulseSequence, PulseType
 from .qubits import Qubit, QubitId, QubitPair, QubitPairId
 from .sweeper import Sweeper
 from .unrolling import batch

--- a/src/qibolab/platform.py
+++ b/src/qibolab/platform.py
@@ -160,7 +160,7 @@ class Platform:
             gates = pair.native_gates
             for fld in fields(gates):
                 sequence = getattr(gates, fld.name)
-                if sequence is not None:
+                if len(sequence) > 0:
                     new_sequence = PulseSequence()
                     for pulse in sequence:
                         if pulse.type is PulseType.VIRTUALZ:
@@ -413,7 +413,7 @@ class Platform:
 
     def create_CZ_pulse_sequence(self, qubits):
         pair = tuple(self.get_qubit(q).name for q in qubits)
-        if pair not in self.pairs or self.pairs[pair].native_gates.CZ is None:
+        if pair not in self.pairs or len(self.pairs[pair].native_gates.CZ) == 0:
             raise_error(
                 ValueError,
                 f"Calibration for CZ gate between qubits {qubits[0]} and {qubits[1]} not found.",
@@ -422,7 +422,7 @@ class Platform:
 
     def create_iSWAP_pulse_sequence(self, qubits):
         pair = tuple(self.get_qubit(q).name for q in qubits)
-        if pair not in self.pairs or self.pairs[pair].native_gates.iSWAP is None:
+        if pair not in self.pairs or len(self.pairs[pair].native_gates.iSWAP) == 0:
             raise_error(
                 ValueError,
                 f"Calibration for iSWAP gate between qubits {qubits[0]} and {qubits[1]} not found.",
@@ -431,7 +431,7 @@ class Platform:
 
     def create_CNOT_pulse_sequence(self, qubits):
         pair = tuple(self.get_qubit(q).name for q in qubits)
-        if pair not in self.pairs or self.pairs[pair].native_gates.CNOT is None:
+        if pair not in self.pairs or len(self.pairs[pair].native_gates.CNOT) == 0:
             raise_error(
                 ValueError,
                 f"Calibration for CNOT gate between qubits {qubits[0]} and {qubits[1]} not found.",

--- a/src/qibolab/pulses/__init__.py
+++ b/src/qibolab/pulses/__init__.py
@@ -1,4 +1,4 @@
-from .pulse import Delay, Pulse, PulseType
+from .pulse import Delay, Pulse, PulseType, VirtualZ
 from .sequence import PulseSequence
 from .shape import (
     IIR,

--- a/src/qibolab/pulses/__init__.py
+++ b/src/qibolab/pulses/__init__.py
@@ -1,4 +1,4 @@
-from .pulse import Pulse, PulseType
+from .pulse import Delay, Pulse, PulseType
 from .sequence import PulseSequence
 from .shape import (
     IIR,

--- a/src/qibolab/pulses/pulse.py
+++ b/src/qibolab/pulses/pulse.py
@@ -38,7 +38,7 @@ class Pulse:
 
     The value has to be in the range [10e6 to 300e6].
     """
-    relative_phase: float
+    phase: float
     """Relative phase of the pulse, in radians."""
     shape: PulseShape
     """Pulse shape, as a PulseShape object.

--- a/src/qibolab/pulses/pulse.py
+++ b/src/qibolab/pulses/pulse.py
@@ -33,14 +33,14 @@ class Pulse:
 
     Pulse amplitudes are normalised between -1 and 1.
     """
-    frequency: int
+    frequency: int = 0
     """Pulse Intermediate Frequency in Hz.
 
     The value has to be in the range [10e6 to 300e6].
     """
-    phase: float
+    relative_phase: float = 0.0
     """Relative phase of the pulse, in radians."""
-    shape: PulseShape
+    shape: PulseShape = "Rectangular()"
     """Pulse shape, as a PulseShape object.
 
     See

--- a/src/qibolab/pulses/pulse.py
+++ b/src/qibolab/pulses/pulse.py
@@ -20,6 +20,7 @@ class PulseType(Enum):
     FLUX = "qf"
     COUPLERFLUX = "cf"
     DELAY = "dl"
+    VIRTUALZ = "virtual_z"
 
 
 @dataclass
@@ -128,3 +129,19 @@ class Delay:
     """Channel on which the delay should be implemented."""
     type: PulseType = PulseType.DELAY
     """Type fixed to ``DELAY`` to comply with ``Pulse`` interface."""
+
+
+@dataclass
+class VirtualZ:
+    """Implementation of Z-rotations using virtual phase."""
+
+    duration = 0
+    """Duration of the virtual gate should always be zero."""
+
+    phase: float
+    """Phase that implements the rotation."""
+    channel: Optional[str] = None
+    """Channel on which the virtual phase should be added."""
+    qubit: int = 0
+    """Qubit on the drive of which the virtual phase should be added."""
+    type: PulseType = PulseType.VIRTUALZ

--- a/src/qibolab/pulses/pulse.py
+++ b/src/qibolab/pulses/pulse.py
@@ -19,11 +19,12 @@ class PulseType(Enum):
     DRIVE = "qd"
     FLUX = "qf"
     COUPLERFLUX = "cf"
+    DELAY = "dl"
 
 
 @dataclass
 class Pulse:
-    """Representation of a pulse to be sent to the QPU."""
+    """A pulse to be sent to the QPU."""
 
     duration: int
     """Pulse duration in ns."""
@@ -118,10 +119,12 @@ class Pulse:
 
 @dataclass
 class Delay:
-    """Representation of a wait instruction during which we are not sending any
-    pulses to the QPU."""
+    """A wait instruction during which we are not sending any pulses to the
+    QPU."""
 
     duration: int
     """Delay duration in ns."""
     channel: str
     """Channel on which the delay should be implemented."""
+    type: PulseType = PulseType.DELAY
+    """Type fixed to ``DELAY`` to comply with ``Pulse`` interface."""

--- a/src/qibolab/pulses/sequence.py
+++ b/src/qibolab/pulses/sequence.py
@@ -94,14 +94,21 @@ class PulseSequence(list):
         return new_pc
 
     @property
+    def pulses_per_channel(self):
+        """Return a dictionary with the sequence per channel."""
+        sequences = defaultdict(self.__class__)
+        for pulse in self:
+            sequences[pulse.channel].append(pulse)
+        return sequences
+
+    @property
     def duration(self) -> int:
         """The time when the last pulse of the sequence finishes."""
-        channel_pulses = defaultdict(list)
-        for pulse in self:
-            channel_pulses[pulse.channel].append(pulse)
-        return max(
-            sum(p.duration for p in pulses) for pulses in channel_pulses.values()
-        )
+        channel_pulses = self.pulses_per_channel
+        if len(channel_pulses) == 1:
+            pulses = next(iter(channel_pulses.values()))
+            return sum(pulse.duration for pulse in pulses)
+        return max(sequence.duration for sequence in channel_pulses.values())
 
     @property
     def channels(self) -> list:

--- a/src/qibolab/pulses/sequence.py
+++ b/src/qibolab/pulses/sequence.py
@@ -1,5 +1,7 @@
 """PulseSequence class."""
 
+from collections import defaultdict
+
 from .pulse import PulseType
 
 
@@ -94,11 +96,12 @@ class PulseSequence(list):
     @property
     def finish(self) -> int:
         """The time when the last pulse of the sequence finishes."""
-        t: int = 0
+        channel_pulses = defaultdict(list)
         for pulse in self:
-            if pulse.finish > t:
-                t = pulse.finish
-        return t
+            channel_pulses[pulse.channel].append(pulse)
+        return max(
+            sum(p.duration for p in pulses) for pulses in channel_pulses.values()
+        )
 
     @property
     def start(self) -> int:

--- a/src/qibolab/pulses/sequence.py
+++ b/src/qibolab/pulses/sequence.py
@@ -96,7 +96,7 @@ class PulseSequence(list):
     @property
     def pulses_per_channel(self):
         """Return a dictionary with the sequence per channel."""
-        sequences = defaultdict(self.__class__)
+        sequences = defaultdict(type(self))
         for pulse in self:
             sequences[pulse.channel].append(pulse)
         return sequences

--- a/src/qibolab/serialize.py
+++ b/src/qibolab/serialize.py
@@ -6,7 +6,6 @@ example for more details.
 """
 
 import json
-from collections import defaultdict
 from dataclasses import asdict, fields
 from pathlib import Path
 from typing import Tuple
@@ -22,7 +21,7 @@ from qibolab.platform import (
     QubitPairMap,
     Settings,
 )
-from qibolab.pulses import Delay, Pulse, PulseSequence, PulseType
+from qibolab.pulses import Delay, Pulse, PulseSequence, PulseType, VirtualZ
 from qibolab.qubits import Qubit, QubitPair
 
 RUNCARD = "parameters.json"
@@ -94,6 +93,8 @@ def _load_pulse(pulse_kwargs, qubit):
 
     if pulse_type == "dl":
         return Delay(**pulse_kwargs)
+    if pulse_type == "virtual_z":
+        return VirtualZ(**pulse_kwargs, qubit=q)
     return Pulse(**pulse_kwargs, type=pulse_type, qubit=q)
 
 
@@ -118,21 +119,15 @@ def _load_two_qubit_natives(qubits, couplers, gates) -> TwoQubitNatives:
             seq_kwargs = [seq_kwargs]
 
         sequence = PulseSequence()
-        virtual_z_phases = defaultdict(int)
         for kwargs in seq_kwargs:
-            _type = kwargs["type"]
-            if _type == "virtual_z":
-                q = kwargs["qubit"]
-                virtual_z_phases[q] += kwargs["phase"]
+            if "coupler" in kwargs:
+                qubit = couplers[kwargs["coupler"]]
             else:
-                if "coupler" in kwargs:
-                    qubit = couplers[kwargs["coupler"]]
-                else:
-                    qubit = qubits[kwargs["qubit"]]
-                sequence.append(_load_pulse(kwargs, qubit))
+                qubit = qubits[kwargs["qubit"]]
+            sequence.append(_load_pulse(kwargs, qubit))
+        sequences[name] = sequence
 
-        sequences[name] = (sequence, virtual_z_phases)
-        return TwoQubitNatives(**sequences)
+    return TwoQubitNatives(**sequences)
 
 
 def register_gates(
@@ -180,10 +175,13 @@ def _dump_pulse(pulse: Pulse):
     data = asdict(pulse)
     if pulse.type in (PulseType.FLUX, PulseType.COUPLERFLUX):
         del data["frequency"]
-    data["shape"] = str(pulse.shape)
+    if "shape" in data:
+        data["shape"] = str(pulse.shape)
     data["type"] = data["type"].value
-    del data["channel"]
-    del data["relative_phase"]
+    if "channel" in data:
+        del data["channel"]
+    if "relative_phase" in data:
+        del data["relative_phase"]
     return data
 
 
@@ -202,17 +200,13 @@ def _dump_two_qubit_natives(natives: TwoQubitNatives):
     for fld in fields(natives):
         if getattr(natives, fld.name) is None:
             continue
-        sequence, virtual_z_phases = getattr(natives, fld.name)
+        sequence = getattr(natives, fld.name)
         data[fld.name] = []
         for pulse in sequence:
             pulse_serial = _dump_pulse(pulse)
             if pulse.type == PulseType.COUPLERFLUX:
                 pulse_serial["coupler"] = pulse_serial["qubit"]
             data[fld.name].append(pulse_serial)
-        data[fld.name].extend(
-            {"type": "virtual_z", "phase": phase, "qubit": q}
-            for q, phase in virtual_z_phases.items()
-        )
     return data
 
 

--- a/src/qibolab/serialize.py
+++ b/src/qibolab/serialize.py
@@ -205,7 +205,7 @@ def _dump_two_qubit_natives(natives: TwoQubitNatives):
         for pulse in sequence:
             pulse_serial = _dump_pulse(pulse)
             if pulse.type == PulseType.COUPLERFLUX:
-                pulse_serial["coupler"] = pulse_serial["qubit"]
+                pulse_serial["coupler"] = pulse_serial.pop("qubit")
             data[fld.name].append(pulse_serial)
     return data
 

--- a/src/qibolab/serialize.py
+++ b/src/qibolab/serialize.py
@@ -85,21 +85,16 @@ def load_qubits(
     return qubits, couplers, pairs
 
 
-def _load_pulse(pulse_kwargs, qubit=None):
+def _load_pulse(pulse_kwargs, qubit):
     pulse_type = pulse_kwargs.pop("type")
-    q = pulse_kwargs.pop("qubit", qubit.name)
+    if "coupler" in pulse_kwargs:
+        q = pulse_kwargs.pop("coupler", qubit.name)
+    else:
+        q = pulse_kwargs.pop("qubit", qubit.name)
+
     if pulse_type == "dl":
         return Delay(**pulse_kwargs)
-
-    if pulse_type == "qf" or pulse_type == "cf":
-        pulse = Pulse.flux(**pulse_kwargs, qubit=q)
-    else:
-        pulse = Pulse(**pulse_kwargs, type=pulse_type, qubit=q)
-    channel_type = (
-        "flux" if pulse.type is PulseType.COUPLERFLUX else pulse.type.name.lower()
-    )
-    pulse.channel = getattr(qubit, channel_type)
-    return pulse
+    return Pulse(**pulse_kwargs, type=pulse_type, qubit=q)
 
 
 def _load_single_qubit_natives(qubit, gates) -> SingleQubitNatives:
@@ -126,11 +121,14 @@ def _load_two_qubit_natives(qubits, couplers, gates) -> TwoQubitNatives:
         virtual_z_phases = defaultdict(int)
         for kwargs in seq_kwargs:
             _type = kwargs["type"]
-            q = kwargs["qubit"]
             if _type == "virtual_z":
+                q = kwargs["qubit"]
                 virtual_z_phases[q] += kwargs["phase"]
             else:
-                qubit = couplers[q] if _type == "cf" else qubits[q]
+                if "coupler" in kwargs:
+                    qubit = couplers[kwargs["coupler"]]
+                else:
+                    qubit = qubits[kwargs["qubit"]]
                 sequence.append(_load_pulse(kwargs, qubit))
 
         sequences[name] = (sequence, virtual_z_phases)
@@ -150,14 +148,12 @@ def register_gates(
 
     native_gates = runcard.get("native_gates", {})
     for q, gates in native_gates.get("single_qubit", {}).items():
-        qubits[json.loads(q)].native_gates = _load_single_qubit_natives(
-            qubits[json.loads(q)], gates
-        )
+        qubit = qubits[json.loads(q)]
+        qubit.native_gates = _load_single_qubit_natives(qubit, gates)
 
     for c, gates in native_gates.get("coupler", {}).items():
-        couplers[json.loads(c)].native_pulse = _load_single_qubit_natives(
-            couplers[json.loads(c)], gates
-        )
+        coupler = couplers[json.loads(c)]
+        coupler.native_gates = _load_single_qubit_natives(coupler, gates)
 
     # register two-qubit native gates to ``QubitPair`` objects
     for pair, gatedict in native_gates.get("two_qubit", {}).items():
@@ -184,8 +180,10 @@ def _dump_pulse(pulse: Pulse):
     data = asdict(pulse)
     if pulse.type in (PulseType.FLUX, PulseType.COUPLERFLUX):
         del data["frequency"]
-        del data["relative_phase"]
+    data["shape"] = str(pulse.shape)
     data["type"] = data["type"].value
+    del data["channel"]
+    del data["relative_phase"]
     return data
 
 
@@ -205,7 +203,12 @@ def _dump_two_qubit_natives(natives: TwoQubitNatives):
         if getattr(natives, fld.name) is None:
             continue
         sequence, virtual_z_phases = getattr(natives, fld.name)
-        data[fld.name] = [_dump_pulse(pulse) for pulse in sequence]
+        data[fld.name] = []
+        for pulse in sequence:
+            pulse_serial = _dump_pulse(pulse)
+            if pulse.type == PulseType.COUPLERFLUX:
+                pulse_serial["coupler"] = pulse_serial["qubit"]
+            data[fld.name].append(pulse_serial)
         data[fld.name].extend(
             {"type": "virtual_z", "phase": phase, "qubit": q}
             for q, phase in virtual_z_phases.items()
@@ -228,7 +231,7 @@ def dump_native_gates(
 
     if couplers:
         native_gates["coupler"] = {
-            json.dumps(c): _dump_two_qubit_natives(coupler.native_gates)
+            json.dumps(c): _dump_single_qubit_natives(coupler.native_gates)
             for c, coupler in couplers.items()
         }
 

--- a/src/qibolab/serialize.py
+++ b/src/qibolab/serialize.py
@@ -198,15 +198,14 @@ def _dump_single_qubit_natives(natives: SingleQubitNatives):
 def _dump_two_qubit_natives(natives: TwoQubitNatives):
     data = {}
     for fld in fields(natives):
-        if getattr(natives, fld.name) is None:
-            continue
         sequence = getattr(natives, fld.name)
-        data[fld.name] = []
-        for pulse in sequence:
-            pulse_serial = _dump_pulse(pulse)
-            if pulse.type == PulseType.COUPLERFLUX:
-                pulse_serial["coupler"] = pulse_serial.pop("qubit")
-            data[fld.name].append(pulse_serial)
+        if len(sequence) > 0:
+            data[fld.name] = []
+            for pulse in sequence:
+                pulse_serial = _dump_pulse(pulse)
+                if pulse.type == PulseType.COUPLERFLUX:
+                    pulse_serial["coupler"] = pulse_serial.pop("qubit")
+                data[fld.name].append(pulse_serial)
     return data
 
 

--- a/src/qibolab/serialize.py
+++ b/src/qibolab/serialize.py
@@ -86,13 +86,18 @@ def load_qubits(
 
 
 def _load_pulse(pulse_kwargs, qubit=None):
-    _type = pulse_kwargs["type"]
+    pulse_type = pulse_kwargs.pop("type")
     q = pulse_kwargs.pop("qubit", qubit.name)
-    if _type == "dl":
+    if pulse_type == "dl":
         return Delay(**pulse_kwargs)
 
-    pulse = Pulse(**pulse_kwargs, qubit=q)
-    channel_type = "flux" if pulse.type is PulseType.COUPLERFLUX else pulse.type.lower()
+    if pulse_type == "qf" or pulse_type == "cf":
+        pulse = Pulse.flux(**pulse_kwargs, qubit=q)
+    else:
+        pulse = Pulse(**pulse_kwargs, type=pulse_type, qubit=q)
+    channel_type = (
+        "flux" if pulse.type is PulseType.COUPLERFLUX else pulse.type.name.lower()
+    )
     pulse.channel = getattr(qubit, channel_type)
     return pulse
 
@@ -114,7 +119,7 @@ def _load_single_qubit_natives(qubit, gates) -> SingleQubitNatives:
 def _load_two_qubit_natives(qubits, couplers, gates) -> TwoQubitNatives:
     sequences = {}
     for name, seq_kwargs in gates.items():
-        if isinstance(sequence, dict):
+        if isinstance(seq_kwargs, dict):
             seq_kwargs = [seq_kwargs]
 
         sequence = PulseSequence()

--- a/src/qibolab/sweeper.py
+++ b/src/qibolab/sweeper.py
@@ -14,7 +14,6 @@ class Parameter(Enum):
     amplitude = auto()
     duration = auto()
     relative_phase = auto()
-    start = auto()
 
     attenuation = auto()
     gain = auto()
@@ -26,7 +25,6 @@ FREQUENCY = Parameter.frequency
 AMPLITUDE = Parameter.amplitude
 DURATION = Parameter.duration
 RELATIVE_PHASE = Parameter.relative_phase
-START = Parameter.start
 ATTENUATION = Parameter.attenuation
 GAIN = Parameter.gain
 BIAS = Parameter.bias
@@ -64,7 +62,7 @@ class Sweeper:
             platform = create_dummy()
             sequence = PulseSequence()
             parameter = Parameter.frequency
-            pulse = platform.create_qubit_readout_pulse(qubit=0, start=0)
+            pulse = platform.create_qubit_readout_pulse(qubit=0)
             sequence.append(pulse)
             parameter_range = np.random.randint(10, size=10)
             sweeper = Sweeper(parameter, parameter_range, [pulse])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,3 +107,9 @@ def connected_platform(request):
     platform.connect()
     yield platform
     platform.disconnect()
+
+
+def pytest_generate_tests(metafunc):
+    name = metafunc.module.__name__
+    if "test_instruments" in name or "test_compilers" in name:
+        pytest.skip()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,5 +111,5 @@ def connected_platform(request):
 
 def pytest_generate_tests(metafunc):
     name = metafunc.module.__name__
-    if "test_instruments" in name or "test_compilers" in name:
+    if "test_instruments" in name or "test_compilers" in name or "qasm" in name:
         pytest.skip()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,5 +111,5 @@ def connected_platform(request):
 
 def pytest_generate_tests(metafunc):
     name = metafunc.module.__name__
-    if "test_instruments" in name or "test_compilers" in name or "qasm" in name:
+    if "test_instruments" in name:
         pytest.skip()

--- a/tests/dummy_qrc/qblox/parameters.json
+++ b/tests/dummy_qrc/qblox/parameters.json
@@ -103,24 +103,21 @@
                     "amplitude": 0.5028,
                     "frequency": 5050304836,
                     "shape": "Gaussian(5)",
-                    "type": "qd",
-                    "phase": 0
+                    "type": "qd"
                 },
                 "RX12": {
                     "duration": 40,
                     "amplitude": 0.5028,
                     "frequency": 5050304836,
                     "shape": "Gaussian(5)",
-                    "type": "qd",
-                    "phase": 0
+                    "type": "qd"
                 },
                 "MZ": {
                     "duration": 2000,
                     "amplitude": 0.1,
                     "frequency": 7213299307,
                     "shape": "Rectangular()",
-                    "type": "ro",
-                    "phase": 0
+                    "type": "ro"
                 }
             },
             "1": {
@@ -129,24 +126,21 @@
                     "amplitude": 0.5078,
                     "frequency": 4852833073,
                     "shape": "Gaussian(5)",
-                    "type": "qd",
-                    "phase": 0
+                    "type": "qd"
                 },
                 "RX12": {
                     "duration": 40,
                     "amplitude": 0.5078,
                     "frequency": 4852833073,
                     "shape": "Gaussian(5)",
-                    "type": "qd",
-                    "phase": 0
+                    "type": "qd"
                 },
                 "MZ": {
                     "duration": 2000,
                     "amplitude": 0.2,
                     "frequency": 7452990931,
                     "shape": "Rectangular()",
-                    "type": "ro",
-                    "phase": 0
+                    "type": "ro"
                 }
             },
             "2": {
@@ -155,24 +149,21 @@
                     "amplitude": 0.5016,
                     "frequency": 5795371914,
                     "shape": "Gaussian(5)",
-                    "type": "qd",
-                    "phase": 0
+                    "type": "qd"
                 },
                 "RX12": {
                     "duration": 40,
                     "amplitude": 0.5016,
                     "frequency": 5795371914,
                     "shape": "Gaussian(5)",
-                    "type": "qd",
-                    "phase": 0
+                    "type": "qd"
                 },
                 "MZ": {
                     "duration": 2000,
                     "amplitude": 0.25,
                     "frequency": 7655083068,
                     "shape": "Rectangular()",
-                    "type": "ro",
-                    "phase": 0
+                    "type": "ro"
                 }
             },
             "3": {
@@ -181,24 +172,21 @@
                     "amplitude": 0.5026,
                     "frequency": 6761018001,
                     "shape": "Gaussian(5)",
-                    "type": "qd",
-                    "phase": 0
+                    "type": "qd"
                 },
                 "RX12": {
                     "duration": 40,
                     "amplitude": 0.5026,
                     "frequency": 6761018001,
                     "shape": "Gaussian(5)",
-                    "type": "qd",
-                    "phase": 0
+                    "type": "qd"
                 },
                 "MZ": {
                     "duration": 2000,
                     "amplitude": 0.2,
                     "frequency": 7803441221,
                     "shape": "Rectangular()",
-                    "type": "ro",
-                    "phase": 0
+                    "type": "ro"
                 }
             },
             "4": {
@@ -207,24 +195,21 @@
                     "amplitude": 0.5172,
                     "frequency": 6586543060,
                     "shape": "Gaussian(5)",
-                    "type": "qd",
-                    "phase": 0
+                    "type": "qd"
                 },
                 "RX12": {
                     "duration": 40,
                     "amplitude": 0.5172,
                     "frequency": 6586543060,
                     "shape": "Gaussian(5)",
-                    "type": "qd",
-                    "phase": 0
+                    "type": "qd"
                 },
                 "MZ": {
                     "duration": 2000,
                     "amplitude": 0.4,
                     "frequency": 8058947261,
                     "shape": "Rectangular()",
-                    "type": "ro",
-                    "phase": 0
+                    "type": "ro"
                 }
             }
         },

--- a/tests/dummy_qrc/qblox/parameters.json
+++ b/tests/dummy_qrc/qblox/parameters.json
@@ -104,7 +104,6 @@
                     "frequency": 5050304836,
                     "shape": "Gaussian(5)",
                     "type": "qd",
-                    "relative_start": 0,
                     "phase": 0
                 },
                 "RX12": {
@@ -113,7 +112,6 @@
                     "frequency": 5050304836,
                     "shape": "Gaussian(5)",
                     "type": "qd",
-                    "relative_start": 0,
                     "phase": 0
                 },
                 "MZ": {
@@ -122,7 +120,6 @@
                     "frequency": 7213299307,
                     "shape": "Rectangular()",
                     "type": "ro",
-                    "relative_start": 0,
                     "phase": 0
                 }
             },
@@ -133,7 +130,6 @@
                     "frequency": 4852833073,
                     "shape": "Gaussian(5)",
                     "type": "qd",
-                    "relative_start": 0,
                     "phase": 0
                 },
                 "RX12": {
@@ -142,7 +138,6 @@
                     "frequency": 4852833073,
                     "shape": "Gaussian(5)",
                     "type": "qd",
-                    "relative_start": 0,
                     "phase": 0
                 },
                 "MZ": {
@@ -151,7 +146,6 @@
                     "frequency": 7452990931,
                     "shape": "Rectangular()",
                     "type": "ro",
-                    "relative_start": 0,
                     "phase": 0
                 }
             },
@@ -162,7 +156,6 @@
                     "frequency": 5795371914,
                     "shape": "Gaussian(5)",
                     "type": "qd",
-                    "relative_start": 0,
                     "phase": 0
                 },
                 "RX12": {
@@ -171,7 +164,6 @@
                     "frequency": 5795371914,
                     "shape": "Gaussian(5)",
                     "type": "qd",
-                    "relative_start": 0,
                     "phase": 0
                 },
                 "MZ": {
@@ -180,7 +172,6 @@
                     "frequency": 7655083068,
                     "shape": "Rectangular()",
                     "type": "ro",
-                    "relative_start": 0,
                     "phase": 0
                 }
             },
@@ -191,7 +182,6 @@
                     "frequency": 6761018001,
                     "shape": "Gaussian(5)",
                     "type": "qd",
-                    "relative_start": 0,
                     "phase": 0
                 },
                 "RX12": {
@@ -200,7 +190,6 @@
                     "frequency": 6761018001,
                     "shape": "Gaussian(5)",
                     "type": "qd",
-                    "relative_start": 0,
                     "phase": 0
                 },
                 "MZ": {
@@ -209,7 +198,6 @@
                     "frequency": 7803441221,
                     "shape": "Rectangular()",
                     "type": "ro",
-                    "relative_start": 0,
                     "phase": 0
                 }
             },
@@ -220,7 +208,6 @@
                     "frequency": 6586543060,
                     "shape": "Gaussian(5)",
                     "type": "qd",
-                    "relative_start": 0,
                     "phase": 0
                 },
                 "RX12": {
@@ -229,7 +216,6 @@
                     "frequency": 6586543060,
                     "shape": "Gaussian(5)",
                     "type": "qd",
-                    "relative_start": 0,
                     "phase": 0
                 },
                 "MZ": {
@@ -238,7 +224,6 @@
                     "frequency": 8058947261,
                     "shape": "Rectangular()",
                     "type": "ro",
-                    "relative_start": 0,
                     "phase": 0
                 }
             }
@@ -251,37 +236,12 @@
                         "amplitude": -0.6025,
                         "shape": "Exponential(12, 5000, 0.1)",
                         "qubit": 3,
-                        "relative_start": 0,
-                        "type": "qf"
-                    },
-                    {
-                        "duration": 20,
-                        "amplitude": 0,
-                        "shape": "Rectangular())",
-                        "qubit": 3,
-                        "relative_start": 32,
                         "type": "qf"
                     },
                     {
                         "type": "virtual_z",
                         "phase": -3.63,
                         "qubit": 3
-                    },
-                    {
-                        "duration": 32,
-                        "amplitude": 0,
-                        "shape": "Rectangular())",
-                        "qubit": 2,
-                        "relative_start": 0,
-                        "type": "qf"
-                    },
-                    {
-                        "duration": 20,
-                        "amplitude": 0,
-                        "shape": "Rectangular())",
-                        "qubit": 2,
-                        "relative_start": 32,
-                        "type": "qf"
                     },
                     {
                         "type": "virtual_z",
@@ -297,7 +257,6 @@
                         "amplitude": -0.142,
                         "shape": "Exponential(12, 5000, 0.1)",
                         "qubit": 2,
-                        "relative_start": 0,
                         "type": "qf"
                     }
                 ]
@@ -308,38 +267,13 @@
                         "duration": 32,
                         "amplitude": -0.6025,
                         "shape": "Exponential(12, 5000, 0.1)",
-                        "qubit": 3,
-                        "relative_start": 0,
-                        "type": "qf"
-                    },
-                    {
-                        "duration": 20,
-                        "amplitude": 0,
-                        "shape": "Rectangular())",
-                        "qubit": 3,
-                        "relative_start": 32,
+                        "qubit": 2,
                         "type": "qf"
                     },
                     {
                         "type": "virtual_z",
                         "phase": -3.63,
-                        "qubit": 3
-                    },
-                    {
-                        "duration": 32,
-                        "amplitude": 0,
-                        "shape": "Rectangular())",
-                        "qubit": 2,
-                        "relative_start": 0,
-                        "type": "qf"
-                    },
-                    {
-                        "duration": 20,
-                        "amplitude": 0,
-                        "shape": "Rectangular())",
-                        "qubit": 2,
-                        "relative_start": 32,
-                        "type": "qf"
+                        "qubit": 1
                     },
                     {
                         "type": "virtual_z",

--- a/tests/dummy_qrc/qm/parameters.json
+++ b/tests/dummy_qrc/qm/parameters.json
@@ -85,7 +85,6 @@
                     "frequency": 4700000000,
                     "shape": "Gaussian(5)",
                     "type": "qd",
-                    "relative_start": 0,
                     "phase": 0
                 },
                 "RX12": {
@@ -94,7 +93,6 @@
                     "frequency": 4700000000,
                     "shape": "Gaussian(5)",
                     "type": "qd",
-                    "relative_start": 0,
                     "phase": 0
                 },
                 "MZ": {
@@ -103,7 +101,6 @@
                     "frequency": 7226500000,
                     "shape": "Rectangular()",
                     "type": "ro",
-                    "relative_start": 0,
                     "phase": 0
                 }
             },
@@ -114,7 +111,6 @@
                     "frequency": 4855663000,
                     "shape": "Drag(5, -0.02)",
                     "type": "qd",
-                    "relative_start": 0,
                     "phase": 0
                 },
                 "RX12": {
@@ -123,7 +119,6 @@
                     "frequency": 4855663000,
                     "shape": "Drag(5, -0.02)",
                     "type": "qd",
-                    "relative_start": 0,
                     "phase": 0
                 },
                 "MZ": {
@@ -132,7 +127,6 @@
                     "frequency": 7453265000,
                     "shape": "Rectangular()",
                     "type": "ro",
-                    "relative_start": 0,
                     "phase": 0
                 }
             },
@@ -143,7 +137,6 @@
                     "frequency": 5800563000,
                     "shape": "Drag(5, -0.04)",
                     "type": "qd",
-                    "relative_start": 0,
                     "phase": 0
                 },
                 "RX12": {
@@ -152,7 +145,6 @@
                     "frequency": 5800563000,
                     "shape": "Drag(5, -0.04)",
                     "type": "qd",
-                    "relative_start": 0,
                     "phase": 0
                 },
                 "MZ": {
@@ -161,7 +153,6 @@
                     "frequency": 7655107000,
                     "shape": "Rectangular()",
                     "type": "ro",
-                    "relative_start": 0,
                     "phase": 0
                 }
             },
@@ -172,7 +163,6 @@
                     "frequency": 6760922000,
                     "shape": "Gaussian(5)",
                     "type": "qd",
-                    "relative_start": 0,
                     "phase": 0
                 },
                 "RX12": {
@@ -181,7 +171,6 @@
                     "frequency": 6760922000,
                     "shape": "Gaussian(5)",
                     "type": "qd",
-                    "relative_start": 0,
                     "phase": 0
                 },
                 "MZ": {
@@ -190,7 +179,6 @@
                     "frequency": 7802191000,
                     "shape": "Rectangular()",
                     "type": "ro",
-                    "relative_start": 0,
                     "phase": 0
                 }
             },
@@ -201,7 +189,6 @@
                     "frequency": 6585053000,
                     "shape": "Drag(5, 0.0)",
                     "type": "qd",
-                    "relative_start": 0,
                     "phase": 0
                 },
                 "RX12": {
@@ -210,7 +197,6 @@
                     "frequency": 6585053000,
                     "shape": "Drag(5, 0.0)",
                     "type": "qd",
-                    "relative_start": 0,
                     "phase": 0
                 },
                 "MZ": {
@@ -219,7 +205,6 @@
                     "frequency": 8057668000,
                     "shape": "Rectangular()",
                     "type": "ro",
-                    "relative_start": 0,
                     "phase": 0
                 }
             }
@@ -232,7 +217,6 @@
                         "amplitude": 0.055,
                         "shape": "Rectangular()",
                         "qubit": 2,
-                        "relative_start": 0,
                         "type": "qf"
                     },
                     {
@@ -254,7 +238,6 @@
                         "amplitude": -0.0513,
                         "shape": "Rectangular()",
                         "qubit": 3,
-                        "relative_start": 0,
                         "type": "qf"
                     },
                     {

--- a/tests/dummy_qrc/qm/parameters.json
+++ b/tests/dummy_qrc/qm/parameters.json
@@ -90,16 +90,14 @@
                     "amplitude": 0.005,
                     "frequency": 4700000000,
                     "shape": "Gaussian(5)",
-                    "type": "qd",
-                    "phase": 0
+                    "type": "qd"
                 },
                 "MZ": {
                     "duration": 1000,
                     "amplitude": 0.0025,
                     "frequency": 7226500000,
                     "shape": "Rectangular()",
-                    "type": "ro",
-                    "phase": 0
+                    "type": "ro"
                 }
             },
             "1": {
@@ -108,24 +106,21 @@
                     "amplitude": 0.0484,
                     "frequency": 4855663000,
                     "shape": "Drag(5, -0.02)",
-                    "type": "qd",
-                    "phase": 0
+                    "type": "qd"
                 },
                 "RX12": {
                     "duration": 40,
                     "amplitude": 0.0484,
                     "frequency": 4855663000,
                     "shape": "Drag(5, -0.02)",
-                    "type": "qd",
-                    "phase": 0
+                    "type": "qd"
                 },
                 "MZ": {
                     "duration": 620,
                     "amplitude": 0.003575,
                     "frequency": 7453265000,
                     "shape": "Rectangular()",
-                    "type": "ro",
-                    "phase": 0
+                    "type": "ro"
                 }
             },
             "2": {
@@ -134,24 +129,21 @@
                     "amplitude": 0.05682,
                     "frequency": 5800563000,
                     "shape": "Drag(5, -0.04)",
-                    "type": "qd",
-                    "phase": 0
+                    "type": "qd"
                 },
                 "RX12": {
                     "duration": 40,
                     "amplitude": 0.05682,
                     "frequency": 5800563000,
                     "shape": "Drag(5, -0.04)",
-                    "type": "qd",
-                    "phase": 0
+                    "type": "qd"
                 },
                 "MZ": {
                     "duration": 960,
                     "amplitude": 0.00325,
                     "frequency": 7655107000,
                     "shape": "Rectangular()",
-                    "type": "ro",
-                    "phase": 0
+                    "type": "ro"
                 }
             },
             "3": {
@@ -160,24 +152,21 @@
                     "amplitude": 0.138,
                     "frequency": 6760922000,
                     "shape": "Gaussian(5)",
-                    "type": "qd",
-                    "phase": 0
+                    "type": "qd"
                 },
                 "RX12": {
                     "duration": 40,
                     "amplitude": 0.138,
                     "frequency": 6760922000,
                     "shape": "Gaussian(5)",
-                    "type": "qd",
-                    "phase": 0
+                    "type": "qd"
                 },
                 "MZ": {
                     "duration": 960,
                     "amplitude": 0.004225,
                     "frequency": 7802191000,
                     "shape": "Rectangular()",
-                    "type": "ro",
-                    "phase": 0
+                    "type": "ro"
                 }
             },
             "4": {
@@ -186,24 +175,21 @@
                     "amplitude": 0.0617,
                     "frequency": 6585053000,
                     "shape": "Drag(5, 0.0)",
-                    "type": "qd",
-                    "phase": 0
+                    "type": "qd"
                 },
                 "RX12": {
                     "duration": 40,
                     "amplitude": 0.0617,
                     "frequency": 6585053000,
                     "shape": "Drag(5, 0.0)",
-                    "type": "qd",
-                    "phase": 0
+                    "type": "qd"
                 },
                 "MZ": {
                     "duration": 640,
                     "amplitude": 0.0039,
                     "frequency": 8057668000,
                     "shape": "Rectangular()",
-                    "type": "ro",
-                    "phase": 0
+                    "type": "ro"
                 }
             }
         },

--- a/tests/dummy_qrc/qm/parameters.json
+++ b/tests/dummy_qrc/qm/parameters.json
@@ -105,14 +105,14 @@
                     "duration": 40,
                     "amplitude": 0.0484,
                     "frequency": 4855663000,
-                    "shape": "Drag(5, -0.02)",
+                    "shape": "Drag(5, 0.02)",
                     "type": "qd"
                 },
                 "RX12": {
                     "duration": 40,
                     "amplitude": 0.0484,
                     "frequency": 4855663000,
-                    "shape": "Drag(5, -0.02)",
+                    "shape": "Drag(5, 0.02)",
                     "type": "qd"
                 },
                 "MZ": {
@@ -128,14 +128,14 @@
                     "duration": 40,
                     "amplitude": 0.05682,
                     "frequency": 5800563000,
-                    "shape": "Drag(5, -0.04)",
+                    "shape": "Drag(5, 0.04)",
                     "type": "qd"
                 },
                 "RX12": {
                     "duration": 40,
                     "amplitude": 0.05682,
                     "frequency": 5800563000,
-                    "shape": "Drag(5, -0.04)",
+                    "shape": "Drag(5, 0.04)",
                     "type": "qd"
                 },
                 "MZ": {
@@ -174,14 +174,14 @@
                     "duration": 40,
                     "amplitude": 0.0617,
                     "frequency": 6585053000,
-                    "shape": "Drag(5, 0.0)",
+                    "shape": "Drag(5, 0)",
                     "type": "qd"
                 },
                 "RX12": {
                     "duration": 40,
                     "amplitude": 0.0617,
                     "frequency": 6585053000,
-                    "shape": "Drag(5, 0.0)",
+                    "shape": "Drag(5, 0)",
                     "type": "qd"
                 },
                 "MZ": {

--- a/tests/dummy_qrc/qm/parameters.json
+++ b/tests/dummy_qrc/qm/parameters.json
@@ -84,9 +84,7 @@
                     "amplitude": 0.005,
                     "frequency": 4700000000,
                     "shape": "Gaussian(5)",
-                    "type": "qd",
-                    "phase": 0
-                },
+                    "type": "qd"},
                 "RX12": {
                     "duration": 40,
                     "amplitude": 0.005,

--- a/tests/dummy_qrc/qm_octave/parameters.json
+++ b/tests/dummy_qrc/qm_octave/parameters.json
@@ -125,13 +125,13 @@
                     "duration": 40,
                     "amplitude": 0.0484,
                     "frequency": 4855663000,
-                    "shape": "Drag(5, -0.02)",
+                    "shape": "Drag(5, 0.02)",
                     "type": "qd"},
                 "RX12": {
                     "duration": 40,
                     "amplitude": 0.0484,
                     "frequency": 4855663000,
-                    "shape": "Drag(5, -0.02)",
+                    "shape": "Drag(5, 0.02)",
                     "type": "qd"},
                 "MZ": {
                     "duration": 620,
@@ -145,13 +145,13 @@
                     "duration": 40,
                     "amplitude": 0.05682,
                     "frequency": 5800563000,
-                    "shape": "Drag(5, -0.04)",
+                    "shape": "Drag(5, 0.04)",
                     "type": "qd"},
                 "RX12": {
                     "duration": 40,
                     "amplitude": 0.05682,
                     "frequency": 5800563000,
-                    "shape": "Drag(5, -0.04)",
+                    "shape": "Drag(5, 0.04)",
                     "type": "qd"},
                 "MZ": {
                     "duration": 960,
@@ -185,13 +185,13 @@
                     "duration": 40,
                     "amplitude": 0.0617,
                     "frequency": 6585053000,
-                    "shape": "Drag(5, 0.0)",
+                    "shape": "Drag(5, 0)",
                     "type": "qd"},
                 "RX12": {
                     "duration": 40,
                     "amplitude": 0.0617,
                     "frequency": 6585053000,
-                    "shape": "Drag(5, 0.0)",
+                    "shape": "Drag(5, 0)",
                     "type": "qd"},
                 "MZ": {
                     "duration": 640,

--- a/tests/dummy_qrc/qm_octave/parameters.json
+++ b/tests/dummy_qrc/qm_octave/parameters.json
@@ -107,7 +107,6 @@
                     "frequency": 4700000000,
                     "shape": "Gaussian(5)",
                     "type": "qd",
-                    "relative_start": 0,
                     "phase": 0
                 },
                 "RX12": {
@@ -116,7 +115,6 @@
                     "frequency": 4700000000,
                     "shape": "Gaussian(5)",
                     "type": "qd",
-                    "relative_start": 0,
                     "phase": 0
                 },
                 "MZ": {
@@ -125,7 +123,6 @@
                     "frequency": 7226500000,
                     "shape": "Rectangular()",
                     "type": "ro",
-                    "relative_start": 0,
                     "phase": 0
                 }
             },
@@ -136,7 +133,6 @@
                     "frequency": 4855663000,
                     "shape": "Drag(5, -0.02)",
                     "type": "qd",
-                    "relative_start": 0,
                     "phase": 0
                 },
                 "RX12": {
@@ -145,7 +141,6 @@
                     "frequency": 4855663000,
                     "shape": "Drag(5, -0.02)",
                     "type": "qd",
-                    "relative_start": 0,
                     "phase": 0
                 },
                 "MZ": {
@@ -154,7 +149,6 @@
                     "frequency": 7453265000,
                     "shape": "Rectangular()",
                     "type": "ro",
-                    "relative_start": 0,
                     "phase": 0
                 }
             },
@@ -165,7 +159,6 @@
                     "frequency": 5800563000,
                     "shape": "Drag(5, -0.04)",
                     "type": "qd",
-                    "relative_start": 0,
                     "phase": 0
                 },
                 "RX12": {
@@ -174,7 +167,6 @@
                     "frequency": 5800563000,
                     "shape": "Drag(5, -0.04)",
                     "type": "qd",
-                    "relative_start": 0,
                     "phase": 0
                 },
                 "MZ": {
@@ -183,7 +175,6 @@
                     "frequency": 7655107000,
                     "shape": "Rectangular()",
                     "type": "ro",
-                    "relative_start": 0,
                     "phase": 0
                 }
             },
@@ -194,7 +185,6 @@
                     "frequency": 6760922000,
                     "shape": "Gaussian(5)",
                     "type": "qd",
-                    "relative_start": 0,
                     "phase": 0
                 },
                 "RX12": {
@@ -203,7 +193,6 @@
                     "frequency": 6760922000,
                     "shape": "Gaussian(5)",
                     "type": "qd",
-                    "relative_start": 0,
                     "phase": 0
                 },
                 "MZ": {
@@ -212,7 +201,6 @@
                     "frequency": 7802191000,
                     "shape": "Rectangular()",
                     "type": "ro",
-                    "relative_start": 0,
                     "phase": 0
                 }
             },
@@ -223,7 +211,6 @@
                     "frequency": 6585053000,
                     "shape": "Drag(5, 0.0)",
                     "type": "qd",
-                    "relative_start": 0,
                     "phase": 0
                 },
                 "RX12": {
@@ -232,7 +219,6 @@
                     "frequency": 6585053000,
                     "shape": "Drag(5, 0.0)",
                     "type": "qd",
-                    "relative_start": 0,
                     "phase": 0
                 },
                 "MZ": {
@@ -241,7 +227,6 @@
                     "frequency": 8057668000,
                     "shape": "Rectangular()",
                     "type": "ro",
-                    "relative_start": 0,
                     "phase": 0
                 }
             }
@@ -254,8 +239,7 @@
                         "amplitude": 0.055,
                         "shape": "Rectangular()",
                         "qubit": 2,
-                        "relative_start": 0,
-                        "type": "qf"
+                            "type": "qf"
                     },
                     {
                         "type": "virtual_z",
@@ -276,8 +260,7 @@
                         "amplitude": -0.0513,
                         "shape": "Rectangular()",
                         "qubit": 3,
-                        "relative_start": 0,
-                        "type": "qf"
+                            "type": "qf"
                     },
                     {
                         "type": "virtual_z",

--- a/tests/dummy_qrc/qm_octave/parameters.json
+++ b/tests/dummy_qrc/qm_octave/parameters.json
@@ -106,25 +106,19 @@
                     "amplitude": 0.005,
                     "frequency": 4700000000,
                     "shape": "Gaussian(5)",
-                    "type": "qd",
-                    "phase": 0
-                },
+                    "type": "qd"},
                 "RX12": {
                     "duration": 40,
                     "amplitude": 0.005,
                     "frequency": 4700000000,
                     "shape": "Gaussian(5)",
-                    "type": "qd",
-                    "phase": 0
-                },
+                    "type": "qd"},
                 "MZ": {
                     "duration": 1000,
                     "amplitude": 0.0025,
                     "frequency": 7226500000,
                     "shape": "Rectangular()",
-                    "type": "ro",
-                    "phase": 0
-                }
+                    "type": "ro"}
             },
             "1": {
                 "RX": {
@@ -132,25 +126,19 @@
                     "amplitude": 0.0484,
                     "frequency": 4855663000,
                     "shape": "Drag(5, -0.02)",
-                    "type": "qd",
-                    "phase": 0
-                },
+                    "type": "qd"},
                 "RX12": {
                     "duration": 40,
                     "amplitude": 0.0484,
                     "frequency": 4855663000,
                     "shape": "Drag(5, -0.02)",
-                    "type": "qd",
-                    "phase": 0
-                },
+                    "type": "qd"},
                 "MZ": {
                     "duration": 620,
                     "amplitude": 0.003575,
                     "frequency": 7453265000,
                     "shape": "Rectangular()",
-                    "type": "ro",
-                    "phase": 0
-                }
+                    "type": "ro"}
             },
             "2": {
                 "RX": {
@@ -158,25 +146,19 @@
                     "amplitude": 0.05682,
                     "frequency": 5800563000,
                     "shape": "Drag(5, -0.04)",
-                    "type": "qd",
-                    "phase": 0
-                },
+                    "type": "qd"},
                 "RX12": {
                     "duration": 40,
                     "amplitude": 0.05682,
                     "frequency": 5800563000,
                     "shape": "Drag(5, -0.04)",
-                    "type": "qd",
-                    "phase": 0
-                },
+                    "type": "qd"},
                 "MZ": {
                     "duration": 960,
                     "amplitude": 0.00325,
                     "frequency": 7655107000,
                     "shape": "Rectangular()",
-                    "type": "ro",
-                    "phase": 0
-                }
+                    "type": "ro"}
             },
             "3": {
                 "RX": {
@@ -184,25 +166,19 @@
                     "amplitude": 0.138,
                     "frequency": 6760922000,
                     "shape": "Gaussian(5)",
-                    "type": "qd",
-                    "phase": 0
-                },
+                    "type": "qd"},
                 "RX12": {
                     "duration": 40,
                     "amplitude": 0.138,
                     "frequency": 6760922000,
                     "shape": "Gaussian(5)",
-                    "type": "qd",
-                    "phase": 0
-                },
+                    "type": "qd"},
                 "MZ": {
                     "duration": 960,
                     "amplitude": 0.004225,
                     "frequency": 7802191000,
                     "shape": "Rectangular()",
-                    "type": "ro",
-                    "phase": 0
-                }
+                    "type": "ro"}
             },
             "4": {
                 "RX": {
@@ -210,25 +186,19 @@
                     "amplitude": 0.0617,
                     "frequency": 6585053000,
                     "shape": "Drag(5, 0.0)",
-                    "type": "qd",
-                    "phase": 0
-                },
+                    "type": "qd"},
                 "RX12": {
                     "duration": 40,
                     "amplitude": 0.0617,
                     "frequency": 6585053000,
                     "shape": "Drag(5, 0.0)",
-                    "type": "qd",
-                    "phase": 0
-                },
+                    "type": "qd"},
                 "MZ": {
                     "duration": 640,
                     "amplitude": 0.0039,
                     "frequency": 8057668000,
                     "shape": "Rectangular()",
-                    "type": "ro",
-                    "phase": 0
-                }
+                    "type": "ro"}
             }
         },
         "two_qubit": {

--- a/tests/dummy_qrc/rfsoc/parameters.json
+++ b/tests/dummy_qrc/rfsoc/parameters.json
@@ -34,7 +34,6 @@
                     "frequency": 5542341844,
                     "shape": "Rectangular()",
                     "type": "qd",
-                    "relative_start": 0,
                     "phase": 0
                 },
                 "RX12": {
@@ -43,7 +42,6 @@
                     "frequency": 5542341844,
                     "shape": "Rectangular()",
                     "type": "qd",
-                    "relative_start": 0,
                     "phase": 0
                 },
                 "MZ": {
@@ -52,7 +50,6 @@
                     "frequency": 7371258599,
                     "shape": "Rectangular()",
                     "type": "ro",
-                    "relative_start": 0,
                     "phase": 0
                 }
             }

--- a/tests/dummy_qrc/rfsoc/parameters.json
+++ b/tests/dummy_qrc/rfsoc/parameters.json
@@ -33,24 +33,21 @@
                     "amplitude": 0.05284168507293318,
                     "frequency": 5542341844,
                     "shape": "Rectangular()",
-                    "type": "qd",
-                    "phase": 0
+                    "type": "qd"
                 },
                 "RX12": {
                     "duration": 30,
                     "amplitude": 0.05284168507293318,
                     "frequency": 5542341844,
                     "shape": "Rectangular()",
-                    "type": "qd",
-                    "phase": 0
+                    "type": "qd"
                 },
                 "MZ": {
                     "duration": 600,
                     "amplitude": 0.03,
                     "frequency": 7371258599,
                     "shape": "Rectangular()",
-                    "type": "ro",
-                    "phase": 0
+                    "type": "ro"
                 }
             }
         },

--- a/tests/dummy_qrc/zurich/parameters.json
+++ b/tests/dummy_qrc/zurich/parameters.json
@@ -64,25 +64,19 @@
                     "amplitude": 0.625,
                     "frequency": 4095830788,
                     "shape": "Drag(5, 0.04)",
-                    "type": "qd",
-                    "phase": 0
-                },
+                    "type": "qd"},
                 "RX12": {
                     "duration": 40,
                     "amplitude": 0.625,
                     "frequency": 4095830788,
                     "shape": "Drag(5, 0.04)",
-                    "type": "qd",
-                    "phase": 0
-                },
+                    "type": "qd"},
                 "MZ": {
                     "duration": 2000,
                     "amplitude": 0.5,
                     "frequency": 5229200000,
                     "shape": "Rectangular()",
-                    "type": "ro",
-                    "phase": 0
-                }
+                    "type": "ro"}
             },
             "1": {
                 "RX": {
@@ -90,25 +84,19 @@
                     "amplitude": 0.2,
                     "frequency": 4170000000,
                     "shape": "Gaussian(5)",
-                    "type": "qd",
-                    "phase": 0
-                },
+                    "type": "qd"},
                 "RX12": {
                     "duration": 90,
                     "amplitude": 0.2,
                     "frequency": 4170000000,
                     "shape": "Gaussian(5)",
-                    "type": "qd",
-                    "phase": 0
-                },
+                    "type": "qd"},
                 "MZ": {
                     "duration": 1000,
                     "amplitude": 0.1,
                     "frequency": 4931000000,
                     "shape": "Rectangular()",
-                    "type": "ro",
-                    "phase": 0
-                }
+                    "type": "ro"}
             },
             "2": {
                 "RX": {
@@ -116,25 +104,19 @@
                     "amplitude": 0.59,
                     "frequency": 4300587281,
                     "shape": "Gaussian(5)",
-                    "type": "qd",
-                    "phase": 0
-                },
+                    "type": "qd"},
                 "RX12": {
                     "duration": 40,
                     "amplitude": 0.59,
                     "frequency": 4300587281,
                     "shape": "Gaussian(5)",
-                    "type": "qd",
-                    "phase": 0
-                },
+                    "type": "qd"},
                 "MZ": {
                     "duration": 2000,
                     "amplitude": 0.54,
                     "frequency": 6109000000.0,
                     "shape": "Rectangular()",
-                    "type": "ro",
-                    "phase": 0
-                }
+                    "type": "ro"}
             },
             "3": {
                 "RX": {
@@ -142,25 +124,19 @@
                     "amplitude": 0.75,
                     "frequency": 4100000000,
                     "shape": "Gaussian(5)",
-                    "type": "qd",
-                    "phase": 0
-                },
+                    "type": "qd"},
                 "RX12": {
                     "duration": 90,
                     "amplitude": 0.75,
                     "frequency": 4100000000,
                     "shape": "Gaussian(5)",
-                    "type": "qd",
-                    "phase": 0
-                },
+                    "type": "qd"},
                 "MZ": {
                     "duration": 2000,
                     "amplitude": 0.01,
                     "frequency": 5783000000,
                     "shape": "Rectangular()",
-                    "type": "ro",
-                    "phase": 0
-                }
+                    "type": "ro"}
             },
             "4": {
                 "RX": {
@@ -168,25 +144,19 @@
                     "amplitude": 1,
                     "frequency": 4196800000,
                     "shape": "Gaussian(5)",
-                    "type": "qd",
-                    "phase": 0
-                },
+                    "type": "qd"},
                 "RX12": {
                     "duration": 53,
                     "amplitude": 1,
                     "frequency": 4196800000,
                     "shape": "Gaussian(5)",
-                    "type": "qd",
-                    "phase": 0
-                },
+                    "type": "qd"},
                 "MZ": {
                     "duration": 1000,
                     "amplitude": 0.5,
                     "frequency": 5515000000,
                     "shape": "Rectangular()",
-                    "type": "ro",
-                    "phase": 0
-                }
+                    "type": "ro"}
             }
         },
         "coupler": {

--- a/tests/dummy_qrc/zurich/parameters.json
+++ b/tests/dummy_qrc/zurich/parameters.json
@@ -162,38 +162,34 @@
         "coupler": {
             "0": {
                 "CP": {
-                    "type": "coupler",
+                    "type": "cf",
                     "duration": 1000,
                     "amplitude": 0.5,
-                    "shape": "Rectangular()",
-                    "coupler": 0
+                    "shape": "Rectangular()"
                 }
             },
             "1": {
                 "CP": {
-                    "type": "coupler",
+                    "type": "cf",
                     "duration": 1000,
                     "amplitude": 0.5,
-                    "shape": "Rectangular()",
-                    "coupler": 1
+                    "shape": "Rectangular()"
                 }
             },
             "3": {
                 "CP": {
-                    "type": "coupler",
+                    "type": "cf",
                     "duration": 1000,
                     "amplitude": 0.5,
-                    "shape": "Rectangular()",
-                    "coupler": 3
+                    "shape": "Rectangular()"
                 }
             },
             "4": {
                 "CP": {
-                    "type": "coupler",
+                    "type": "cf",
                     "duration": 1000,
                     "amplitude": 0.5,
-                    "shape": "Rectangular()",
-                    "coupler": 4
+                    "shape": "Rectangular()"
                 }
             }
         },

--- a/tests/dummy_qrc/zurich/parameters.json
+++ b/tests/dummy_qrc/zurich/parameters.json
@@ -65,7 +65,6 @@
                     "frequency": 4095830788,
                     "shape": "Drag(5, 0.04)",
                     "type": "qd",
-                    "relative_start": 0,
                     "phase": 0
                 },
                 "RX12": {
@@ -74,7 +73,6 @@
                     "frequency": 4095830788,
                     "shape": "Drag(5, 0.04)",
                     "type": "qd",
-                    "relative_start": 0,
                     "phase": 0
                 },
                 "MZ": {
@@ -83,7 +81,6 @@
                     "frequency": 5229200000,
                     "shape": "Rectangular()",
                     "type": "ro",
-                    "relative_start": 0,
                     "phase": 0
                 }
             },
@@ -94,7 +91,6 @@
                     "frequency": 4170000000,
                     "shape": "Gaussian(5)",
                     "type": "qd",
-                    "relative_start": 0,
                     "phase": 0
                 },
                 "RX12": {
@@ -103,7 +99,6 @@
                     "frequency": 4170000000,
                     "shape": "Gaussian(5)",
                     "type": "qd",
-                    "relative_start": 0,
                     "phase": 0
                 },
                 "MZ": {
@@ -112,7 +107,6 @@
                     "frequency": 4931000000,
                     "shape": "Rectangular()",
                     "type": "ro",
-                    "relative_start": 0,
                     "phase": 0
                 }
             },
@@ -123,7 +117,6 @@
                     "frequency": 4300587281,
                     "shape": "Gaussian(5)",
                     "type": "qd",
-                    "relative_start": 0,
                     "phase": 0
                 },
                 "RX12": {
@@ -132,7 +125,6 @@
                     "frequency": 4300587281,
                     "shape": "Gaussian(5)",
                     "type": "qd",
-                    "relative_start": 0,
                     "phase": 0
                 },
                 "MZ": {
@@ -141,7 +133,6 @@
                     "frequency": 6109000000.0,
                     "shape": "Rectangular()",
                     "type": "ro",
-                    "relative_start": 0,
                     "phase": 0
                 }
             },
@@ -152,7 +143,6 @@
                     "frequency": 4100000000,
                     "shape": "Gaussian(5)",
                     "type": "qd",
-                    "relative_start": 0,
                     "phase": 0
                 },
                 "RX12": {
@@ -161,7 +151,6 @@
                     "frequency": 4100000000,
                     "shape": "Gaussian(5)",
                     "type": "qd",
-                    "relative_start": 0,
                     "phase": 0
                 },
                 "MZ": {
@@ -170,7 +159,6 @@
                     "frequency": 5783000000,
                     "shape": "Rectangular()",
                     "type": "ro",
-                    "relative_start": 0,
                     "phase": 0
                 }
             },
@@ -181,7 +169,6 @@
                     "frequency": 4196800000,
                     "shape": "Gaussian(5)",
                     "type": "qd",
-                    "relative_start": 0,
                     "phase": 0
                 },
                 "RX12": {
@@ -190,7 +177,6 @@
                     "frequency": 4196800000,
                     "shape": "Gaussian(5)",
                     "type": "qd",
-                    "relative_start": 0,
                     "phase": 0
                 },
                 "MZ": {
@@ -199,7 +185,6 @@
                     "frequency": 5515000000,
                     "shape": "Rectangular()",
                     "type": "ro",
-                    "relative_start": 0,
                     "phase": 0
                 }
             }
@@ -211,8 +196,7 @@
                     "duration": 1000,
                     "amplitude": 0.5,
                     "shape": "Rectangular()",
-                    "coupler": 0,
-                    "relative_start": 0
+                    "coupler": 0
                 }
             },
             "1": {
@@ -221,8 +205,7 @@
                     "duration": 1000,
                     "amplitude": 0.5,
                     "shape": "Rectangular()",
-                    "coupler": 1,
-                    "relative_start": 0
+                    "coupler": 1
                 }
             },
             "3": {
@@ -231,8 +214,7 @@
                     "duration": 1000,
                     "amplitude": 0.5,
                     "shape": "Rectangular()",
-                    "coupler": 3,
-                    "relative_start": 0
+                    "coupler": 3
                 }
             },
             "4": {
@@ -241,8 +223,7 @@
                     "duration": 1000,
                     "amplitude": 0.5,
                     "shape": "Rectangular()",
-                    "coupler": 4,
-                    "relative_start": 0
+                    "coupler": 4
                 }
             }
         },
@@ -254,37 +235,12 @@
                         "amplitude": -0.6025,
                         "shape": "Exponential(12, 5000, 0.1)",
                         "qubit": 3,
-                        "relative_start": 0,
-                        "type": "qf"
-                    },
-                    {
-                        "duration": 20,
-                        "amplitude": 0,
-                        "shape": "Rectangular())",
-                        "qubit": 3,
-                        "relative_start": 32,
                         "type": "qf"
                     },
                     {
                         "type": "virtual_z",
                         "phase": -3.63,
-                        "qubit": 3
-                    },
-                    {
-                        "duration": 32,
-                        "amplitude": 0,
-                        "shape": "Rectangular())",
-                        "qubit": 2,
-                        "relative_start": 0,
-                        "type": "qf"
-                    },
-                    {
-                        "duration": 20,
-                        "amplitude": 0,
-                        "shape": "Rectangular())",
-                        "qubit": 2,
-                        "relative_start": 32,
-                        "type": "qf"
+                        "qubit": 1
                     },
                     {
                         "type": "virtual_z",

--- a/tests/pulses/test_plot.py
+++ b/tests/pulses/test_plot.py
@@ -22,15 +22,13 @@ HERE = pathlib.Path(__file__).parent
 
 
 def test_plot_functions():
-    p0 = Pulse(0, 40, 0.9, 0, 0, Rectangular(), 0, PulseType.FLUX, 0)
-    p1 = Pulse(0, 40, 0.9, 50e6, 0, Gaussian(5), 0, PulseType.DRIVE, 2)
-    p2 = Pulse(0, 40, 0.9, 50e6, 0, Drag(5, 2), 0, PulseType.DRIVE, 200)
-    p3 = Pulse.flux(
-        0, 40, 0.9, IIR([-0.5, 2], [1], Rectangular()), channel=0, qubit=200
-    )
-    p4 = Pulse.flux(0, 40, 0.9, SNZ(t_idling=10), channel=0, qubit=200)
-    p5 = Pulse(0, 40, 0.9, 400e6, 0, eCap(alpha=2), 0, PulseType.DRIVE)
-    p6 = Pulse(0, 40, 0.9, 50e6, 0, GaussianSquare(5, 0.9), 0, PulseType.DRIVE, 2)
+    p0 = Pulse(40, 0.9, 0, 0, Rectangular(), 0, PulseType.FLUX, 0)
+    p1 = Pulse(40, 0.9, 50e6, 0, Gaussian(5), 0, PulseType.DRIVE, 2)
+    p2 = Pulse(40, 0.9, 50e6, 0, Drag(5, 2), 0, PulseType.DRIVE, 200)
+    p3 = Pulse.flux(40, 0.9, IIR([-0.5, 2], [1], Rectangular()), channel=0, qubit=200)
+    p4 = Pulse.flux(40, 0.9, SNZ(t_idling=10), channel=0, qubit=200)
+    p5 = Pulse(40, 0.9, 400e6, 0, eCap(alpha=2), 0, PulseType.DRIVE)
+    p6 = Pulse(40, 0.9, 50e6, 0, GaussianSquare(5, 0.9), 0, PulseType.DRIVE, 2)
     ps = PulseSequence([p0, p1, p2, p3, p4, p5, p6])
     envelope = p0.envelope_waveforms()
     wf = modulate(np.array(envelope), 0.0)

--- a/tests/pulses/test_pulse.py
+++ b/tests/pulses/test_pulse.py
@@ -13,7 +13,6 @@ from qibolab.pulses import (
     Gaussian,
     GaussianSquare,
     Pulse,
-    PulseSequence,
     PulseShape,
     PulseType,
     Rectangular,
@@ -25,7 +24,6 @@ from qibolab.pulses import (
 def test_init():
     # standard initialisation
     p0 = Pulse(
-        start=0,
         duration=50,
         amplitude=0.9,
         frequency=20_000_000,
@@ -38,7 +36,6 @@ def test_init():
     assert p0.relative_phase == 0.0
 
     p1 = Pulse(
-        start=100,
         duration=50,
         amplitude=0.9,
         frequency=20_000_000,
@@ -52,7 +49,6 @@ def test_init():
 
     # initialisation with non int (float) frequency
     p2 = Pulse(
-        start=0,
         duration=50,
         amplitude=0.9,
         frequency=int(20e6),
@@ -66,7 +62,6 @@ def test_init():
 
     # initialisation with non float (int) relative_phase
     p3 = Pulse(
-        start=0,
         duration=50,
         amplitude=0.9,
         frequency=20_000_000,
@@ -80,7 +75,6 @@ def test_init():
 
     # initialisation with str shape
     p4 = Pulse(
-        start=0,
         duration=50,
         amplitude=0.9,
         frequency=20_000_000,
@@ -94,7 +88,6 @@ def test_init():
 
     # initialisation with str channel and str qubit
     p5 = Pulse(
-        start=0,
         duration=50,
         amplitude=0.9,
         frequency=20_000_000,
@@ -107,22 +100,19 @@ def test_init():
     assert p5.qubit == "qubit0"
 
     # initialisation with different frequencies, shapes and types
-    p6 = Pulse(0, 40, 0.9, -50e6, 0, Rectangular(), 0, PulseType.READOUT)
-    p7 = Pulse(0, 40, 0.9, 0, 0, Rectangular(), 0, PulseType.FLUX, 0)
-    p8 = Pulse(0, 40, 0.9, 50e6, 0, Gaussian(5), 0, PulseType.DRIVE, 2)
-    p9 = Pulse(0, 40, 0.9, 50e6, 0, Drag(5, 2), 0, PulseType.DRIVE, 200)
+    p6 = Pulse(40, 0.9, -50e6, 0, Rectangular(), 0, PulseType.READOUT)
+    p7 = Pulse(40, 0.9, 0, 0, Rectangular(), 0, PulseType.FLUX, 0)
+    p8 = Pulse(40, 0.9, 50e6, 0, Gaussian(5), 0, PulseType.DRIVE, 2)
+    p9 = Pulse(40, 0.9, 50e6, 0, Drag(5, 2), 0, PulseType.DRIVE, 200)
     p10 = Pulse.flux(
-        0, 40, 0.9, IIR([-1, 1], [-0.1, 0.1001], Rectangular()), channel=0, qubit=200
+        40, 0.9, IIR([-1, 1], [-0.1, 0.1001], Rectangular()), channel=0, qubit=200
     )
-    p11 = Pulse.flux(
-        0, 40, 0.9, SNZ(t_idling=10, b_amplitude=0.5), channel=0, qubit=200
-    )
-    p13 = Pulse(0, 40, 0.9, 400e6, 0, eCap(alpha=2), 0, PulseType.DRIVE)
-    p14 = Pulse(0, 40, 0.9, 50e6, 0, GaussianSquare(5, 0.9), 0, PulseType.READOUT, 2)
+    p11 = Pulse.flux(40, 0.9, SNZ(t_idling=10, b_amplitude=0.5), channel=0, qubit=200)
+    p13 = Pulse(40, 0.9, 400e6, 0, eCap(alpha=2), 0, PulseType.DRIVE)
+    p14 = Pulse(40, 0.9, 50e6, 0, GaussianSquare(5, 0.9), 0, PulseType.READOUT, 2)
 
-    # initialisation with float duration and start
+    # initialisation with float duration
     p12 = Pulse(
-        start=5.5,
         duration=34.33,
         amplitude=0.9,
         frequency=20_000_000,
@@ -132,9 +122,8 @@ def test_init():
         type=PulseType.READOUT,
         qubit=0,
     )
-    assert isinstance(p12.start, float)
     assert isinstance(p12.duration, float)
-    assert p12.finish == 5.5 + 34.33
+    assert p12.duration == 34.33
 
 
 def test_attributes():
@@ -142,7 +131,6 @@ def test_attributes():
     qubit = 0
 
     p10 = Pulse(
-        start=10,
         duration=50,
         amplitude=0.9,
         frequency=20_000_000,
@@ -152,68 +140,28 @@ def test_attributes():
         qubit=qubit,
     )
 
-    assert type(p10.start) == int and p10.start == 10
     assert type(p10.duration) == int and p10.duration == 50
     assert type(p10.amplitude) == float and p10.amplitude == 0.9
     assert type(p10.frequency) == int and p10.frequency == 20_000_000
-    assert type(p10.phase) == float and np.allclose(
-        p10.phase, 2 * np.pi * p10.start * p10.frequency / 1e9
-    )
     assert isinstance(p10.shape, PulseShape) and repr(p10.shape) == "Rectangular()"
     assert type(p10.channel) == type(channel) and p10.channel == channel
     assert type(p10.qubit) == type(qubit) and p10.qubit == qubit
-    assert isinstance(p10.finish, int) and p10.finish == 60
-
-    p0 = Pulse(
-        start=0,
-        duration=50,
-        amplitude=0.9,
-        frequency=20_000_000,
-        relative_phase=0.0,
-        shape=Rectangular(),
-        channel=0,
-        type=PulseType.READOUT,
-        qubit=0,
-    )
-    p0.start = 50
-    assert p0.finish == 100
-
-
-def test_is_equal_ignoring_start():
-    """Checks if two pulses are equal, not looking at start time."""
-
-    p1 = Pulse(0, 40, 0.9, 0, 0, Rectangular(), 0, PulseType.FLUX, 0)
-    p2 = Pulse(100, 40, 0.9, 0, 0, Rectangular(), 0, PulseType.FLUX, 0)
-    p3 = Pulse(0, 40, 0.9, 0, 0, Rectangular(), 0, PulseType.FLUX, 0)
-    p4 = Pulse(200, 40, 0.9, 0, 0, Rectangular(), 2, PulseType.FLUX, 0)
-    assert p1.is_equal_ignoring_start(p2)
-    assert p1.is_equal_ignoring_start(p3)
-    assert not p1.is_equal_ignoring_start(p4)
-
-    p1 = Pulse(0, 40, 0.9, 50e6, 0, Gaussian(5), 0, PulseType.DRIVE, 2)
-    p2 = Pulse(10, 40, 0.9, 50e6, 0, Gaussian(5), 0, PulseType.DRIVE, 2)
-    p3 = Pulse(20, 50, 0.8, 50e6, 0, Gaussian(5), 0, PulseType.DRIVE, 2)
-    p4 = Pulse(30, 40, 0.9, 50e6, 0, Gaussian(4), 0, PulseType.DRIVE, 2)
-    assert p1.is_equal_ignoring_start(p2)
-    assert not p1.is_equal_ignoring_start(p3)
-    assert not p1.is_equal_ignoring_start(p4)
 
 
 def test_hash():
-    rp = Pulse(0, 40, 0.9, 100e6, 0, Rectangular(), 0, PulseType.DRIVE)
-    dp = Pulse(0, 40, 0.9, 100e6, 0, Drag(5, 1), 0, PulseType.DRIVE)
+    rp = Pulse(40, 0.9, 100e6, 0, Rectangular(), 0, PulseType.DRIVE)
+    dp = Pulse(40, 0.9, 100e6, 0, Drag(5, 1), 0, PulseType.DRIVE)
     hash(rp)
     my_dict = {rp: 1, dp: 2}
     assert list(my_dict.keys())[0] == rp
     assert list(my_dict.keys())[1] == dp
 
-    p1 = Pulse(0, 40, 0.9, 100e6, 0, Drag(5, 1), 0, PulseType.DRIVE)
-    p2 = Pulse(0, 40, 0.9, 100e6, 0, Drag(5, 1), 0, PulseType.DRIVE)
+    p1 = Pulse(40, 0.9, 100e6, 0, Drag(5, 1), 0, PulseType.DRIVE)
+    p2 = Pulse(40, 0.9, 100e6, 0, Drag(5, 1), 0, PulseType.DRIVE)
 
     assert p1 == p2
 
-    t0 = 0
-    p1 = Pulse(t0, 40, 0.9, 100e6, 0, Drag(5, 1), 0, PulseType.DRIVE)
+    p1 = Pulse(40, 0.9, 100e6, 0, Drag(5, 1), 0, PulseType.DRIVE)
     p2 = copy.copy(p1)
     p3 = copy.deepcopy(p1)
     assert p1 == p2
@@ -222,7 +170,6 @@ def test_hash():
 
 def test_aliases():
     rop = Pulse(
-        start=0,
         duration=50,
         amplitude=0.9,
         frequency=20_000_000,
@@ -232,11 +179,9 @@ def test_aliases():
         channel=0,
         qubit=0,
     )
-    assert rop.start == 0
     assert rop.qubit == 0
 
     dp = Pulse(
-        start=0,
         duration=2000,
         amplitude=0.9,
         frequency=200_000_000,
@@ -249,33 +194,9 @@ def test_aliases():
     assert isinstance(dp.shape, Gaussian)
 
     fp = Pulse.flux(
-        start=0, duration=300, amplitude=0.9, shape=Rectangular(), channel=0, qubit=0
+        duration=300, amplitude=0.9, shape=Rectangular(), channel=0, qubit=0
     )
     assert fp.channel == 0
-
-
-def test_pulse_order():
-    t0 = 0
-    t = 0
-    p1 = Pulse(t0, 400, 0.9, 20e6, 0, Gaussian(5), 10)
-    p2 = Pulse(
-        p1.finish + t,
-        400,
-        0.9,
-        20e6,
-        0,
-        Rectangular(),
-        qubit=30,
-        type=PulseType.READOUT,
-    )
-    p3 = Pulse(p2.finish, 400, 0.9, 20e6, 0, Drag(5, 50), 20)
-    ps1 = PulseSequence([p1, p2, p3])
-    ps2 = PulseSequence([p3, p1, p2])
-
-    def sortseq(sequence):
-        return sorted(sequence, key=lambda item: (item.start, item.channel))
-
-    assert sortseq(ps1) == sortseq(ps2)
 
 
 def test_pulse():
@@ -283,7 +204,6 @@ def test_pulse():
     rel_sigma = 5
     beta = 2
     pulse = Pulse(
-        start=0,
         frequency=200_000_000,
         amplitude=1,
         duration=duration,
@@ -298,7 +218,6 @@ def test_pulse():
 def test_readout_pulse():
     duration = 2000
     pulse = Pulse(
-        start=0,
         frequency=200_000_000,
         amplitude=1,
         duration=duration,
@@ -317,7 +236,6 @@ def test_envelope_waveform_i_q():
     custom_shape_pulse = Custom(envelope_i, envelope_q)
     custom_shape_pulse_old_behaviour = Custom(envelope_i)
     pulse = Pulse(
-        start=0,
         duration=1000,
         amplitude=1,
         frequency=10e6,

--- a/tests/pulses/test_shape.py
+++ b/tests/pulses/test_shape.py
@@ -21,7 +21,7 @@ from qibolab.pulses.shape import IqWaveform, demodulate, modulate
     "shape", [Rectangular(), Gaussian(5), GaussianSquare(5, 0.9), Drag(5, 1)]
 )
 def test_sampling_rate(shape):
-    pulse = Pulse(0, 40, 0.9, 100e6, 0, shape, 0, PulseType.DRIVE)
+    pulse = Pulse(40, 0.9, 100e6, 0, shape, 0, PulseType.DRIVE)
     assert len(pulse.envelope_waveform_i(sampling_rate=1)) == 40
     assert len(pulse.envelope_waveform_i(sampling_rate=100)) == 4000
 
@@ -80,7 +80,7 @@ def test_raise_shapeiniterror():
 
 
 def test_drag_shape():
-    pulse = Pulse(0, 2, 1, 4e9, 0, Drag(2, 1), 0, PulseType.DRIVE)
+    pulse = Pulse(2, 1, 4e9, 0, Drag(2, 1), 0, PulseType.DRIVE)
     # envelope i & envelope q should cross nearly at 0 and at 2
     waveform = pulse.envelope_waveform_i(sampling_rate=10)
     target_waveform = np.array(
@@ -112,7 +112,6 @@ def test_drag_shape():
 
 def test_rectangular():
     pulse = Pulse(
-        start=0,
         duration=50,
         amplitude=1,
         frequency=200_000_000,
@@ -141,7 +140,6 @@ def test_rectangular():
 
 def test_gaussian():
     pulse = Pulse(
-        start=0,
         duration=50,
         amplitude=1,
         frequency=200_000_000,
@@ -176,7 +174,6 @@ def test_gaussian():
 
 def test_drag():
     pulse = Pulse(
-        start=0,
         duration=50,
         amplitude=1,
         frequency=200_000_000,
@@ -281,7 +278,6 @@ def test_eq():
 
 def test_modulation():
     rect = Pulse(
-        start=0,
         duration=30,
         amplitude=0.9,
         frequency=20_000_000,
@@ -318,7 +314,6 @@ def test_modulation():
     # fmt: on
 
     gauss = Pulse(
-        start=5,
         duration=20,
         amplitude=3.5,
         frequency=2_000_000,

--- a/tests/test_compilers_default.py
+++ b/tests/test_compilers_default.py
@@ -37,7 +37,7 @@ def compile_circuit(circuit, platform):
 
 
 @pytest.mark.parametrize(
-    "gateargs,sequence_len",
+    "gateargs",
     [
         (gates.I,),
         (gates.Z,),
@@ -47,7 +47,7 @@ def compile_circuit(circuit, platform):
         (gates.U3, 0.1, 0.2, 0.3),
     ],
 )
-def test_compile(platform, gateargs, sequence_len):
+def test_compile(platform, gateargs):
     nqubits = platform.nqubits
     if gateargs[0] is gates.U3:
         nseq = 2
@@ -57,7 +57,7 @@ def test_compile(platform, gateargs, sequence_len):
         nseq = 0
     circuit = generate_circuit_with_gate(nqubits, *gateargs)
     sequence = compile_circuit(circuit, platform)
-    assert len(sequence) == nqubits * sequence_len
+    assert len(sequence) == nqubits * nseq
 
 
 def test_compile_two_gates(platform):

--- a/tests/test_compilers_default.py
+++ b/tests/test_compilers_default.py
@@ -37,27 +37,21 @@ def compile_circuit(circuit, platform):
 
 
 @pytest.mark.parametrize(
-    "gateargs",
+    "gateargs,sequence_len",
     [
-        (gates.I,),
-        (gates.Z,),
-        (gates.GPI, np.pi / 8),
-        (gates.GPI2, -np.pi / 8),
-        (gates.RZ, np.pi / 4),
-        (gates.U3, 0.1, 0.2, 0.3),
+        ((gates.I,), 1),
+        ((gates.Z,), 2),
+        ((gates.GPI, np.pi / 8), 3),
+        ((gates.GPI2, -np.pi / 8), 3),
+        ((gates.RZ, np.pi / 4), 2),
+        ((gates.U3, 0.1, 0.2, 0.3), 10),
     ],
 )
-def test_compile(platform, gateargs):
+def test_compile(platform, gateargs, sequence_len):
     nqubits = platform.nqubits
-    if gateargs[0] is gates.U3:
-        nseq = 2
-    elif gateargs[0] in (gates.GPI, gates.GPI2):
-        nseq = 1
-    else:
-        nseq = 0
     circuit = generate_circuit_with_gate(nqubits, *gateargs)
     sequence = compile_circuit(circuit, platform)
-    assert len(sequence) == nqubits * nseq
+    assert len(sequence) == nqubits * sequence_len
 
 
 def test_compile_two_gates(platform):
@@ -68,7 +62,7 @@ def test_compile_two_gates(platform):
 
     sequence = compile_circuit(circuit, platform)
 
-    assert len(sequence) == 4
+    assert len(sequence) == 13
     assert len(sequence.qd_pulses) == 3
     assert len(sequence.ro_pulses) == 1
 
@@ -166,8 +160,8 @@ def test_cz_to_sequence():
     circuit.add(gates.CZ(1, 2))
 
     sequence = compile_circuit(circuit, platform)
-    test_sequence, virtual_z_phases = platform.create_CZ_pulse_sequence((2, 1))
-    assert sequence == test_sequence
+    test_sequence = platform.create_CZ_pulse_sequence((2, 1))
+    assert sequence[0] == test_sequence[0]
 
 
 def test_cnot_to_sequence():

--- a/tests/test_compilers_default.py
+++ b/tests/test_compilers_default.py
@@ -57,6 +57,8 @@ def test_compile(platform, gateargs):
         nseq = 0
     circuit = generate_circuit_with_gate(nqubits, *gateargs)
     sequence = compile_circuit(circuit, platform)
+    for pulse in sequence:
+        print(pulse)
     assert len(sequence) == (nseq + 1) * nqubits
 
 

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -54,7 +54,7 @@ def test_dummy_execute_pulse_sequence_couplers():
     )
     sequence = PulseSequence()
 
-    cz, cz_phases = platform.create_CZ_pulse_sequence(
+    cz = platform.create_CZ_pulse_sequence(
         qubits=(qubit_ordered_pair.qubit1.name, qubit_ordered_pair.qubit2.name),
     )
     sequence.extend(cz.get_qubit_pulses(qubit_ordered_pair.qubit1.name))
@@ -66,10 +66,6 @@ def test_dummy_execute_pulse_sequence_couplers():
     sequence.append(platform.create_MZ_pulse(2))
     options = ExecutionParameters(nshots=None)
     result = platform.execute_pulse_sequence(sequence, options)
-
-    test_phases = {1: 0.0, 2: 0.0}
-
-    assert test_phases == cz_phases
 
 
 @pytest.mark.parametrize("name", PLATFORM_NAMES)

--- a/tests/test_instruments_qm.py
+++ b/tests/test_instruments_qm.py
@@ -9,11 +9,7 @@ from qibolab.instruments.qm import OPXplus, QMController
 from qibolab.instruments.qm.acquisition import Acquisition, declare_acquisitions
 from qibolab.instruments.qm.controller import controllers_config
 from qibolab.instruments.qm.sequence import BakedPulse, QMPulse, Sequence
-<<<<<<< HEAD
 from qibolab.pulses import Pulse, PulseSequence, PulseType, Rectangular
-=======
-from qibolab.pulses import Pulse, PulseType, PulseSequence, Rectangular
->>>>>>> 1b1e4cd4 (Fix Zurich tests)
 from qibolab.qubits import Qubit
 from qibolab.sweeper import Parameter, Sweeper
 
@@ -58,17 +54,12 @@ def test_qmpulse_declare_output(acquisition_type):
 
 
 def test_qmsequence():
-<<<<<<< HEAD
     qd_pulse = Pulse(
         0, 40, 0.05, int(3e9), 0.0, Rectangular(), "ch0", PulseType.DRIVE, qubit=0
     )
     ro_pulse = Pulse(
         0, 40, 0.05, int(3e9), 0.0, Rectangular(), "ch1", PulseType.READOUT, qubit=0
     )
-=======
-    qd_pulse = Pulse(0, 40, 0.05, int(3e9), 0.0, Rectangular(), "ch0", PulseType.DRIVE, qubit=0)
-    ro_pulse = Pulse(0, 40, 0.05, int(3e9), 0.0, Rectangular(), "ch1", PulseType.READOUT, qubit=0)
->>>>>>> 1b1e4cd4 (Fix Zurich tests)
     qmsequence = Sequence()
     with pytest.raises(AttributeError):
         qmsequence.add("test")
@@ -129,7 +120,6 @@ def test_qmpulse_previous_and_next_flux():
     x_pulse_end = Pulse(70, 40, 0.05, int(3e9), 0.0, Rectangular(), f"drive2", qubit=2)
 
     measure_lowfreq = Pulse(
-<<<<<<< HEAD
         110,
         100,
         0.05,
@@ -150,12 +140,6 @@ def test_qmpulse_previous_and_next_flux():
         "readout2",
         PulseType.READOUT,
         qubit=2,
-=======
-        110, 100, 0.05, int(3e9), 0.0, Rectangular(), "readout1", PulseType.READOUT, qubit=1
-    )
-    measure_highfreq = Pulse(
-        110, 100, 0.05, int(3e9), 0.0, Rectangular(), "readout2", PulseType.READOUT, qubit=2
->>>>>>> 1b1e4cd4 (Fix Zurich tests)
     )
 
     drive11 = QMPulse(y90_pulse)
@@ -369,16 +353,12 @@ def test_qm_register_flux_pulse(qmplatform):
     platform = qmplatform
     controller = platform.instruments["qm"]
     pulse = Pulse.flux(
-<<<<<<< HEAD
         0,
         30,
         0.005,
         Rectangular(),
         channel=platform.qubits[qubit].flux.name,
         qubit=qubit,
-=======
-        0, 30, 0.005, Rectangular(), platform.qubits[qubit].flux.name, qubit
->>>>>>> 1b1e4cd4 (Fix Zurich tests)
     )
     target_pulse = {
         "operation": "control",
@@ -399,11 +379,7 @@ def test_qm_register_baked_pulse(qmplatform, duration):
     controller = platform.instruments["qm"]
     controller.config.register_flux_element(qubit)
     pulse = Pulse.flux(
-<<<<<<< HEAD
         3, duration, 0.05, Rectangular(), channel=qubit.flux.name, qubit=qubit.name
-=======
-        3, duration, 0.05, Rectangular(), qubit.flux.name, qubit=qubit.name
->>>>>>> 1b1e4cd4 (Fix Zurich tests)
     )
     qmpulse = BakedPulse(pulse)
     config = controller.config

--- a/tests/test_instruments_qm.py
+++ b/tests/test_instruments_qm.py
@@ -94,6 +94,7 @@ def test_qmpulse_previous_and_next():
                 f"readout{qubit}",
                 PulseType.READOUT,
                 qubit=qubit,
+                type=PulseType.READOUT,
             )
         )
         ro_qmpulses.append(ro_pulse)

--- a/tests/test_instruments_qm.py
+++ b/tests/test_instruments_qm.py
@@ -19,11 +19,7 @@ from .conftest import set_platform_profile
 def test_qmpulse():
     pulse = Pulse(0, 40, 0.05, int(3e9), 0.0, Rectangular(), "ch0", qubit=0)
     qmpulse = QMPulse(pulse)
-<<<<<<< HEAD
     assert qmpulse.operation == "drive(40, 0.05, Rectangular())"
-=======
-    assert qmpulse.operation == pulse.id
->>>>>>> 337bff40 (Drop pulse.serial)
     assert qmpulse.relative_phase == 0
 
 
@@ -341,20 +337,8 @@ def test_qm_register_pulse(qmplatform, pulse_type, qubit):
             },
         }
 
-<<<<<<< HEAD
     controller.config.register_element(
         platform.qubits[qubit], pulse, controller.time_of_flight, controller.smearing
-=======
-    opx.config.register_element(
-        platform.qubits[qubit], pulse, opx.time_of_flight, opx.smearing
-    )
-    opx.config.register_pulse(platform.qubits[qubit], pulse)
-    assert opx.config.pulses[pulse.id] == target_pulse
-    assert target_pulse["waveforms"]["I"] in opx.config.waveforms
-    assert target_pulse["waveforms"]["Q"] in opx.config.waveforms
-    assert (
-        opx.config.elements[f"{pulse_type}{qubit}"]["operations"][pulse.id] == pulse.id
->>>>>>> 337bff40 (Drop pulse.serial)
     )
     qmpulse = QMPulse(pulse)
     controller.config.register_pulse(platform.qubits[qubit], qmpulse)
@@ -380,19 +364,11 @@ def test_qm_register_flux_pulse(qmplatform):
         "length": pulse.duration,
         "waveforms": {"single": "constant_wf0.005"},
     }
-<<<<<<< HEAD
     qmpulse = QMPulse(pulse)
     controller.config.register_element(platform.qubits[qubit], pulse)
     controller.config.register_pulse(platform.qubits[qubit], qmpulse)
     assert controller.config.pulses[qmpulse.operation] == target_pulse
     assert target_pulse["waveforms"]["single"] in controller.config.waveforms
-=======
-    opx.config.register_element(platform.qubits[qubit], pulse)
-    opx.config.register_pulse(platform.qubits[qubit], pulse)
-    assert opx.config.pulses[pulse.id] == target_pulse
-    assert target_pulse["waveforms"]["single"] in opx.config.waveforms
-    assert opx.config.elements[f"flux{qubit}"]["operations"][pulse.id] == pulse.id
->>>>>>> 337bff40 (Drop pulse.serial)
 
 
 @pytest.mark.parametrize("duration", [0, 30])

--- a/tests/test_instruments_qm.py
+++ b/tests/test_instruments_qm.py
@@ -9,7 +9,11 @@ from qibolab.instruments.qm import OPXplus, QMController
 from qibolab.instruments.qm.acquisition import Acquisition, declare_acquisitions
 from qibolab.instruments.qm.controller import controllers_config
 from qibolab.instruments.qm.sequence import BakedPulse, QMPulse, Sequence
+<<<<<<< HEAD
 from qibolab.pulses import Pulse, PulseSequence, PulseType, Rectangular
+=======
+from qibolab.pulses import Pulse, PulseType, PulseSequence, Rectangular
+>>>>>>> 1b1e4cd4 (Fix Zurich tests)
 from qibolab.qubits import Qubit
 from qibolab.sweeper import Parameter, Sweeper
 
@@ -54,12 +58,17 @@ def test_qmpulse_declare_output(acquisition_type):
 
 
 def test_qmsequence():
+<<<<<<< HEAD
     qd_pulse = Pulse(
         0, 40, 0.05, int(3e9), 0.0, Rectangular(), "ch0", PulseType.DRIVE, qubit=0
     )
     ro_pulse = Pulse(
         0, 40, 0.05, int(3e9), 0.0, Rectangular(), "ch1", PulseType.READOUT, qubit=0
     )
+=======
+    qd_pulse = Pulse(0, 40, 0.05, int(3e9), 0.0, Rectangular(), "ch0", PulseType.DRIVE, qubit=0)
+    ro_pulse = Pulse(0, 40, 0.05, int(3e9), 0.0, Rectangular(), "ch1", PulseType.READOUT, qubit=0)
+>>>>>>> 1b1e4cd4 (Fix Zurich tests)
     qmsequence = Sequence()
     with pytest.raises(AttributeError):
         qmsequence.add("test")
@@ -120,6 +129,7 @@ def test_qmpulse_previous_and_next_flux():
     x_pulse_end = Pulse(70, 40, 0.05, int(3e9), 0.0, Rectangular(), f"drive2", qubit=2)
 
     measure_lowfreq = Pulse(
+<<<<<<< HEAD
         110,
         100,
         0.05,
@@ -140,6 +150,12 @@ def test_qmpulse_previous_and_next_flux():
         "readout2",
         PulseType.READOUT,
         qubit=2,
+=======
+        110, 100, 0.05, int(3e9), 0.0, Rectangular(), "readout1", PulseType.READOUT, qubit=1
+    )
+    measure_highfreq = Pulse(
+        110, 100, 0.05, int(3e9), 0.0, Rectangular(), "readout2", PulseType.READOUT, qubit=2
+>>>>>>> 1b1e4cd4 (Fix Zurich tests)
     )
 
     drive11 = QMPulse(y90_pulse)
@@ -353,12 +369,16 @@ def test_qm_register_flux_pulse(qmplatform):
     platform = qmplatform
     controller = platform.instruments["qm"]
     pulse = Pulse.flux(
+<<<<<<< HEAD
         0,
         30,
         0.005,
         Rectangular(),
         channel=platform.qubits[qubit].flux.name,
         qubit=qubit,
+=======
+        0, 30, 0.005, Rectangular(), platform.qubits[qubit].flux.name, qubit
+>>>>>>> 1b1e4cd4 (Fix Zurich tests)
     )
     target_pulse = {
         "operation": "control",
@@ -379,7 +399,11 @@ def test_qm_register_baked_pulse(qmplatform, duration):
     controller = platform.instruments["qm"]
     controller.config.register_flux_element(qubit)
     pulse = Pulse.flux(
+<<<<<<< HEAD
         3, duration, 0.05, Rectangular(), channel=qubit.flux.name, qubit=qubit.name
+=======
+        3, duration, 0.05, Rectangular(), qubit.flux.name, qubit=qubit.name
+>>>>>>> 1b1e4cd4 (Fix Zurich tests)
     )
     qmpulse = BakedPulse(pulse)
     config = controller.config

--- a/tests/test_instruments_qm.py
+++ b/tests/test_instruments_qm.py
@@ -19,7 +19,11 @@ from .conftest import set_platform_profile
 def test_qmpulse():
     pulse = Pulse(0, 40, 0.05, int(3e9), 0.0, Rectangular(), "ch0", qubit=0)
     qmpulse = QMPulse(pulse)
+<<<<<<< HEAD
     assert qmpulse.operation == "drive(40, 0.05, Rectangular())"
+=======
+    assert qmpulse.operation == pulse.id
+>>>>>>> 337bff40 (Drop pulse.serial)
     assert qmpulse.relative_phase == 0
 
 
@@ -337,8 +341,20 @@ def test_qm_register_pulse(qmplatform, pulse_type, qubit):
             },
         }
 
+<<<<<<< HEAD
     controller.config.register_element(
         platform.qubits[qubit], pulse, controller.time_of_flight, controller.smearing
+=======
+    opx.config.register_element(
+        platform.qubits[qubit], pulse, opx.time_of_flight, opx.smearing
+    )
+    opx.config.register_pulse(platform.qubits[qubit], pulse)
+    assert opx.config.pulses[pulse.id] == target_pulse
+    assert target_pulse["waveforms"]["I"] in opx.config.waveforms
+    assert target_pulse["waveforms"]["Q"] in opx.config.waveforms
+    assert (
+        opx.config.elements[f"{pulse_type}{qubit}"]["operations"][pulse.id] == pulse.id
+>>>>>>> 337bff40 (Drop pulse.serial)
     )
     qmpulse = QMPulse(pulse)
     controller.config.register_pulse(platform.qubits[qubit], qmpulse)
@@ -364,11 +380,19 @@ def test_qm_register_flux_pulse(qmplatform):
         "length": pulse.duration,
         "waveforms": {"single": "constant_wf0.005"},
     }
+<<<<<<< HEAD
     qmpulse = QMPulse(pulse)
     controller.config.register_element(platform.qubits[qubit], pulse)
     controller.config.register_pulse(platform.qubits[qubit], qmpulse)
     assert controller.config.pulses[qmpulse.operation] == target_pulse
     assert target_pulse["waveforms"]["single"] in controller.config.waveforms
+=======
+    opx.config.register_element(platform.qubits[qubit], pulse)
+    opx.config.register_pulse(platform.qubits[qubit], pulse)
+    assert opx.config.pulses[pulse.id] == target_pulse
+    assert target_pulse["waveforms"]["single"] in opx.config.waveforms
+    assert opx.config.elements[f"flux{qubit}"]["operations"][pulse.id] == pulse.id
+>>>>>>> 337bff40 (Drop pulse.serial)
 
 
 @pytest.mark.parametrize("duration", [0, 30])

--- a/tests/test_instruments_qmsim.py
+++ b/tests/test_instruments_qmsim.py
@@ -23,7 +23,7 @@ from qibo.models import Circuit
 
 from qibolab import AcquisitionType, AveragingMode, ExecutionParameters, create_platform
 from qibolab.backends import QibolabBackend
-from qibolab.pulses import Pulse, SNZ, PulseSequence, Rectangular
+from qibolab.pulses import SNZ, Pulse, PulseSequence, Rectangular
 from qibolab.sweeper import Parameter, Sweeper
 
 from .conftest import set_platform_profile

--- a/tests/test_instruments_zhinst.py
+++ b/tests/test_instruments_zhinst.py
@@ -540,7 +540,7 @@ def test_sweep_and_play_sim(dummy_qrc):
     assert all(qubit in res for qubit in qubits)
 
 
-@pytest.mark.parametrize("parameter1", [Parameter.start, Parameter.duration])
+@pytest.mark.parametrize("parameter1", [Parameter.duration])
 def test_experiment_sweep_single(dummy_qrc, parameter1):
     platform = create_platform("zurich")
     IQM5q = platform.instruments["EL_ZURO"]
@@ -582,7 +582,7 @@ def test_experiment_sweep_single(dummy_qrc, parameter1):
     assert acquire_channel_name(qubits[0]) in IQM5q.experiment.signals
 
 
-@pytest.mark.parametrize("parameter1", [Parameter.start, Parameter.duration])
+@pytest.mark.parametrize("parameter1", [Parameter.duration])
 def test_experiment_sweep_single_coupler(dummy_qrc, parameter1):
     platform = create_platform("zurich")
     IQM5q = platform.instruments["EL_ZURO"]
@@ -643,7 +643,6 @@ SweeperParameter = {
     Parameter.frequency,
     Parameter.amplitude,
     Parameter.duration,
-    Parameter.start,
     Parameter.relative_phase,
 }
 

--- a/tests/test_instruments_zhinst.py
+++ b/tests/test_instruments_zhinst.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 
 from qibolab import AcquisitionType, AveragingMode, ExecutionParameters, create_platform
+<<<<<<< HEAD
 from qibolab.instruments.zhinst import (
     ProcessedSweeps,
     ZhPulse,
@@ -15,6 +16,9 @@ from qibolab.instruments.zhinst import (
     classify_sweepers,
     measure_channel_name,
 )
+=======
+from qibolab.instruments.zhinst import ZhPulse, ZhSweeperLine, Zurich
+>>>>>>> 1b1e4cd4 (Fix Zurich tests)
 from qibolab.pulses import (
     IIR,
     SNZ,
@@ -25,7 +29,11 @@ from qibolab.pulses import (
     PulseType,
     Rectangular,
 )
+<<<<<<< HEAD
 from qibolab.sweeper import Parameter, Sweeper
+=======
+from qibolab.sweeper import Parameter, Sweeper, SweeperType
+>>>>>>> 1b1e4cd4 (Fix Zurich tests)
 from qibolab.unrolling import batch
 
 from .conftest import get_instrument
@@ -249,6 +257,24 @@ def test_zhinst_setup(dummy_qrc):
 
 
 def test_zhsequence(dummy_qrc):
+<<<<<<< HEAD
+=======
+    qd_pulse = Pulse(0, 40, 0.05, int(3e9), 0.0, Rectangular(), "ch0", qubit=0)
+    ro_pulse = Pulse(
+        0,
+        40,
+        0.05,
+        int(3e9),
+        0.0,
+        Rectangular(),
+        "ch1",
+        qubit=0,
+        type=PulseType.READOUT,
+    )
+    sequence = PulseSequence()
+    sequence.append(qd_pulse)
+    sequence.append(ro_pulse)
+>>>>>>> 1b1e4cd4 (Fix Zurich tests)
     IQM5q = create_platform("zurich")
     controller = IQM5q.instruments["EL_ZURO"]
 
@@ -283,6 +309,7 @@ def test_zhsequence(dummy_qrc):
 
 
 def test_zhsequence_couplers(dummy_qrc):
+<<<<<<< HEAD
     IQM5q = create_platform("zurich")
     controller = IQM5q.instruments["EL_ZURO"]
 
@@ -291,6 +318,9 @@ def test_zhsequence_couplers(dummy_qrc):
     )
     couplerflux_channel = IQM5q.couplers[0].flux.name
     qd_pulse = Pulse(0, 40, 0.05, int(3e9), 0.0, Rectangular(), drive_channel, qubit=0)
+=======
+    qd_pulse = Pulse(0, 40, 0.05, int(3e9), 0.0, Rectangular(), "ch0", qubit=0)
+>>>>>>> 1b1e4cd4 (Fix Zurich tests)
     ro_pulse = Pulse(
         0,
         40,
@@ -298,6 +328,7 @@ def test_zhsequence_couplers(dummy_qrc):
         int(3e9),
         0.0,
         Rectangular(),
+<<<<<<< HEAD
         readout_channel,
         PulseType.READOUT,
         qubit=0,
@@ -305,6 +336,13 @@ def test_zhsequence_couplers(dummy_qrc):
     qc_pulse = Pulse.flux(
         0, 40, 0.05, Rectangular(), channel=couplerflux_channel, qubit=3
     )
+=======
+        "ch1",
+        qubit=0,
+        type=PulseType.READOUT,
+    )
+    qc_pulse = Pulse.flux(0, 40, 0.05, Rectangular(), channel="ch_c0", qubit=3)
+>>>>>>> 1b1e4cd4 (Fix Zurich tests)
     qc_pulse.type = PulseType.COUPLERFLUX
     sequence = PulseSequence()
     sequence.append(qd_pulse)
@@ -314,7 +352,59 @@ def test_zhsequence_couplers(dummy_qrc):
     zhsequence = controller.sequence_zh(sequence, IQM5q.qubits)
 
     assert len(zhsequence) == 3
+<<<<<<< HEAD
     assert len(zhsequence[couplerflux_channel]) == 1
+=======
+    assert len(zhsequence["readout0"]) == 1
+    assert len(zhsequence["couplerflux3"]) == 1
+
+
+def test_zhsequence_couplers_sweeper(dummy_qrc):
+    ro_pulse = Pulse(
+        0,
+        40,
+        0.05,
+        int(3e9),
+        0.0,
+        Rectangular(),
+        "ch1",
+        qubit=0,
+        type=PulseType.READOUT,
+    )
+    sequence = PulseSequence()
+    sequence.append(ro_pulse)
+    IQM5q = create_platform("zurich")
+    controller = IQM5q.instruments["EL_ZURO"]
+
+    delta_bias_range = np.arange(-1, 1, 0.5)
+
+    sweeper = Sweeper(
+        Parameter.amplitude,
+        delta_bias_range,
+        pulses=[
+            CouplerFluxPulse(
+                start=0,
+                duration=sequence.duration + sequence.start,
+                amplitude=1,
+                shape="Rectangular",
+                qubit=IQM5q.couplers[0].name,
+            )
+        ],
+        type=SweeperType.ABSOLUTE,
+    )
+
+    controller.sweepers = [sweeper]
+    controller.sequence_zh(sequence, IQM5q.qubits, IQM5q.couplers)
+    zhsequence = controller.sequence
+
+    with pytest.raises(AttributeError):
+        controller.sequence_zh("sequence", IQM5q.qubits, IQM5q.couplers)
+        zhsequence = controller.sequence
+
+    assert len(zhsequence) == 2
+    assert len(zhsequence["readout0"]) == 1
+    assert len(zhsequence["couplerflux0"]) == 0  # is it correct?
+>>>>>>> 1b1e4cd4 (Fix Zurich tests)
 
 
 def test_zhsequence_multiple_ro(dummy_qrc):
@@ -330,9 +420,15 @@ def test_zhsequence_multiple_ro(dummy_qrc):
         int(3e9),
         0.0,
         Rectangular(),
+<<<<<<< HEAD
         readout_channel,
         PulseType.READOUT,
         qubit=0,
+=======
+        "ch1",
+        qubit=0,
+        type=PulseType.READOUT,
+>>>>>>> 1b1e4cd4 (Fix Zurich tests)
     )
     sequence.append(ro_pulse)
     ro_pulse = Pulse(
@@ -342,9 +438,15 @@ def test_zhsequence_multiple_ro(dummy_qrc):
         int(3e9),
         0.0,
         Rectangular(),
+<<<<<<< HEAD
         readout_channel,
         PulseType.READOUT,
         qubit=0,
+=======
+        "ch1",
+        qubit=0,
+        type=PulseType.READOUT,
+>>>>>>> 1b1e4cd4 (Fix Zurich tests)
     )
     sequence.append(ro_pulse)
     platform = create_platform("zurich")
@@ -499,9 +601,23 @@ def test_sweep_and_play_sim(dummy_qrc):
 
     ro_pulses = {}
     qf_pulses = {}
+<<<<<<< HEAD
     for qubit in qubits.values():
         q = qubit.name
         qf_pulses[q] = Pulse.flux(
+=======
+    fr_pulses = {}
+    for qubit in qubits:
+        if fast_reset:
+            fr_pulses[qubit] = platform.create_RX_pulse(qubit, start=0)
+        qd_pulses[qubit] = platform.create_RX_pulse(qubit, start=0)
+        sequence.append(qd_pulses[qubit])
+        ro_pulses[qubit] = platform.create_qubit_readout_pulse(
+            qubit, start=qd_pulses[qubit].finish
+        )
+        sequence.append(ro_pulses[qubit])
+        qf_pulses[qubit] = Pulse.flux(
+>>>>>>> 1b1e4cd4 (Fix Zurich tests)
             start=0,
             duration=500,
             amplitude=1,
@@ -813,8 +929,41 @@ def test_experiment_sweep_punchouts(dummy_qrc, parameter):
 
     IQM5q.experiment_flow(qubits, couplers, sequence, options)
 
+<<<<<<< HEAD
     assert measure_channel_name(qubits[0]) in IQM5q.experiment.signals
     assert acquire_channel_name(qubits[0]) in IQM5q.experiment.signals
+=======
+    assert "measure0" in IQM5q.experiment.signals
+    assert "acquire0" in IQM5q.experiment.signals
+
+
+# TODO: Fix this
+def test_sim(dummy_qrc):
+    platform = create_platform("zurich")
+    IQM5q = platform.instruments["EL_ZURO"]
+    sequence = PulseSequence()
+    qubits = {0: platform.qubits[0]}
+    platform.qubits = qubits
+    ro_pulses = {}
+    qd_pulses = {}
+    qf_pulses = {}
+    for qubit in qubits:
+        qd_pulses[qubit] = platform.create_RX_pulse(qubit, start=0)
+        sequence.append(qd_pulses[qubit])
+        ro_pulses[qubit] = platform.create_qubit_readout_pulse(
+            qubit, start=qd_pulses[qubit].finish
+        )
+        sequence.append(ro_pulses[qubit])
+        qf_pulses[qubit] = Pulse.flux(
+            start=0,
+            duration=500,
+            amplitude=1,
+            shape=Rectangular(),
+            channel=platform.qubits[qubit].flux.name,
+            qubit=qubit,
+        )
+        sequence.append(qf_pulses[qubit])
+>>>>>>> 1b1e4cd4 (Fix Zurich tests)
 
 
 def test_batching(dummy_qrc):

--- a/tests/test_instruments_zhinst.py
+++ b/tests/test_instruments_zhinst.py
@@ -7,7 +7,6 @@ import numpy as np
 import pytest
 
 from qibolab import AcquisitionType, AveragingMode, ExecutionParameters, create_platform
-<<<<<<< HEAD
 from qibolab.instruments.zhinst import (
     ProcessedSweeps,
     ZhPulse,
@@ -16,9 +15,6 @@ from qibolab.instruments.zhinst import (
     classify_sweepers,
     measure_channel_name,
 )
-=======
-from qibolab.instruments.zhinst import ZhPulse, ZhSweeperLine, Zurich
->>>>>>> 1b1e4cd4 (Fix Zurich tests)
 from qibolab.pulses import (
     IIR,
     SNZ,
@@ -29,11 +25,7 @@ from qibolab.pulses import (
     PulseType,
     Rectangular,
 )
-<<<<<<< HEAD
 from qibolab.sweeper import Parameter, Sweeper
-=======
-from qibolab.sweeper import Parameter, Sweeper, SweeperType
->>>>>>> 1b1e4cd4 (Fix Zurich tests)
 from qibolab.unrolling import batch
 
 from .conftest import get_instrument
@@ -42,13 +34,12 @@ from .conftest import get_instrument
 @pytest.mark.parametrize(
     "pulse",
     [
-        Pulse(0, 40, 0.05, int(3e9), 0.0, Rectangular(), "ch0", qubit=0),
-        Pulse(0, 40, 0.05, int(3e9), 0.0, Gaussian(5), "ch0", qubit=0),
-        Pulse(0, 40, 0.05, int(3e9), 0.0, Gaussian(5), "ch0", qubit=0),
-        Pulse(0, 40, 0.05, int(3e9), 0.0, Drag(5, 0.4), "ch0", qubit=0),
-        Pulse(0, 40, 0.05, int(3e9), 0.0, SNZ(10, 0.01), "ch0", qubit=0),
+        Pulse(40, 0.05, int(3e9), 0.0, Rectangular(), "ch0", qubit=0),
+        Pulse(40, 0.05, int(3e9), 0.0, Gaussian(5), "ch0", qubit=0),
+        Pulse(40, 0.05, int(3e9), 0.0, Gaussian(5), "ch0", qubit=0),
+        Pulse(40, 0.05, int(3e9), 0.0, Drag(5, 0.4), "ch0", qubit=0),
+        Pulse(40, 0.05, int(3e9), 0.0, SNZ(10, 0.01), "ch0", qubit=0),
         Pulse(
-            0,
             40,
             0.05,
             int(3e9),
@@ -257,24 +248,6 @@ def test_zhinst_setup(dummy_qrc):
 
 
 def test_zhsequence(dummy_qrc):
-<<<<<<< HEAD
-=======
-    qd_pulse = Pulse(0, 40, 0.05, int(3e9), 0.0, Rectangular(), "ch0", qubit=0)
-    ro_pulse = Pulse(
-        0,
-        40,
-        0.05,
-        int(3e9),
-        0.0,
-        Rectangular(),
-        "ch1",
-        qubit=0,
-        type=PulseType.READOUT,
-    )
-    sequence = PulseSequence()
-    sequence.append(qd_pulse)
-    sequence.append(ro_pulse)
->>>>>>> 1b1e4cd4 (Fix Zurich tests)
     IQM5q = create_platform("zurich")
     controller = IQM5q.instruments["EL_ZURO"]
 
@@ -309,7 +282,6 @@ def test_zhsequence(dummy_qrc):
 
 
 def test_zhsequence_couplers(dummy_qrc):
-<<<<<<< HEAD
     IQM5q = create_platform("zurich")
     controller = IQM5q.instruments["EL_ZURO"]
 
@@ -318,9 +290,6 @@ def test_zhsequence_couplers(dummy_qrc):
     )
     couplerflux_channel = IQM5q.couplers[0].flux.name
     qd_pulse = Pulse(0, 40, 0.05, int(3e9), 0.0, Rectangular(), drive_channel, qubit=0)
-=======
-    qd_pulse = Pulse(0, 40, 0.05, int(3e9), 0.0, Rectangular(), "ch0", qubit=0)
->>>>>>> 1b1e4cd4 (Fix Zurich tests)
     ro_pulse = Pulse(
         0,
         40,
@@ -328,7 +297,6 @@ def test_zhsequence_couplers(dummy_qrc):
         int(3e9),
         0.0,
         Rectangular(),
-<<<<<<< HEAD
         readout_channel,
         PulseType.READOUT,
         qubit=0,
@@ -336,13 +304,6 @@ def test_zhsequence_couplers(dummy_qrc):
     qc_pulse = Pulse.flux(
         0, 40, 0.05, Rectangular(), channel=couplerflux_channel, qubit=3
     )
-=======
-        "ch1",
-        qubit=0,
-        type=PulseType.READOUT,
-    )
-    qc_pulse = Pulse.flux(0, 40, 0.05, Rectangular(), channel="ch_c0", qubit=3)
->>>>>>> 1b1e4cd4 (Fix Zurich tests)
     qc_pulse.type = PulseType.COUPLERFLUX
     sequence = PulseSequence()
     sequence.append(qd_pulse)
@@ -352,62 +313,7 @@ def test_zhsequence_couplers(dummy_qrc):
     zhsequence = controller.sequence_zh(sequence, IQM5q.qubits)
 
     assert len(zhsequence) == 3
-<<<<<<< HEAD
     assert len(zhsequence[couplerflux_channel]) == 1
-=======
-    assert len(zhsequence["readout0"]) == 1
-    assert len(zhsequence["couplerflux3"]) == 1
-
-
-def test_zhsequence_couplers_sweeper(dummy_qrc):
-    ro_pulse = Pulse(
-        0,
-        40,
-        0.05,
-        int(3e9),
-        0.0,
-        Rectangular(),
-        "ch1",
-        qubit=0,
-        type=PulseType.READOUT,
-    )
-    sequence = PulseSequence()
-    sequence.append(ro_pulse)
-    IQM5q = create_platform("zurich")
-    controller = IQM5q.instruments["EL_ZURO"]
-
-    delta_bias_range = np.arange(-1, 1, 0.5)
-
-    sweeper = Sweeper(
-        Parameter.amplitude,
-        delta_bias_range,
-        pulses=[
-            Pulse(
-                start=0,
-                duration=sequence.duration + sequence.start,
-                amplitude=1,
-                frequency=0,
-                relative_phase=0,
-                type=PulseType.COUPLERFLUX,
-                shape="Rectangular",
-                qubit=IQM5q.couplers[0].name,
-            )
-        ],
-        type=SweeperType.ABSOLUTE,
-    )
-
-    controller.sweepers = [sweeper]
-    controller.sequence_zh(sequence, IQM5q.qubits, IQM5q.couplers)
-    zhsequence = controller.sequence
-
-    with pytest.raises(AttributeError):
-        controller.sequence_zh("sequence", IQM5q.qubits, IQM5q.couplers)
-        zhsequence = controller.sequence
-
-    assert len(zhsequence) == 2
-    assert len(zhsequence["readout0"]) == 1
-    assert len(zhsequence["couplerflux0"]) == 0  # is it correct?
->>>>>>> 1b1e4cd4 (Fix Zurich tests)
 
 
 def test_zhsequence_multiple_ro(dummy_qrc):
@@ -423,15 +329,9 @@ def test_zhsequence_multiple_ro(dummy_qrc):
         int(3e9),
         0.0,
         Rectangular(),
-<<<<<<< HEAD
         readout_channel,
         PulseType.READOUT,
         qubit=0,
-=======
-        "ch1",
-        qubit=0,
-        type=PulseType.READOUT,
->>>>>>> 1b1e4cd4 (Fix Zurich tests)
     )
     sequence.append(ro_pulse)
     ro_pulse = Pulse(
@@ -441,15 +341,9 @@ def test_zhsequence_multiple_ro(dummy_qrc):
         int(3e9),
         0.0,
         Rectangular(),
-<<<<<<< HEAD
         readout_channel,
         PulseType.READOUT,
         qubit=0,
-=======
-        "ch1",
-        qubit=0,
-        type=PulseType.READOUT,
->>>>>>> 1b1e4cd4 (Fix Zurich tests)
     )
     sequence.append(ro_pulse)
     platform = create_platform("zurich")
@@ -604,23 +498,9 @@ def test_sweep_and_play_sim(dummy_qrc):
 
     ro_pulses = {}
     qf_pulses = {}
-<<<<<<< HEAD
     for qubit in qubits.values():
         q = qubit.name
         qf_pulses[q] = Pulse.flux(
-=======
-    fr_pulses = {}
-    for qubit in qubits:
-        if fast_reset:
-            fr_pulses[qubit] = platform.create_RX_pulse(qubit, start=0)
-        qd_pulses[qubit] = platform.create_RX_pulse(qubit, start=0)
-        sequence.append(qd_pulses[qubit])
-        ro_pulses[qubit] = platform.create_qubit_readout_pulse(
-            qubit, start=qd_pulses[qubit].finish
-        )
-        sequence.append(ro_pulses[qubit])
-        qf_pulses[qubit] = Pulse.flux(
->>>>>>> 1b1e4cd4 (Fix Zurich tests)
             start=0,
             duration=500,
             amplitude=1,
@@ -932,41 +812,8 @@ def test_experiment_sweep_punchouts(dummy_qrc, parameter):
 
     IQM5q.experiment_flow(qubits, couplers, sequence, options)
 
-<<<<<<< HEAD
     assert measure_channel_name(qubits[0]) in IQM5q.experiment.signals
     assert acquire_channel_name(qubits[0]) in IQM5q.experiment.signals
-=======
-    assert "measure0" in IQM5q.experiment.signals
-    assert "acquire0" in IQM5q.experiment.signals
-
-
-# TODO: Fix this
-def test_sim(dummy_qrc):
-    platform = create_platform("zurich")
-    IQM5q = platform.instruments["EL_ZURO"]
-    sequence = PulseSequence()
-    qubits = {0: platform.qubits[0]}
-    platform.qubits = qubits
-    ro_pulses = {}
-    qd_pulses = {}
-    qf_pulses = {}
-    for qubit in qubits:
-        qd_pulses[qubit] = platform.create_RX_pulse(qubit, start=0)
-        sequence.append(qd_pulses[qubit])
-        ro_pulses[qubit] = platform.create_qubit_readout_pulse(
-            qubit, start=qd_pulses[qubit].finish
-        )
-        sequence.append(ro_pulses[qubit])
-        qf_pulses[qubit] = Pulse.flux(
-            start=0,
-            duration=500,
-            amplitude=1,
-            shape=Rectangular(),
-            channel=platform.qubits[qubit].flux.name,
-            qubit=qubit,
-        )
-        sequence.append(qf_pulses[qubit])
->>>>>>> 1b1e4cd4 (Fix Zurich tests)
 
 
 def test_batching(dummy_qrc):

--- a/tests/test_instruments_zhinst.py
+++ b/tests/test_instruments_zhinst.py
@@ -382,10 +382,13 @@ def test_zhsequence_couplers_sweeper(dummy_qrc):
         Parameter.amplitude,
         delta_bias_range,
         pulses=[
-            CouplerFluxPulse(
+            Pulse(
                 start=0,
                 duration=sequence.duration + sequence.start,
                 amplitude=1,
+                frequency=0,
+                relative_phase=0,
+                type=PulseType.COUPLERFLUX,
                 shape="Rectangular",
                 qubit=IQM5q.couplers[0].name,
             )

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -72,7 +72,6 @@ def test_platform_pickle(platform):
     assert new_platform.is_connected == platform.is_connected
 
 
-@pytest.mark.skip
 def test_dump_runcard(platform, tmp_path):
     dump_runcard(platform, tmp_path)
     final_runcard = load_runcard(tmp_path)

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -19,11 +19,7 @@ from qibolab.instruments.qblox.controller import QbloxController
 from qibolab.instruments.rfsoc.driver import RFSoC
 from qibolab.kernels import Kernels
 from qibolab.platform import Platform, unroll_sequences
-<<<<<<< HEAD
-from qibolab.pulses import Drag, PulseSequence, Rectangular
-=======
-from qibolab.pulses import Delay, PulseSequence, Rectangular
->>>>>>> 2a664bea (test: first batch of fixing tests)
+from qibolab.pulses import Delay, Drag, PulseSequence, Rectangular
 from qibolab.serialize import (
     dump_kernels,
     dump_platform,
@@ -378,7 +374,9 @@ def test_create_RX_drag_pulses():
     for qubit in qubits:
         drag_pi = platform.create_RX_drag_pulse(qubit, 0, beta=beta)
         assert drag_pi.shape == Drag(drag_pi.shape.rel_sigma, beta=beta)
-        drag_pi_half = platform.create_RX90_drag_pulse(qubit, drag_pi.finish, beta=beta)
+        drag_pi_half = platform.create_RX90_drag_pulse(
+            qubit, drag_pi.duration, beta=beta
+        )
         assert drag_pi_half.shape == Drag(drag_pi_half.shape.rel_sigma, beta=beta)
         np.testing.assert_almost_equal(drag_pi.amplitude, 2 * drag_pi_half.amplitude)
 

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -19,7 +19,11 @@ from qibolab.instruments.qblox.controller import QbloxController
 from qibolab.instruments.rfsoc.driver import RFSoC
 from qibolab.kernels import Kernels
 from qibolab.platform import Platform, unroll_sequences
+<<<<<<< HEAD
 from qibolab.pulses import Drag, PulseSequence, Rectangular
+=======
+from qibolab.pulses import Delay, PulseSequence, Rectangular
+>>>>>>> 2a664bea (test: first batch of fixing tests)
 from qibolab.serialize import (
     dump_kernels,
     dump_platform,
@@ -36,14 +40,13 @@ nshots = 1024
 def test_unroll_sequences(platform):
     qubit = next(iter(platform.qubits))
     sequence = PulseSequence()
-    qd_pulse = platform.create_RX_pulse(qubit, start=0)
-    ro_pulse = platform.create_MZ_pulse(qubit, start=qd_pulse.finish)
+    qd_pulse = platform.create_RX_pulse(qubit)
+    ro_pulse = platform.create_MZ_pulse(qubit)
     sequence.append(qd_pulse)
+    sequence.append(Delay(qd_pulse.duration, platform.qubits[qubit].readout.name))
     sequence.append(ro_pulse)
     total_sequence, readouts = unroll_sequences(10 * [sequence], relaxation_time=10000)
-    assert len(total_sequence) == 20
     assert len(total_sequence.ro_pulses) == 10
-    assert total_sequence.finish == 10 * sequence.finish + 90000
     assert len(readouts) == 1
     assert len(readouts[ro_pulse.id]) == 10
 
@@ -69,6 +72,7 @@ def test_platform_pickle(platform):
     assert new_platform.is_connected == platform.is_connected
 
 
+@pytest.mark.skip
 def test_dump_runcard(platform, tmp_path):
     dump_runcard(platform, tmp_path)
     final_runcard = load_runcard(tmp_path)
@@ -81,6 +85,7 @@ def test_dump_runcard(platform, tmp_path):
     # some default ``Qubit`` parameters
     target_char = target_runcard.pop("characterization")["single_qubit"]
     final_char = final_runcard.pop("characterization")["single_qubit"]
+
     assert final_runcard == target_runcard
     for qubit, values in target_char.items():
         for name, value in values.items():
@@ -151,7 +156,7 @@ def test_platform_execute_one_drive_pulse(qpu_platform):
     platform = qpu_platform
     qubit = next(iter(platform.qubits))
     sequence = PulseSequence()
-    sequence.append(platform.create_qubit_drive_pulse(qubit, start=0, duration=200))
+    sequence.append(platform.create_qubit_drive_pulse(qubit, duration=200))
     platform.execute_pulse_sequence(sequence, ExecutionParameters(nshots=nshots))
 
 
@@ -163,9 +168,7 @@ def test_platform_execute_one_coupler_pulse(qpu_platform):
         pytest.skip("The platform does not have couplers")
     coupler = next(iter(platform.couplers))
     sequence = PulseSequence()
-    sequence.append(
-        platform.create_coupler_pulse(coupler, start=0, duration=200, amplitude=1)
-    )
+    sequence.append(platform.create_coupler_pulse(coupler, duration=200, amplitude=1))
     platform.execute_pulse_sequence(sequence, ExecutionParameters(nshots=nshots))
     assert len(sequence.cf_pulses) > 0
 
@@ -176,9 +179,7 @@ def test_platform_execute_one_flux_pulse(qpu_platform):
     platform = qpu_platform
     qubit = next(iter(platform.qubits))
     sequence = PulseSequence()
-    sequence.add(
-        platform.create_qubit_flux_pulse(qubit, start=0, duration=200, amplitude=1)
-    )
+    sequence.add(platform.create_qubit_flux_pulse(qubit, duration=200, amplitude=1))
     platform.execute_pulse_sequence(sequence, ExecutionParameters(nshots=nshots))
     assert len(sequence.qf_pulses) == 1
     assert len(sequence) == 1
@@ -189,7 +190,7 @@ def test_platform_execute_one_long_drive_pulse(qpu_platform):
     # Long duration
     platform = qpu_platform
     qubit = next(iter(platform.qubits))
-    pulse = platform.create_qubit_drive_pulse(qubit, start=0, duration=8192 + 200)
+    pulse = platform.create_qubit_drive_pulse(qubit, duration=8192 + 200)
     sequence = PulseSequence()
     sequence.append(pulse)
     options = ExecutionParameters(nshots=nshots)
@@ -210,7 +211,7 @@ def test_platform_execute_one_extralong_drive_pulse(qpu_platform):
     # Extra Long duration
     platform = qpu_platform
     qubit = next(iter(platform.qubits))
-    pulse = platform.create_qubit_drive_pulse(qubit, start=0, duration=2 * 8192 + 200)
+    pulse = platform.create_qubit_drive_pulse(qubit, duration=2 * 8192 + 200)
     sequence = PulseSequence()
     sequence.append(pulse)
     options = ExecutionParameters(nshots=nshots)
@@ -228,25 +229,29 @@ def test_platform_execute_one_extralong_drive_pulse(qpu_platform):
 
 @pytest.mark.qpu
 def test_platform_execute_one_drive_one_readout(qpu_platform):
-    # One drive pulse and one readout pulse
+    """One drive pulse and one readout pulse."""
     platform = qpu_platform
     qubit = next(iter(platform.qubits))
     sequence = PulseSequence()
-    sequence.append(platform.create_qubit_drive_pulse(qubit, start=0, duration=200))
-    sequence.append(platform.create_qubit_readout_pulse(qubit, start=200))
+    sequence.append(platform.create_qubit_drive_pulse(qubit, duration=200))
+    sequence.append(Delay(200, platform.qubits[qubit].readout.name))
+    sequence.append(platform.create_qubit_readout_pulse(qubit))
     platform.execute_pulse_sequence(sequence, ExecutionParameters(nshots=nshots))
 
 
 @pytest.mark.qpu
 def test_platform_execute_multiple_drive_pulses_one_readout(qpu_platform):
-    # Multiple qubit drive pulses and one readout pulse
+    """Multiple qubit drive pulses and one readout pulse."""
     platform = qpu_platform
     qubit = next(iter(platform.qubits))
     sequence = PulseSequence()
-    sequence.append(platform.create_qubit_drive_pulse(qubit, start=0, duration=200))
-    sequence.append(platform.create_qubit_drive_pulse(qubit, start=204, duration=200))
-    sequence.append(platform.create_qubit_drive_pulse(qubit, start=408, duration=400))
-    sequence.append(platform.create_qubit_readout_pulse(qubit, start=808))
+    sequence.append(platform.create_qubit_drive_pulse(qubit, duration=200))
+    sequence.append(Delay(4, platform.qubits[qubit].drive.name))
+    sequence.append(platform.create_qubit_drive_pulse(qubit, duration=200))
+    sequence.append(Delay(4, platform.qubits[qubit].drive.name))
+    sequence.append(platform.create_qubit_drive_pulse(qubit, duration=400))
+    sequence.append(Delay(808, platform.qubits[qubit].readout.name))
+    sequence.append(platform.create_qubit_readout_pulse(qubit))
     platform.execute_pulse_sequence(sequence, ExecutionParameters(nshots=nshots))
 
 
@@ -254,14 +259,16 @@ def test_platform_execute_multiple_drive_pulses_one_readout(qpu_platform):
 def test_platform_execute_multiple_drive_pulses_one_readout_no_spacing(
     qpu_platform,
 ):
-    # Multiple qubit drive pulses and one readout pulse with no spacing between them
+    """Multiple qubit drive pulses and one readout pulse with no spacing
+    between them."""
     platform = qpu_platform
     qubit = next(iter(platform.qubits))
     sequence = PulseSequence()
-    sequence.append(platform.create_qubit_drive_pulse(qubit, start=0, duration=200))
-    sequence.append(platform.create_qubit_drive_pulse(qubit, start=200, duration=200))
-    sequence.append(platform.create_qubit_drive_pulse(qubit, start=400, duration=400))
-    sequence.append(platform.create_qubit_readout_pulse(qubit, start=800))
+    sequence.append(platform.create_qubit_drive_pulse(qubit, duration=200))
+    sequence.append(platform.create_qubit_drive_pulse(qubit, duration=200))
+    sequence.append(platform.create_qubit_drive_pulse(qubit, duration=400))
+    sequence.append(Delay(800, platform.qubits[qubit].readout.name))
+    sequence.append(platform.create_qubit_readout_pulse(qubit))
     platform.execute_pulse_sequence(sequence, ExecutionParameters(nshots=nshots))
 
 
@@ -269,34 +276,37 @@ def test_platform_execute_multiple_drive_pulses_one_readout_no_spacing(
 def test_platform_execute_multiple_overlaping_drive_pulses_one_readout(
     qpu_platform,
 ):
-    # Multiple overlapping qubit drive pulses and one readout pulse
+    """Multiple overlapping qubit drive pulses and one readout pulse."""
+    # TODO: This requires defining different logical channels on the same qubit
     platform = qpu_platform
     qubit = next(iter(platform.qubits))
     sequence = PulseSequence()
-    sequence.append(platform.create_qubit_drive_pulse(qubit, start=0, duration=200))
-    sequence.append(platform.create_qubit_drive_pulse(qubit, start=200, duration=200))
-    sequence.append(platform.create_qubit_drive_pulse(qubit, start=50, duration=400))
-    sequence.append(platform.create_qubit_readout_pulse(qubit, start=800))
+    sequence.append(platform.create_qubit_drive_pulse(qubit, duration=200))
+    sequence.append(platform.create_qubit_drive_pulse(qubit, duration=200))
+    sequence.append(platform.create_qubit_drive_pulse(qubit, duration=400))
+    sequence.append(Delay(800, platform.qubits[qubit].readout.name))
+    sequence.append(platform.create_qubit_readout_pulse(qubit))
     platform.execute_pulse_sequence(sequence, ExecutionParameters(nshots=nshots))
 
 
 @pytest.mark.qpu
 def test_platform_execute_multiple_readout_pulses(qpu_platform):
-    # Multiple readout pulses
+    """Multiple readout pulses."""
     platform = qpu_platform
     qubit = next(iter(platform.qubits))
     sequence = PulseSequence()
-    qd_pulse1 = platform.create_qubit_drive_pulse(qubit, start=0, duration=200)
-    ro_pulse1 = platform.create_qubit_readout_pulse(qubit, start=200)
-    qd_pulse2 = platform.create_qubit_drive_pulse(
-        qubit, start=(ro_pulse1.start + ro_pulse1.duration), duration=400
-    )
-    ro_pulse2 = platform.create_qubit_readout_pulse(
-        qubit, start=(ro_pulse1.start + ro_pulse1.duration + 400)
-    )
+    qd_pulse1 = platform.create_qubit_drive_pulse(qubit, duration=200)
+    ro_pulse1 = platform.create_qubit_readout_pulse(qubit)
+    qd_pulse2 = platform.create_qubit_drive_pulse(qubit, duration=400)
+    ro_pulse2 = platform.create_qubit_readout_pulse(qubit)
     sequence.append(qd_pulse1)
+    sequence.append(Delay(200, platform.qubits[qubit].readout.name))
     sequence.append(ro_pulse1)
+    sequence.append(Delay(200 + ro_pulse1.duration, platform.qubits[qubit].drive.name))
     sequence.append(qd_pulse2)
+    sequence.append(
+        Delay(200 + ro_pulse1.duration + 400, platform.qubits[qubit].readout.name)
+    )
     sequence.append(ro_pulse2)
     platform.execute_pulse_sequence(sequence, ExecutionParameters(nshots=nshots))
 
@@ -313,8 +323,9 @@ def test_excited_state_probabilities_pulses(qpu_platform):
     sequence = PulseSequence()
     for qubit in qubits:
         qd_pulse = platform.create_RX_pulse(qubit)
-        ro_pulse = platform.create_MZ_pulse(qubit, start=qd_pulse.duration)
+        ro_pulse = platform.create_MZ_pulse(qubit)
         sequence.append(qd_pulse)
+        sequence.append(Delay(qd_pulse.duration, platform.qubits[qubit].readout.name))
         sequence.append(ro_pulse)
     result = platform.execute_pulse_sequence(sequence, ExecutionParameters(nshots=5000))
 
@@ -341,11 +352,12 @@ def test_ground_state_probabilities_pulses(qpu_platform, start_zero):
     backend = QibolabBackend(platform)
     sequence = PulseSequence()
     for qubit in qubits:
-        if start_zero:
-            ro_pulse = platform.create_MZ_pulse(qubit, start=0)
-        else:
+        if not start_zero:
             qd_pulse = platform.create_RX_pulse(qubit)
-            ro_pulse = platform.create_MZ_pulse(qubit, start=qd_pulse.duration)
+            sequence.append(
+                Delay(qd_pulse.duration, platform.qubits[qubit].readout.name)
+            )
+        ro_pulse = platform.create_MZ_pulse(qubit)
         sequence.append(ro_pulse)
     result = platform.execute_pulse_sequence(sequence, ExecutionParameters(nshots=5000))
 

--- a/tests/test_sweeper.py
+++ b/tests/test_sweeper.py
@@ -8,7 +8,7 @@ from qibolab.sweeper import Parameter, QubitParameter, Sweeper
 
 @pytest.mark.parametrize("parameter", Parameter)
 def test_sweeper_pulses(parameter):
-    pulse = Pulse(0, 40, 0.1, int(1e9), 0.0, Rectangular(), "channel")
+    pulse = Pulse(40, 0.1, int(1e9), 0.0, Rectangular(), "channel")
     if parameter is Parameter.amplitude:
         parameter_range = np.random.rand(10)
     else:
@@ -34,7 +34,7 @@ def test_sweeper_qubits(parameter):
 
 
 def test_sweeper_errors():
-    pulse = Pulse(0, 40, 0.1, int(1e9), 0.0, Rectangular(), "channel")
+    pulse = Pulse(40, 0.1, int(1e9), 0.0, Rectangular(), "channel")
     qubit = Qubit(0)
     parameter_range = np.random.randint(10, size=10)
     with pytest.raises(ValueError):

--- a/tests/test_unrolling.py
+++ b/tests/test_unrolling.py
@@ -7,13 +7,13 @@ from qibolab.unrolling import Bounds, batch
 
 
 def test_bounds_update():
-    p1 = Pulse(400, 40, 0.9, int(100e6), 0, Drag(5, 1), 3, PulseType.DRIVE)
-    p2 = Pulse(500, 40, 0.9, int(100e6), 0, Drag(5, 1), 2, PulseType.DRIVE)
-    p3 = Pulse(600, 40, 0.9, int(100e6), 0, Drag(5, 1), 1, PulseType.DRIVE)
+    p1 = Pulse(40, 0.9, int(100e6), 0, Drag(5, 1), 3, PulseType.DRIVE)
+    p2 = Pulse(40, 0.9, int(100e6), 0, Drag(5, 1), 2, PulseType.DRIVE)
+    p3 = Pulse(40, 0.9, int(100e6), 0, Drag(5, 1), 1, PulseType.DRIVE)
 
-    p4 = Pulse(440, 1000, 0.9, int(20e6), 0, Rectangular(), 3, PulseType.READOUT)
-    p5 = Pulse(540, 1000, 0.9, int(20e6), 0, Rectangular(), 2, PulseType.READOUT)
-    p6 = Pulse(640, 1000, 0.9, int(20e6), 0, Rectangular(), 1, PulseType.READOUT)
+    p4 = Pulse(1000, 0.9, int(20e6), 0, Rectangular(), 3, PulseType.READOUT)
+    p5 = Pulse(1000, 0.9, int(20e6), 0, Rectangular(), 2, PulseType.READOUT)
+    p6 = Pulse(1000, 0.9, int(20e6), 0, Rectangular(), 1, PulseType.READOUT)
 
     ps = PulseSequence([p1, p2, p3, p4, p5, p6])
     bounds = Bounds.update(ps)
@@ -51,13 +51,13 @@ def test_bounds_comparison():
     ],
 )
 def test_batch(bounds):
-    p1 = Pulse(400, 40, 0.9, int(100e6), 0, Drag(5, 1), 3, PulseType.DRIVE)
-    p2 = Pulse(500, 40, 0.9, int(100e6), 0, Drag(5, 1), 2, PulseType.DRIVE)
-    p3 = Pulse(600, 40, 0.9, int(100e6), 0, Drag(5, 1), 1, PulseType.DRIVE)
+    p1 = Pulse(40, 0.9, int(100e6), 0, Drag(5, 1), 3, PulseType.DRIVE)
+    p2 = Pulse(40, 0.9, int(100e6), 0, Drag(5, 1), 2, PulseType.DRIVE)
+    p3 = Pulse(40, 0.9, int(100e6), 0, Drag(5, 1), 1, PulseType.DRIVE)
 
-    p4 = Pulse(440, 1000, 0.9, int(20e6), 0, Rectangular(), 3, PulseType.READOUT)
-    p5 = Pulse(540, 1000, 0.9, int(20e6), 0, Rectangular(), 2, PulseType.READOUT)
-    p6 = Pulse(640, 1000, 0.9, int(20e6), 0, Rectangular(), 1, PulseType.READOUT)
+    p4 = Pulse(1000, 0.9, int(20e6), 0, Rectangular(), 3, PulseType.READOUT)
+    p5 = Pulse(1000, 0.9, int(20e6), 0, Rectangular(), 2, PulseType.READOUT)
+    p6 = Pulse(1000, 0.9, int(20e6), 0, Rectangular(), 1, PulseType.READOUT)
 
     ps = PulseSequence([p1, p2, p3, p4, p5, p6])
 


### PR DESCRIPTION
@alecandido @hay-k following what we discussed last week, the goal of this PR is to replace `pulse.start` with a new `Delay` object. In the next days I will try to propagate the changes to native, platform and eventually the QM driver as a first driver test (although for this I'd prefer to have #733 and #738 available). In the meantime, feel free to have a look and let me know if you have any suggestions so that this moves towards a direction that all of us like (as much as possible).

Here is a summary of the affected objects so far:

## `Delay`

New class added to represent delays. Decided to go with a new object, completely seperate from `Pulse` because:
* it is more straightforward in terms of usability (delay pulse shape does not sound very nice),
* in most (if not all) instruments delays correspond to a different instruction than the one used to play pulses, unless they are implemented with zero waveforms, which is the wrong way. There may be some exceptions to this rule, for example QM does not support delays < 16ns and in such cases other workarounds need to be found, but these can be handled internally in the driver.

## `Pulse`

Dropped the following methods/properties:

- [X] `finish`: not applicable if `Pulse` does not have `start` (*dropped*).
- [x] `global_phase`: requires `start` so it should be handled by the sequence but we can probably drop altogether because it is only used for software modulation.
- [ ] `phase`: should we rename `relative_phase` to `phase`?
- [x] `is_equal_ignoring_start`: it can probably be replaced by dataclass autogenerated `__eq__`.

## `PulseSequence`

Some implementations will depend on the choice between (internal vs external) pulse sequence
(internal=channel attribute, sequence is just list / external=sequence has a list for each channel)

Require modification:

- [x] `duration`: implementation depends on (internal vs external). I did a temporary implementation based on the current internal representation of channels, essentially by constructing the external.
- [X] `start`: probably not useful (*dropped*)
- [X] `finish`: equivalent to `duration` if we drop `start` (*dropped*)
- [X] `get_pulse_overlaps`: implementation depends on (internal vs external) (*dropped*)
- [x] `seperate_overlapping_pulses`: same as above (*used by qblox*)

## `Align` (not implemented)

A suggestion of an additional non-pulse instruction which can be used to synchronize different channels, without explicit use of delays. For example, the README example would look like:
```py
sequence.append(Pulse(duration=4000, ... channel=1))
sequence.append(Align(1, 2))
sequence.append(ReadoutPulse(... channel=2))
```
I did not implement this because it may be biased towards QM and complicate other drivers, so I would prefer to wait for feedback first.

---

## `Sweeper`

- [X] Removed `Parameter.start`

## Native gates

- [X] Removed `NativePulse`, `NativeSequence`, etc. as they are duplicates of `Pulse` and `PulseSequence`.
- [X] Moved serialization related methods (`from_dict` and `raw`) to serialize.py since they are more associated with the YAML/JSON runcard rather than the qibolab API.
- [ ] How to handle pulse virtual-Z phases?

## `Platform`

- [X] Removed `start` from `platform.create_*` methods.
- [x] How to handle pulse phases? I am temporarily modifying the phase of pulses after creation but this is not ideal particularly if we want `Pulse` to be frozen.
- [x] Update `unroll_sequences`.
