### PR TITLE
Clear some clutter in the ZI driver

### DIFF
--- a/src/qibolab/instruments/zhinst.py
+++ b/src/qibolab/instruments/zhinst.py
@@ -271,11 +271,7 @@ class Zurich(Controller):
     def __init__(
         self, name, device_setup, time_of_flight=0.0, smearing=0.0
     ):
-        self.name = name
-        "Setup name (str)"
-
-        self.is_connected = False
-        "Is the device connected ? (bool)"
+        super().__init__(name, None)
 
         self.signal_map = {}
         "Signals to lines mapping"

--- a/src/qibolab/instruments/zhinst.py
+++ b/src/qibolab/instruments/zhinst.py
@@ -1147,6 +1147,11 @@ class Zurich(Controller):
         sweepers = list(sweepers)
         rearranging_axes, sweepers = self.rearrange_sweepers(sweepers)
         self.sweepers = sweepers
+        # if using singleshot, the first axis contains shots,
+        # i.e.: (nshots, sweeper_1, sweeper_2)
+        # if using integration: (sweeper_1, sweeper_2)
+        if options.averaging_mode is AveragingMode.SINGLESHOT:
+            rearranging_axes += 1
 
         self.frequency_from_pulses(qubits, sequence)
 
@@ -1159,11 +1164,7 @@ class Zurich(Controller):
             q = qubit.name  # pylint: disable=C0103
             for i, ropulse in enumerate(self.sequence[measure_signal_name(qubit)]):
                 exp_res = self.results.get_data(f"sequence{q}_{i}")
-                # if using singleshot, the first axis contains shots,
-                # i.e.: (nshots, sweeper_1, sweeper_2)
-                # if using integration: (sweeper_1, sweeper_2)
-                if options.averaging_mode is AveragingMode.SINGLESHOT:
-                    rearranging_axes += 1
+
                 # Reorder dimensions
                 data = np.moveaxis(exp_res, rearranging_axes[0], rearranging_axes[1])
                 if options.acquisition_type is AcquisitionType.DISCRIMINATION:

--- a/src/qibolab/instruments/zhinst.py
+++ b/src/qibolab/instruments/zhinst.py
@@ -606,16 +606,15 @@ class Zurich(Controller):
         results = {}
         for qubit in qubits.values():
             q = qubit.name  # pylint: disable=C0103
-            if len(self.sequence[measure_signal_name(qubit)]) != 0:
-                for i, ropulse in enumerate(self.sequence[measure_signal_name(qubit)]):
-                    data = np.array(self.results.get_data(f"sequence{q}_{i}"))
-                    if options.acquisition_type is AcquisitionType.DISCRIMINATION:
-                        data = (
-                            np.ones(data.shape) - data.real
-                        )  # Probability inversion patch
-                    serial = ropulse.pulse.serial
-                    qubit = ropulse.pulse.qubit
-                    results[serial] = results[qubit] = options.results_type(data)
+            for i, ropulse in enumerate(self.sequence[measure_signal_name(qubit)]):
+                data = np.array(self.results.get_data(f"sequence{q}_{i}"))
+                if options.acquisition_type is AcquisitionType.DISCRIMINATION:
+                    data = (
+                        np.ones(data.shape) - data.real
+                    )  # Probability inversion patch
+                serial = ropulse.pulse.serial
+                qubit = ropulse.pulse.qubit
+                results[serial] = results[qubit] = options.results_type(data)
 
         return results
 
@@ -1005,11 +1004,10 @@ class Zurich(Controller):
         for qubit in qubits.values():
             iq_angle = qubit.iq_angle
             channel_name = measure_signal_name(qubit)
-            if len(self.sequence[channel_name]) != 0:
-                for i, pulse in enumerate(self.sequence[channel_name]):
-                    readout_schedule[i].append(pulse)
-                    qubit_readout_schedule[i].append(qubit)
-                    iq_angle_readout_schedule[i].append(iq_angle)
+            for i, pulse in enumerate(self.sequence[channel_name]):
+                readout_schedule[i].append(pulse)
+                qubit_readout_schedule[i].append(qubit)
+                iq_angle_readout_schedule[i].append(iq_angle)
 
         weights = {}
         for i, (pulses, qubits_readout, iq_angles) in enumerate(
@@ -1159,26 +1157,23 @@ class Zurich(Controller):
         results = {}
         for qubit in qubits.values():
             q = qubit.name  # pylint: disable=C0103
-            if len(self.sequence[measure_signal_name(qubit)]) != 0:
-                for i, ropulse in enumerate(self.sequence[measure_signal_name(qubit)]):
-                    exp_res = self.results.get_data(f"sequence{q}_{i}")
-                    # if using singleshot, the first axis contains shots,
-                    # i.e.: (nshots, sweeper_1, sweeper_2)
-                    # if using integration: (sweeper_1, sweeper_2)
-                    if options.averaging_mode is AveragingMode.SINGLESHOT:
-                        rearranging_axes += 1
-                    # Reorder dimensions
-                    data = np.moveaxis(
-                        exp_res, rearranging_axes[0], rearranging_axes[1]
-                    )
-                    if options.acquisition_type is AcquisitionType.DISCRIMINATION:
-                        data = (
-                            np.ones(data.shape) - data.real
-                        )  # Probability inversion patch
+            for i, ropulse in enumerate(self.sequence[measure_signal_name(qubit)]):
+                exp_res = self.results.get_data(f"sequence{q}_{i}")
+                # if using singleshot, the first axis contains shots,
+                # i.e.: (nshots, sweeper_1, sweeper_2)
+                # if using integration: (sweeper_1, sweeper_2)
+                if options.averaging_mode is AveragingMode.SINGLESHOT:
+                    rearranging_axes += 1
+                # Reorder dimensions
+                data = np.moveaxis(exp_res, rearranging_axes[0], rearranging_axes[1])
+                if options.acquisition_type is AcquisitionType.DISCRIMINATION:
+                    data = (
+                        np.ones(data.shape) - data.real
+                    )  # Probability inversion patch
 
-                    serial = ropulse.pulse.serial
-                    qubit = ropulse.pulse.qubit
-                    results[serial] = results[qubit] = options.results_type(data)
+                serial = ropulse.pulse.serial
+                qubit = ropulse.pulse.qubit
+                results[serial] = results[qubit] = options.results_type(data)
 
         return results
 

--- a/src/qibolab/instruments/zhinst.py
+++ b/src/qibolab/instruments/zhinst.py
@@ -806,9 +806,9 @@ class Zurich(Controller):
         """Play pulse and sweepers sequence."""
 
         self.signal_map = {}
+        self.sweepers = list(sweepers)
         self.nt_sweeps, self.rt_sweeps = classify_sweepers(self.sweepers)
         swapped_axis_pair, self.rt_sweeps = self.rearrange_sweepers(self.rt_sweeps)
-        self.sweepers = list(sweepers)
         swapped_axis_pair += len(self.nt_sweeps)
         # if using singleshot, the first axis contains shots,
         # i.e.: (nshots, sweeper_1, sweeper_2)

--- a/src/qibolab/instruments/zhinst.py
+++ b/src/qibolab/instruments/zhinst.py
@@ -1,12 +1,10 @@
 """Instrument for using the Zurich Instruments (Zhinst) devices."""
 
 import copy
-import os
 from collections import defaultdict
 from dataclasses import dataclass, replace
 from typing import Dict, List, Tuple, Union
 
-import laboneq._token
 import laboneq.simple as lo
 import numpy as np
 from laboneq.dsl.experiment.pulse_library import (
@@ -25,9 +23,6 @@ from qibolab.unrolling import Bounds
 from .abstract import Controller
 from .port import Port
 
-# this env var just needs to be set
-os.environ["LABONEQ_TOKEN"] = "not required"
-laboneq._token.is_valid_token = lambda _token: True  # pylint: disable=W0212
 
 SAMPLING_RATE = 2
 NANO_TO_SECONDS = 1e-9

--- a/src/qibolab/instruments/zhinst.py
+++ b/src/qibolab/instruments/zhinst.py
@@ -113,6 +113,13 @@ def select_pulse(pulse, pulse_type):
         )
 
 
+@dataclass
+class ZhPort(Port):
+    name: Tuple[str, str]
+    offset: float = 0.0
+    power_range: int = 0
+
+
 class ZhPulse:
     """Zurich pulse from qibolab pulse translation."""
 
@@ -254,12 +261,6 @@ class ZhSweeperLine:
                 uid=sweeper.parameter.name,
                 values=sweeper.values * NANO_TO_SECONDS,
             )
-
-
-# FIXME: not needed for any logic inside the driver. Only needed to meet the expectations set by parent class Controller.
-@dataclass
-class ZhPort:
-    name: str
 
 
 class Zurich(Controller):

--- a/src/qibolab/instruments/zhinst.py
+++ b/src/qibolab/instruments/zhinst.py
@@ -289,18 +289,14 @@ class Zurich(Controller):
 
         self.device_setup = device_setup
         self.session = None
-        self.device = None
         "Zurich device parameters for connection"
 
         self.time_of_flight = time_of_flight
         self.smearing = smearing
-        self.chip = "iqm5q"
         "Parameters read from the runcard not part of ExecutionParameters"
 
         self.exp = None
         self.experiment = None
-        self.exp_options = ExecutionParameters()
-        self.exp_calib = lo.Calibration()
         self.results = None
         "Zurich experiment definitions"
 
@@ -323,8 +319,6 @@ class Zurich(Controller):
         self.nt_sweeps = None
         "Storing sweepers"
         # Improve the storing of multiple sweeps
-        self._ports = {}
-        self.settings = None
 
     @property
     def sampling_rate(self):
@@ -335,12 +329,12 @@ class Zurich(Controller):
             # To fully remove logging #configure_logging=False
             # I strongly advise to set it to 20 to have time estimates of the experiment duration!
             self.session = lo.Session(self.device_setup, log_level=20)
-            self.device = self.session.connect()
+            _ = self.session.connect()
             self.is_connected = True
 
     def disconnect(self):
         if self.is_connected:
-            self.device = self.session.disconnect()
+            _ = self.session.disconnect()
             self.is_connected = False
 
     def calibration_step(self, qubits, couplers, options):

--- a/src/qibolab/instruments/zhinst.py
+++ b/src/qibolab/instruments/zhinst.py
@@ -144,8 +144,6 @@ class ZhPulse:
         """Zurich pulse from qibolab pulse."""
         self.pulse = pulse
         """Qibolab pulse."""
-        self.signal = f"{pulse.type.name.lower()}{pulse.qubit}"
-        """Line associated with the pulse."""
         self.zhpulse = select_pulse(pulse, pulse.type.name.lower())
         """Zurich pulse."""
 
@@ -160,8 +158,7 @@ class ZhSweeper:
 
         self.pulse = pulse
         """Qibolab pulse associated to the sweeper."""
-        self.signal = f"{pulse.type.name.lower()}{pulse.qubit}"
-        """Line associated with the pulse."""
+
         self.zhpulse = ZhPulse(pulse).zhpulse
         """Zurich pulse associated to the sweeper."""
 
@@ -234,7 +231,6 @@ class ZhSweeperLine:
                     channel=qubit.flux.name,
                     qubit=qubit.name,
                 )
-                self.signal = qubit.flux.name
             if isinstance(qubit, Coupler):
                 pulse = CouplerFluxPulse(
                     start=0,
@@ -244,7 +240,6 @@ class ZhSweeperLine:
                     channel=qubit.flux.name,
                     qubit=qubit.name,
                 )
-                self.signal = qubit.flux.name
 
             self.pulse = pulse
 
@@ -257,8 +252,6 @@ class ZhSweeperLine:
         elif sweeper.parameter is Parameter.start:
             if pulse:
                 self.pulse = pulse
-                self.signal = qubit.flux.name
-
                 self.zhpulse = ZhPulse(pulse).zhpulse
 
         # Need something better to store multiple sweeps on the same pulse

--- a/src/qibolab/instruments/zhinst.py
+++ b/src/qibolab/instruments/zhinst.py
@@ -206,7 +206,9 @@ class ZhPulse:
     # pylint: disable=R0903
     def add_sweeper(self, sweeper, qubit):
         """Add sweeper to list of sweepers associated with this pulse."""
-        self.zhsweepers.append(select_sweeper(sweeper, self.pulse.type, qubit))
+        self.zhsweepers.append(
+            (sweeper.parameter, select_sweeper(sweeper, self.pulse.type, qubit))
+        )
 
     def add_delay_sweeper(self, sweeper):
         self.delay_sweeper = select_sweeper(sweeper)
@@ -757,14 +759,14 @@ class Zurich(Controller):
     def play_sweep(exp, channel_name, pulse):
         """Play Zurich pulse when a single sweeper is involved."""
         play_parameters = {}
-        for zhs in pulse.zhsweepers:
-            if zhs.uid == "amplitude":
+        for p, zhs in pulse.zhsweepers:
+            if p is Parameter.amplitude:
                 pulse.zhpulse.amplitude *= max(zhs.values)
                 zhs.values /= max(zhs.values)
                 play_parameters["amplitude"] = zhs
-            if zhs.uid == "duration":
+            if p is Parameter.duration:
                 play_parameters["length"] = zhs
-            if zhs.uid == "relative_phase":
+            if p is Parameter.relative_phase:
                 play_parameters["phase"] = zhs
         if "phase" not in play_parameters:
             play_parameters["phase"] = pulse.pulse.relative_phase

--- a/src/qibolab/instruments/zhinst.py
+++ b/src/qibolab/instruments/zhinst.py
@@ -23,7 +23,6 @@ from qibolab.unrolling import Bounds
 from .abstract import Controller
 from .port import Port
 
-
 SAMPLING_RATE = 2
 NANO_TO_SECONDS = 1e-9
 COMPILER_SETTINGS = {
@@ -201,8 +200,7 @@ class ZhSweeper:
 
 class ZhSweeperLine:
     """Zurich sweeper from qibolab sweeper for non pulse parameters Bias, Delay
-    (, power_range, local_oscillator frequency, offset ???)
-    """
+    (, power_range, local_oscillator frequency, offset ???)"""
 
     def __init__(self, sweeper, qubit=None, sequence=None, pulse=None):
         self.sweeper = sweeper
@@ -268,9 +266,7 @@ class Zurich(Controller):
 
     PortType = ZhPort
 
-    def __init__(
-        self, name, device_setup, time_of_flight=0.0, smearing=0.0
-    ):
+    def __init__(self, name, device_setup, time_of_flight=0.0, smearing=0.0):
         super().__init__(name, None)
 
         self.signal_map = {}

--- a/src/qibolab/instruments/zhinst.py
+++ b/src/qibolab/instruments/zhinst.py
@@ -663,19 +663,7 @@ class Zurich(Controller):
         """Zurich experiment initialization using their Experiment class."""
 
         # Setting experiment signal lines
-        signals = []
-        for coupler in couplers.values():
-            signals.append(lo.ExperimentSignal(f"couplerflux{coupler.name}"))
-
-        for qubit in qubits.values():
-            q = qubit.name  # pylint: disable=C0103
-            if len(self.sequence[f"drive{q}"]) != 0:
-                signals.append(lo.ExperimentSignal(f"drive{q}"))
-            if qubit.flux is not None:
-                signals.append(lo.ExperimentSignal(f"flux{q}"))
-            if len(self.sequence[f"readout{q}"]) != 0:
-                signals.append(lo.ExperimentSignal(f"measure{q}"))
-                signals.append(lo.ExperimentSignal(f"acquire{q}"))
+        signals = [lo.ExperimentSignal(name) for name in self.signal_map.keys()]
 
         exp = lo.Experiment(
             uid="Sequence",

--- a/src/qibolab/instruments/zhinst.py
+++ b/src/qibolab/instruments/zhinst.py
@@ -113,13 +113,6 @@ def select_pulse(pulse, pulse_type):
         )
 
 
-@dataclass
-class ZhPort(Port):
-    name: Tuple[str, str]
-    offset: float = 0.0
-    power_range: int = 0
-
-
 class ZhPulse:
     """Zurich pulse from qibolab pulse translation."""
 
@@ -261,6 +254,12 @@ class ZhSweeperLine:
                 uid=sweeper.parameter.name,
                 values=sweeper.values * NANO_TO_SECONDS,
             )
+
+
+# FIXME: not needed for any logic inside the driver. Only needed to meet the expectations set by parent class Controller.
+@dataclass
+class ZhPort:
+    name: str
 
 
 class Zurich(Controller):

--- a/src/qibolab/instruments/zhinst.py
+++ b/src/qibolab/instruments/zhinst.py
@@ -581,7 +581,7 @@ class Zurich(Controller):
 
         def set_acquisition_type():
             for sweeper in self.sweepers:
-                if sweeper.parameter.name in {Parameter.frequency, Parameter.amplitude}:
+                if sweeper.parameter in {Parameter.frequency, Parameter.amplitude}:
                     for pulse in sweeper.pulses:
                         if pulse.type is PulseType.READOUT:
                             # FIXME: case of multiple pulses

--- a/src/qibolab/instruments/zhinst/__init__.py
+++ b/src/qibolab/instruments/zhinst/__init__.py
@@ -1,0 +1,4 @@
+from .executor import Zurich
+from .pulse import ZhPulse
+from .sweep import ProcessedSweeps, classify_sweepers
+from .util import acquire_channel_name, measure_channel_name

--- a/src/qibolab/instruments/zhinst/executor.py
+++ b/src/qibolab/instruments/zhinst/executor.py
@@ -11,15 +11,13 @@ from qibo.config import log
 
 from qibolab import AcquisitionType, AveragingMode, ExecutionParameters
 from qibolab.couplers import Coupler
-
-from qibolab.instruments.unrolling import batch_max_sequences
+from qibolab.instruments.abstract import Controller
+from qibolab.instruments.port import Port
 from qibolab.pulses import PulseSequence, PulseType
 from qibolab.qubits import Qubit
 from qibolab.sweeper import Parameter, Sweeper
 from qibolab.unrolling import Bounds
 
-from .abstract import Controller
-from .port import Port
 
 from .pulse import ZhPulse
 from .sweep import ProcessedSweeps, classify_sweepers
@@ -740,6 +738,3 @@ class Zurich(Controller):
                 results[serial] = results[qubit] = options.results_type(data)
 
         return results
-
-    def split_batches(self, sequences):
-        return batch_max_sequences(sequences, MAX_SEQUENCES)

--- a/src/qibolab/instruments/zhinst/executor.py
+++ b/src/qibolab/instruments/zhinst/executor.py
@@ -18,7 +18,6 @@ from qibolab.qubits import Qubit
 from qibolab.sweeper import Parameter, Sweeper
 from qibolab.unrolling import Bounds
 
-
 from .pulse import ZhPulse
 from .sweep import ProcessedSweeps, classify_sweepers
 from .util import (

--- a/src/qibolab/instruments/zhinst/executor.py
+++ b/src/qibolab/instruments/zhinst/executor.py
@@ -652,8 +652,9 @@ class Zurich(Controller):
         play_parameters = {}
         for p, zhs in pulse.zhsweepers:
             if p is Parameter.amplitude:
-                pulse.zhpulse.amplitude *= max(zhs.values)
-                zhs.values /= max(zhs.values)
+                max_value = max(np.abs(zhs.values))
+                pulse.zhpulse.amplitude *= max_value
+                zhs.values /= max_value
                 play_parameters["amplitude"] = zhs
             if p is Parameter.duration:
                 play_parameters["length"] = zhs

--- a/src/qibolab/instruments/zhinst/pulse.py
+++ b/src/qibolab/instruments/zhinst/pulse.py
@@ -1,0 +1,107 @@
+"""Wrapper for qibolab and laboneq pulses and sweeps."""
+
+from typing import Optional
+
+import laboneq.simple as lo
+import numpy as np
+from laboneq.dsl.experiment.pulse_library import (
+    sampled_pulse_complex,
+    sampled_pulse_real,
+)
+
+from qibolab.pulses import Pulse, PulseType
+from qibolab.sweeper import Parameter
+
+from .util import NANO_TO_SECONDS, SAMPLING_RATE
+
+
+def select_pulse(pulse: Pulse):
+    """Return laboneq pulse object corresponding to the given qibolab pulse."""
+    if "IIR" not in str(pulse.shape):
+        if str(pulse.shape) == "Rectangular()":
+            can_compress = pulse.type is not PulseType.READOUT
+            return lo.pulse_library.const(
+                length=round(pulse.duration * NANO_TO_SECONDS, 9),
+                amplitude=pulse.amplitude,
+                can_compress=can_compress,
+            )
+        if "Gaussian" in str(pulse.shape):
+            sigma = pulse.shape.rel_sigma
+            return lo.pulse_library.gaussian(
+                length=round(pulse.duration * NANO_TO_SECONDS, 9),
+                amplitude=pulse.amplitude,
+                sigma=2 / sigma,
+                zero_boundaries=False,
+            )
+
+        if "GaussianSquare" in str(pulse.shape):
+            sigma = pulse.shape.rel_sigma
+            width = pulse.shape.width
+            can_compress = pulse.type is not PulseType.READOUT
+            return lo.pulse_library.gaussian_square(
+                length=round(pulse.duration * NANO_TO_SECONDS, 9),
+                width=round(pulse.duration * NANO_TO_SECONDS, 9) * width,
+                amplitude=pulse.amplitude,
+                can_compress=can_compress,
+                sigma=2 / sigma,
+                zero_boundaries=False,
+            )
+
+        if "Drag" in str(pulse.shape):
+            sigma = pulse.shape.rel_sigma
+            beta = pulse.shape.beta
+            return lo.pulse_library.drag(
+                length=round(pulse.duration * NANO_TO_SECONDS, 9),
+                amplitude=pulse.amplitude,
+                sigma=2 / sigma,
+                beta=beta,
+                zero_boundaries=False,
+            )
+
+    if np.all(pulse.envelope_waveform_q(SAMPLING_RATE).data == 0):
+        return sampled_pulse_real(
+            samples=pulse.envelope_waveform_i(SAMPLING_RATE).data,
+            can_compress=True,
+        )
+    else:
+        return sampled_pulse_complex(
+            samples=pulse.envelope_waveform_i(SAMPLING_RATE).data
+            + (1j * pulse.envelope_waveform_q(SAMPLING_RATE).data),
+            can_compress=True,
+        )
+
+
+class ZhPulse:
+    """Wrapper data type that holds a qibolab pulse, the corresponding laboneq
+    pulse object, and any sweeps associated with this pulse."""
+
+    def __init__(self, pulse):
+        self.pulse: Pulse = pulse
+        """Qibolab pulse."""
+        self.zhpulse = select_pulse(pulse)
+        """Laboneq pulse."""
+        self.zhsweepers: list[tuple[Parameter, lo.SweepParameter]] = []
+        """Parameters to be swept, along with their laboneq sweep parameter
+        definitions."""
+        self.delay_sweeper: Optional[lo.SweepParameter] = None
+        """Laboneq sweep parameter if the delay of the pulse should be
+        swept."""
+
+    # pylint: disable=R0903
+    def add_sweeper(self, param: Parameter, sweeper: lo.SweepParameter):
+        """Add sweeper to list of sweepers associated with this pulse."""
+        if param in {
+            Parameter.amplitude,
+            Parameter.frequency,
+            Parameter.duration,
+            Parameter.relative_phase,
+        }:
+            self.zhsweepers.append((param, sweeper))
+        elif param is Parameter.start:
+            if self.delay_sweeper:
+                raise ValueError(
+                    "Cannot have multiple delay sweepers for a single pulse"
+                )
+            self.delay_sweeper = sweeper
+        else:
+            raise ValueError(f"Sweeping {param} is not supported")

--- a/src/qibolab/instruments/zhinst/sweep.py
+++ b/src/qibolab/instruments/zhinst/sweep.py
@@ -1,0 +1,139 @@
+"""Pre-execution processing of sweeps."""
+
+from collections.abc import Iterable
+from copy import copy
+
+import laboneq.simple as lo
+
+from qibolab.pulses import Pulse, PulseType
+from qibolab.qubits import Qubit
+from qibolab.sweeper import Parameter, Sweeper
+
+from .util import NANO_TO_SECONDS, measure_channel_name
+
+
+def classify_sweepers(
+    sweepers: Iterable[Sweeper],
+) -> tuple[list[Sweeper], list[Sweeper]]:
+    """Divide sweepers into two lists: 1. sweeps that can be done in the laboneq near-time sweep loop, 2. sweeps that
+    can be done in real-time (i.e. on hardware)"""
+    nt_sweepers, rt_sweepers = [], []
+    for sweeper in sweepers:
+        if (
+            sweeper.parameter is Parameter.amplitude
+            and sweeper.pulses[0].type is PulseType.READOUT
+        ):
+            nt_sweepers.append(sweeper)
+        elif sweeper.parameter is Parameter.bias:
+            nt_sweepers.append(sweeper)
+        else:
+            rt_sweepers.append(sweeper)
+    return nt_sweepers, rt_sweepers
+
+
+class ProcessedSweeps:
+    """Data type that centralizes and allows extracting information about given
+    sweeps."""
+
+    def __init__(self, sweepers: Iterable[Sweeper], qubits: dict[str, Qubit]):
+        pulse_sweeps = []
+        channel_sweeps = []
+        parallel_sweeps = []
+        for sweeper in sweepers:
+            for pulse in sweeper.pulses or []:
+                if sweeper.parameter in (Parameter.duration, Parameter.start):
+                    sweep_param = lo.SweepParameter(
+                        values=sweeper.values * NANO_TO_SECONDS
+                    )
+                    pulse_sweeps.append((pulse, sweeper.parameter, sweep_param))
+                elif sweeper.parameter is Parameter.frequency:
+                    ptype, qubit = pulse.type, qubits[pulse.qubit]
+                    if ptype is PulseType.READOUT:
+                        ch = measure_channel_name(qubit)
+                        intermediate_frequency = (
+                            qubit.readout_frequency
+                            - qubit.readout.local_oscillator.frequency
+                        )
+                    elif ptype is PulseType.DRIVE:
+                        ch = qubit.drive.name
+                        intermediate_frequency = (
+                            qubit.drive_frequency
+                            - qubit.drive.local_oscillator.frequency
+                        )
+                    else:
+                        raise ValueError(
+                            f"Cannot sweep frequency of pulse of type {ptype}, because it does not have associated frequency"
+                        )
+                    sweep_param = lo.SweepParameter(
+                        values=sweeper.values + intermediate_frequency
+                    )
+                    channel_sweeps.append((ch, sweeper.parameter, sweep_param))
+                elif (
+                    pulse.type is PulseType.READOUT
+                    and sweeper.parameter is Parameter.amplitude
+                ):
+                    sweep_param = lo.SweepParameter(
+                        values=sweeper.values / max(sweeper.values)
+                    )
+                    channel_sweeps.append(
+                        (
+                            measure_channel_name(qubits[pulse.qubit]),
+                            sweeper.parameter,
+                            sweep_param,
+                        )
+                    )
+                else:
+                    sweep_param = lo.SweepParameter(values=copy(sweeper.values))
+                    pulse_sweeps.append((pulse, sweeper.parameter, sweep_param))
+                parallel_sweeps.append((sweeper, sweep_param))
+
+            for qubit in sweeper.qubits or []:
+                if sweeper.parameter is not Parameter.bias:
+                    raise ValueError(
+                        f"Sweeping {sweeper.parameter.name} for {qubit} is not supported"
+                    )
+                sweep_param = lo.SweepParameter(
+                    values=sweeper.values + qubit.flux.offset
+                )
+                channel_sweeps.append((qubit.flux.name, sweeper.parameter, sweep_param))
+                parallel_sweeps.append((sweeper, sweep_param))
+
+            for coupler in sweeper.couplers or []:
+                if sweeper.parameter is not Parameter.bias:
+                    raise ValueError(
+                        f"Sweeping {sweeper.parameter.name} for {coupler} is not supported"
+                    )
+                sweep_param = lo.SweepParameter(
+                    values=sweeper.values + coupler.flux.offset
+                )
+                channel_sweeps.append(
+                    (coupler.flux.name, sweeper.parameter, sweep_param)
+                )
+                parallel_sweeps.append((sweeper, sweep_param))
+
+        self._pulse_sweeps = pulse_sweeps
+        self._channel_sweeps = channel_sweeps
+        self._parallel_sweeps = parallel_sweeps
+
+    def sweeps_for_pulse(
+        self, pulse: Pulse
+    ) -> list[tuple[Parameter, lo.SweepParameter]]:
+        return [item[1:] for item in self._pulse_sweeps if item[0] == pulse]
+
+    def sweeps_for_channel(self, ch: str) -> list[tuple[Parameter, lo.SweepParameter]]:
+        return [item[1:] for item in self._channel_sweeps if item[0] == ch]
+
+    def sweeps_for_sweeper(self, sweeper: Sweeper) -> list[lo.SweepParameter]:
+        return [item[1] for item in self._parallel_sweeps if item[0] == sweeper]
+
+    def channel_sweeps_for_sweeper(
+        self, sweeper: Sweeper
+    ) -> list[tuple[str, Parameter, lo.SweepParameter]]:
+        return [
+            item
+            for item in self._channel_sweeps
+            if item[2] in self.sweeps_for_sweeper(sweeper)
+        ]
+
+    def channels_with_sweeps(self) -> set[str]:
+        return {ch for ch, _, _ in self._channel_sweeps}

--- a/src/qibolab/instruments/zhinst/sweep.py
+++ b/src/qibolab/instruments/zhinst/sweep.py
@@ -19,10 +19,9 @@ def classify_sweepers(
     can be done in real-time (i.e. on hardware)"""
     nt_sweepers, rt_sweepers = [], []
     for sweeper in sweepers:
-        if (
-            sweeper.parameter is Parameter.bias or
-            (sweeper.parameter is Parameter.amplitude
-            and sweeper.pulses[0].type is PulseType.READOUT)
+        if sweeper.parameter is Parameter.bias or (
+            sweeper.parameter is Parameter.amplitude
+            and sweeper.pulses[0].type is PulseType.READOUT
         ):
             nt_sweepers.append(sweeper)
         else:

--- a/src/qibolab/instruments/zhinst/sweep.py
+++ b/src/qibolab/instruments/zhinst/sweep.py
@@ -95,6 +95,11 @@ class ProcessedSweeps:
                     sweep_param = lo.SweepParameter(
                         values=sweeper.values / max(sweeper.values)
                     )
+                    # FIXME: this implicitly relies on the fact that pulse is the same python object as appears in the
+                    # sequence that is being executed, hence the mutation is propagated. This is bad programming and
+                    # should be fixed once things become simpler
+                    pulse.amplitude *= max(sweeper.values)
+
                     channel_sweeps.append(
                         (
                             measure_channel_name(qubits[pulse.qubit]),

--- a/src/qibolab/instruments/zhinst/sweep.py
+++ b/src/qibolab/instruments/zhinst/sweep.py
@@ -31,7 +31,29 @@ def classify_sweepers(
 
 class ProcessedSweeps:
     """Data type that centralizes and allows extracting information about given
-    sweeps."""
+    sweeps.
+
+    In laboneq, sweeps are represented with the help of SweepParameter
+    instances. When adding pulses to a laboneq experiment, some
+    properties can be set to be an instance of SweepParameter instead of
+    a fixed numeric value. In case of channel property sweeps, either
+    the relevant calibration property or the instrument node directly
+    can be set ot a SweepParameter instance. Parts of the laboneq
+    experiment that define the sweep loops refer to SweepParameter
+    instances as well. These should be linkable to instances that are
+    either set to a pulse property, a channel calibration or instrument
+    node. To achieve this, we use the exact same SweepParameter instance
+    in both places. This class takes care of creating these
+    SweepParameter instances and giving access to them in a consistent
+    way (i.e. whenever they need to be the same instance they will be
+    the same instance). When constructing sweep loops you may ask from
+    this class to provide all the SweepParameter instances related to a
+    given qibolab Sweeper (parallel sweeps). Later, when adding pulses
+    or setting channel properties, you may ask from this class to
+    provide all SweepParameter instances related to a given pulse or
+    channel, and you will get parameters that are linkable to the ones
+    in the sweep loop definition
+    """
 
     def __init__(self, sweepers: Iterable[Sweeper], qubits: dict[str, Qubit]):
         pulse_sweeps = []

--- a/src/qibolab/instruments/zhinst/sweep.py
+++ b/src/qibolab/instruments/zhinst/sweep.py
@@ -20,11 +20,10 @@ def classify_sweepers(
     nt_sweepers, rt_sweepers = [], []
     for sweeper in sweepers:
         if (
-            sweeper.parameter is Parameter.amplitude
-            and sweeper.pulses[0].type is PulseType.READOUT
+            sweeper.parameter is Parameter.bias or
+            (sweeper.parameter is Parameter.amplitude
+            and sweeper.pulses[0].type is PulseType.READOUT)
         ):
-            nt_sweepers.append(sweeper)
-        elif sweeper.parameter is Parameter.bias:
             nt_sweepers.append(sweeper)
         else:
             rt_sweepers.append(sweeper)

--- a/src/qibolab/instruments/zhinst/sweep.py
+++ b/src/qibolab/instruments/zhinst/sweep.py
@@ -4,6 +4,7 @@ from collections.abc import Iterable
 from copy import copy
 
 import laboneq.simple as lo
+import numpy as np
 
 from qibolab.pulses import Pulse, PulseType
 from qibolab.qubits import Qubit
@@ -92,13 +93,12 @@ class ProcessedSweeps:
                     pulse.type is PulseType.READOUT
                     and sweeper.parameter is Parameter.amplitude
                 ):
-                    sweep_param = lo.SweepParameter(
-                        values=sweeper.values / max(sweeper.values)
-                    )
+                    max_value = max(np.abs(sweeper.values))
+                    sweep_param = lo.SweepParameter(values=sweeper.values / max_value)
                     # FIXME: this implicitly relies on the fact that pulse is the same python object as appears in the
                     # sequence that is being executed, hence the mutation is propagated. This is bad programming and
                     # should be fixed once things become simpler
-                    pulse.amplitude *= max(sweeper.values)
+                    pulse.amplitude *= max_value
 
                     channel_sweeps.append(
                         (

--- a/src/qibolab/instruments/zhinst/util.py
+++ b/src/qibolab/instruments/zhinst/util.py
@@ -1,0 +1,24 @@
+"""Utility methods."""
+
+from qibolab.qubits import Qubit
+
+SAMPLING_RATE = 2
+NANO_TO_SECONDS = 1e-9
+
+
+def measure_channel_name(qubit: Qubit) -> str:
+    """Construct and return a name for qubit's measure channel.
+
+    FIXME: We cannot use channel name directly, because currently channels are named after wires, and due to multiplexed readout
+    multiple qubits have the same channel name for their readout. Should be fixed once channels are refactored.
+    """
+    return f"{qubit.readout.name}_{qubit.name}"
+
+
+def acquire_channel_name(qubit: Qubit) -> str:
+    """Construct and return a name for qubit's acquire channel.
+
+    FIXME: We cannot use acquire channel name, because qibolab does not have a concept of acquire channel. This function shall be removed
+    once all channel refactoring is done.
+    """
+    return f"acquire{qubit.name}"

--- a/tests/dummy_qrc/zurich/platform.py
+++ b/tests/dummy_qrc/zurich/platform.py
@@ -86,7 +86,6 @@ def create(path: pathlib.Path = FOLDER):
     controller = Zurich(
         "EL_ZURO",
         device_setup=device_setup,
-        use_emulation=False,
         time_of_flight=75,
         smearing=50,
     )

--- a/tests/test_instruments_zhinst.py
+++ b/tests/test_instruments_zhinst.py
@@ -489,12 +489,19 @@ def test_sweep_and_play_sim(dummy_qrc):
         nshots=12,
     )
 
+    # check play
     IQM5q.session = lo.Session(IQM5q.device_setup)
     IQM5q.session.connect(do_emulation=True)
     res = IQM5q.play(qubits, couplers, sequence, options)
     assert res is not None
     assert all(qubit in res for qubit in qubits)
 
+    # check sweep with empty list of sweeps
+    res = IQM5q.sweep(qubits, couplers, sequence, options)
+    assert res is not None
+    assert all(qubit in res for qubit in qubits)
+
+    # check sweep with sweeps
     sweep_1 = Sweeper(Parameter.start, np.array([1, 2, 3, 4]), list(qf_pulses.values()))
     sweep_2 = Sweeper(Parameter.bias, np.array([1, 2, 3]), qubits=[qubits[0]])
     res = IQM5q.sweep(qubits, couplers, sequence, options, sweep_1, sweep_2)

--- a/tests/test_instruments_zhinst.py
+++ b/tests/test_instruments_zhinst.py
@@ -1,11 +1,20 @@
 import math
-import re
+from collections import defaultdict
 
+import laboneq.dsl.experiment.pulse as laboneq_pulse
+import laboneq.simple as lo
 import numpy as np
 import pytest
 
 from qibolab import AcquisitionType, AveragingMode, ExecutionParameters, create_platform
-from qibolab.instruments.zhinst import ZhPulse, ZhSweeperLine, Zurich
+from qibolab.instruments.zhinst import (
+    ProcessedSweeps,
+    ZhPulse,
+    Zurich,
+    acquire_channel_name,
+    classify_sweepers,
+    measure_channel_name,
+)
 from qibolab.pulses import (
     IIR,
     SNZ,
@@ -15,31 +24,25 @@ from qibolab.pulses import (
     Gaussian,
     Pulse,
     PulseSequence,
+    PulseType,
     ReadoutPulse,
     Rectangular,
 )
-from qibolab.sweeper import Parameter, Sweeper, SweeperType
+from qibolab.sweeper import Parameter, Sweeper
 from qibolab.unrolling import batch
 
 from .conftest import get_instrument
 
 
 @pytest.mark.parametrize(
-    "shape", ["Rectangular", "Gaussian", "GaussianSquare", "Drag", "SNZ", "IIR"]
-)
-def test_zhpulse(shape):
-    if shape == "Rectangular":
-        pulse = Pulse(0, 40, 0.05, int(3e9), 0.0, Rectangular(), "ch0", qubit=0)
-    if shape == "Gaussian":
-        pulse = Pulse(0, 40, 0.05, int(3e9), 0.0, Gaussian(5), "ch0", qubit=0)
-    if shape == "GaussianSquare":
-        pulse = Pulse(0, 40, 0.05, int(3e9), 0.0, Gaussian(5), "ch0", qubit=0)
-    if shape == "Drag":
-        pulse = Pulse(0, 40, 0.05, int(3e9), 0.0, Drag(5, 0.4), "ch0", qubit=0)
-    if shape == "SNZ":
-        pulse = Pulse(0, 40, 0.05, int(3e9), 0.0, SNZ(10, 0.01), "ch0", qubit=0)
-    if shape == "IIR":
-        pulse = Pulse(
+    "pulse",
+    [
+        Pulse(0, 40, 0.05, int(3e9), 0.0, Rectangular(), "ch0", qubit=0),
+        Pulse(0, 40, 0.05, int(3e9), 0.0, Gaussian(5), "ch0", qubit=0),
+        Pulse(0, 40, 0.05, int(3e9), 0.0, Gaussian(5), "ch0", qubit=0),
+        Pulse(0, 40, 0.05, int(3e9), 0.0, Drag(5, 0.4), "ch0", qubit=0),
+        Pulse(0, 40, 0.05, int(3e9), 0.0, SNZ(10, 0.01), "ch0", qubit=0),
+        Pulse(
             0,
             40,
             0.05,
@@ -48,39 +51,198 @@ def test_zhpulse(shape):
             IIR([10, 1], [0.4, 1], target=Gaussian(5)),
             "ch0",
             qubit=0,
-        )
-
-    zhpulse = ZhPulse(pulse)
-    assert zhpulse.pulse.serial == pulse.serial
-    if shape == "SNZ" or shape == "IIR":
-        assert len(zhpulse.zhpulse.samples) == 80
+        ),
+    ],
+)
+def test_zhpulse_pulse_conversion(pulse):
+    shape = pulse.shape
+    zhpulse = ZhPulse(pulse).zhpulse
+    assert isinstance(zhpulse, laboneq_pulse.Pulse)
+    if isinstance(shape, (SNZ, IIR)):
+        assert len(zhpulse.samples) == 80
     else:
-        assert zhpulse.zhpulse.length == 40e-9
+        assert zhpulse.length == 40e-9
 
 
-@pytest.mark.parametrize("parameter", [Parameter.bias, Parameter.start])
-def test_select_sweeper(dummy_qrc, parameter):
-    swept_points = 5
+def test_zhpulse_add_sweeper():
+    pulse = Pulse(0, 40, 0.05, int(3e9), 0.0, Gaussian(5), "ch", qubit=0)
+    zhpulse = ZhPulse(pulse)
+    assert zhpulse.zhsweepers == []
+    assert zhpulse.delay_sweeper is None
+
+    zhpulse.add_sweeper(
+        Parameter.duration, lo.SweepParameter(values=np.array([1, 2, 3]))
+    )
+    assert len(zhpulse.zhsweepers) == 1
+    assert zhpulse.delay_sweeper is None
+
+    zhpulse.add_sweeper(
+        Parameter.start, lo.SweepParameter(values=np.array([4, 5, 6, 7]))
+    )
+    assert len(zhpulse.zhsweepers) == 1
+    assert zhpulse.delay_sweeper is not None
+
+    zhpulse.add_sweeper(
+        Parameter.amplitude, lo.SweepParameter(values=np.array([3, 2, 1, 0]))
+    )
+    assert len(zhpulse.zhsweepers) == 2
+    assert zhpulse.delay_sweeper is not None
+
+
+def test_measure_channel_name(dummy_qrc):
     platform = create_platform("zurich")
-    qubits = {0: platform.qubits[0]}
-    sequence = PulseSequence()
-    ro_pulses = {}
-    qd_pulses = {}
-    for qubit in qubits.values():
-        q = qubit.name
-        qd_pulses[q] = platform.create_RX_pulse(q, start=0)
-        sequence.add(qd_pulses[q])
-        ro_pulses[q] = platform.create_qubit_readout_pulse(q, start=qd_pulses[q].finish)
-        sequence.add(ro_pulses[q])
+    qubits = platform.qubits.values()
+    meas_ch_names = {measure_channel_name(q) for q in qubits}
+    assert len(qubits) > 0
+    assert len(meas_ch_names) == len(qubits)
 
-        parameter_range = np.random.randint(swept_points, size=swept_points)
-        if parameter is Parameter.start:
-            sweeper = Sweeper(parameter, parameter_range, pulses=[qd_pulses[q]])
-        if parameter is Parameter.bias:
-            sweeper = Sweeper(parameter, parameter_range, qubits=q)
 
-        ZhSweeper = ZhSweeperLine(sweeper, qubit, sequence)
-        assert ZhSweeper.sweeper == sweeper
+def test_acquire_channel_name(dummy_qrc):
+    platform = create_platform("zurich")
+    qubits = platform.qubits.values()
+    acq_ch_names = {acquire_channel_name(q) for q in qubits}
+    assert len(qubits) > 0
+    assert len(acq_ch_names) == len(qubits)
+
+
+def test_classify_sweepers(dummy_qrc):
+    platform = create_platform("zurich")
+    qubit_id, qubit = 0, platform.qubits[0]
+    pulse_1 = Pulse(0, 40, 0.05, int(3e9), 0.0, Gaussian(5), "ch0", qubit=qubit_id)
+    pulse_2 = Pulse(
+        0,
+        40,
+        0.05,
+        int(3e9),
+        0.0,
+        Rectangular(),
+        "ch7",
+        PulseType.READOUT,
+        qubit=qubit_id,
+    )
+    amplitude_sweeper = Sweeper(Parameter.amplitude, np.array([1, 2, 3]), [pulse_1])
+    readout_amplitude_sweeper = Sweeper(
+        Parameter.amplitude, np.array([1, 2, 3, 4, 5]), [pulse_2]
+    )
+    freq_sweeper = Sweeper(Parameter.frequency, np.array([4, 5, 6, 7]), [pulse_1])
+    bias_sweeper = Sweeper(Parameter.bias, np.array([3, 2, 1]), qubits=[qubit])
+    nt_sweeps, rt_sweeps = classify_sweepers(
+        [amplitude_sweeper, readout_amplitude_sweeper, bias_sweeper, freq_sweeper]
+    )
+
+    assert amplitude_sweeper in rt_sweeps
+    assert freq_sweeper in rt_sweeps
+    assert bias_sweeper in nt_sweeps
+    assert readout_amplitude_sweeper in nt_sweeps
+
+
+def test_processed_sweeps_pulse_properties(dummy_qrc):
+    platform = create_platform("zurich")
+    qubit_id_1, qubit_1 = 0, platform.qubits[0]
+    qubit_id_2, qubit_2 = 3, platform.qubits[3]
+    pulse_1 = Pulse(
+        0, 40, 0.05, int(3e9), 0.0, Gaussian(5), qubit_1.drive.name, qubit=qubit_id_1
+    )
+    pulse_2 = Pulse(
+        0, 40, 0.05, int(3e9), 0.0, Gaussian(5), qubit_2.drive.name, qubit=qubit_id_2
+    )
+    sweeper_amplitude = Sweeper(
+        Parameter.amplitude, np.array([1, 2, 3]), [pulse_1, pulse_2]
+    )
+    sweeper_duration = Sweeper(Parameter.duration, np.array([1, 2, 3, 4]), [pulse_2])
+    processed_sweeps = ProcessedSweeps(
+        [sweeper_duration, sweeper_amplitude], qubits=platform.qubits
+    )
+
+    assert len(processed_sweeps.sweeps_for_pulse(pulse_1)) == 1
+    assert processed_sweeps.sweeps_for_pulse(pulse_1)[0][0] == Parameter.amplitude
+    assert isinstance(
+        processed_sweeps.sweeps_for_pulse(pulse_1)[0][1], lo.SweepParameter
+    )
+    assert len(processed_sweeps.sweeps_for_pulse(pulse_2)) == 2
+
+    assert len(processed_sweeps.sweeps_for_sweeper(sweeper_amplitude)) == 2
+    parallel_sweep_ids = {
+        s.uid for s in processed_sweeps.sweeps_for_sweeper(sweeper_amplitude)
+    }
+    assert len(parallel_sweep_ids) == 2
+    assert processed_sweeps.sweeps_for_pulse(pulse_1)[0][1].uid in parallel_sweep_ids
+    assert any(
+        s.uid in parallel_sweep_ids
+        for _, s in processed_sweeps.sweeps_for_pulse(pulse_2)
+    )
+
+    assert len(processed_sweeps.sweeps_for_sweeper(sweeper_duration)) == 1
+    pulse_2_sweep_ids = {s.uid for _, s in processed_sweeps.sweeps_for_pulse(pulse_2)}
+    assert len(pulse_2_sweep_ids) == 2
+    assert (
+        processed_sweeps.sweeps_for_sweeper(sweeper_duration)[0].uid
+        in pulse_2_sweep_ids
+    )
+
+    assert processed_sweeps.channels_with_sweeps() == set()
+
+
+def test_processed_sweeps_frequency(dummy_qrc):
+    platform = create_platform("zurich")
+    qubit_id, qubit = 1, platform.qubits[1]
+    pulse = Pulse(
+        0, 40, 0.05, int(3e9), 0.0, Gaussian(5), qubit.drive.name, qubit=qubit_id
+    )
+    freq_sweeper = Sweeper(Parameter.frequency, np.array([1, 2, 3]), [pulse])
+    processed_sweeps = ProcessedSweeps([freq_sweeper], platform.qubits)
+
+    # Frequency sweepers should result into channel property sweeps
+    assert len(processed_sweeps.sweeps_for_pulse(pulse)) == 0
+    assert processed_sweeps.channels_with_sweeps() == {qubit.drive.name}
+    assert len(processed_sweeps.sweeps_for_channel(qubit.drive.name)) == 1
+
+    with pytest.raises(ValueError):
+        flux_pulse = Pulse(
+            0,
+            40,
+            0.05,
+            int(3e9),
+            0.0,
+            Gaussian(5),
+            qubit.flux.name,
+            PulseType.FLUX,
+            qubit=qubit_id,
+        )
+        freq_sweeper = Sweeper(
+            Parameter.frequency, np.array([1, 3, 5, 7]), [flux_pulse]
+        )
+        ProcessedSweeps([freq_sweeper], platform.qubits)
+
+
+def test_processed_sweeps_readout_amplitude(dummy_qrc):
+    platform = create_platform("zurich")
+    qubit_id, qubit = 0, platform.qubits[0]
+    readout_ch = measure_channel_name(qubit)
+    pulse_readout = Pulse(
+        0,
+        40,
+        0.05,
+        int(3e9),
+        0.0,
+        Rectangular(),
+        readout_ch,
+        PulseType.READOUT,
+        qubit_id,
+    )
+    readout_amplitude_sweeper = Sweeper(
+        Parameter.amplitude, np.array([1, 2, 3, 4]), [pulse_readout]
+    )
+    processed_sweeps = ProcessedSweeps(
+        [readout_amplitude_sweeper], qubits=platform.qubits
+    )
+
+    # Readout amplitude should result into channel property (gain) sweep
+    assert len(processed_sweeps.sweeps_for_pulse(pulse_readout)) == 0
+    assert processed_sweeps.channels_with_sweeps() == {
+        readout_ch,
+    }
+    assert len(processed_sweeps.sweeps_for_channel(readout_ch)) == 1
 
 
 def test_zhinst_setup(dummy_qrc):
@@ -90,110 +252,84 @@ def test_zhinst_setup(dummy_qrc):
 
 
 def test_zhsequence(dummy_qrc):
-    qd_pulse = Pulse(0, 40, 0.05, int(3e9), 0.0, Rectangular(), "ch0", qubit=0)
-    ro_pulse = ReadoutPulse(0, 40, 0.05, int(3e9), 0.0, Rectangular(), "ch1", qubit=0)
-    sequence = PulseSequence()
-    sequence.add(qd_pulse)
-    sequence.add(ro_pulse)
     IQM5q = create_platform("zurich")
     controller = IQM5q.instruments["EL_ZURO"]
 
-    controller.sequence_zh(sequence, IQM5q.qubits, IQM5q.couplers)
-    zhsequence = controller.sequence
+    drive_channel, readout_channel = IQM5q.qubits[0].drive.name, measure_channel_name(
+        IQM5q.qubits[0]
+    )
+    qd_pulse = Pulse(0, 40, 0.05, int(3e9), 0.0, Rectangular(), drive_channel, qubit=0)
+    ro_pulse = ReadoutPulse(
+        0, 40, 0.05, int(3e9), 0.0, Rectangular(), readout_channel, qubit=0
+    )
+    sequence = PulseSequence()
+    sequence.add(qd_pulse)
+    sequence.add(qd_pulse)
+    sequence.add(ro_pulse)
 
-    with pytest.raises(AttributeError):
-        controller.sequence_zh("sequence", IQM5q.qubits, IQM5q.couplers)
-        zhsequence = controller.sequence
+    zhsequence = controller.sequence_zh(sequence, IQM5q.qubits)
 
     assert len(zhsequence) == 2
-    assert len(zhsequence["readout0"]) == 1
+    assert len(zhsequence[drive_channel]) == 2
+    assert len(zhsequence[readout_channel]) == 1
+
+    with pytest.raises(AttributeError):
+        controller.sequence_zh("sequence", IQM5q.qubits)
 
 
 def test_zhsequence_couplers(dummy_qrc):
-    qd_pulse = Pulse(0, 40, 0.05, int(3e9), 0.0, Rectangular(), "ch0", qubit=0)
-    ro_pulse = ReadoutPulse(0, 40, 0.05, int(3e9), 0.0, Rectangular(), "ch1", qubit=0)
-    qc_pulse = CouplerFluxPulse(0, 40, 0.05, Rectangular(), "ch_c0", qubit=3)
+    IQM5q = create_platform("zurich")
+    controller = IQM5q.instruments["EL_ZURO"]
+
+    drive_channel, readout_channel = IQM5q.qubits[0].drive.name, measure_channel_name(
+        IQM5q.qubits[0]
+    )
+    couplerflux_channel = IQM5q.couplers[0].flux.name
+    qd_pulse = Pulse(0, 40, 0.05, int(3e9), 0.0, Rectangular(), drive_channel, qubit=0)
+    ro_pulse = ReadoutPulse(
+        0, 40, 0.05, int(3e9), 0.0, Rectangular(), readout_channel, qubit=0
+    )
+    qc_pulse = CouplerFluxPulse(
+        0, 40, 0.05, Rectangular(), couplerflux_channel, qubit=3
+    )
     sequence = PulseSequence()
     sequence.add(qd_pulse)
     sequence.add(ro_pulse)
     sequence.add(qc_pulse)
-    IQM5q = create_platform("zurich")
-    controller = IQM5q.instruments["EL_ZURO"]
 
-    controller.sequence_zh(sequence, IQM5q.qubits, IQM5q.couplers)
-    zhsequence = controller.sequence
-
-    with pytest.raises(AttributeError):
-        controller.sequence_zh("sequence", IQM5q.qubits, IQM5q.couplers)
-        zhsequence = controller.sequence
+    zhsequence = controller.sequence_zh(sequence, IQM5q.qubits)
 
     assert len(zhsequence) == 3
-    assert len(zhsequence["readout0"]) == 1
-    assert len(zhsequence["couplerflux3"]) == 1
-
-
-def test_zhsequence_couplers_sweeper(dummy_qrc):
-    ro_pulse = ReadoutPulse(0, 40, 0.05, int(3e9), 0.0, Rectangular(), "ch1", qubit=0)
-    sequence = PulseSequence()
-    sequence.add(ro_pulse)
-    IQM5q = create_platform("zurich")
-    controller = IQM5q.instruments["EL_ZURO"]
-
-    delta_bias_range = np.arange(-1, 1, 0.5)
-
-    sweeper = Sweeper(
-        Parameter.amplitude,
-        delta_bias_range,
-        pulses=[
-            CouplerFluxPulse(
-                start=0,
-                duration=sequence.duration + sequence.start,
-                amplitude=1,
-                shape="Rectangular",
-                qubit=IQM5q.couplers[0].name,
-            )
-        ],
-        type=SweeperType.ABSOLUTE,
-    )
-
-    controller.sweepers = [sweeper]
-    controller.sequence_zh(sequence, IQM5q.qubits, IQM5q.couplers)
-    zhsequence = controller.sequence
-
-    with pytest.raises(AttributeError):
-        controller.sequence_zh("sequence", IQM5q.qubits, IQM5q.couplers)
-        zhsequence = controller.sequence
-
-    assert len(zhsequence) == 2
-    assert len(zhsequence["readout0"]) == 1
-    assert len(zhsequence["couplerflux0"]) == 0  # is it correct?
+    assert len(zhsequence[couplerflux_channel]) == 1
 
 
 def test_zhsequence_multiple_ro(dummy_qrc):
+    platform = create_platform("zurich")
+    readout_channel = measure_channel_name(platform.qubits[0])
     sequence = PulseSequence()
     qd_pulse = Pulse(0, 40, 0.05, int(3e9), 0.0, Rectangular(), "ch0", qubit=0)
     sequence.add(qd_pulse)
-    ro_pulse = ReadoutPulse(0, 40, 0.05, int(3e9), 0.0, Rectangular(), "ch1", qubit=0)
+    ro_pulse = ReadoutPulse(
+        0, 40, 0.05, int(3e9), 0.0, Rectangular(), readout_channel, qubit=0
+    )
     sequence.add(ro_pulse)
-    ro_pulse = ReadoutPulse(0, 5000, 0.05, int(3e9), 0.0, Rectangular(), "ch1", qubit=0)
+    ro_pulse = ReadoutPulse(
+        0, 5000, 0.05, int(3e9), 0.0, Rectangular(), readout_channel, qubit=0
+    )
     sequence.add(ro_pulse)
     platform = create_platform("zurich")
 
     controller = platform.instruments["EL_ZURO"]
-    controller.sequence_zh(sequence, platform.qubits, platform.couplers)
-    zhsequence = controller.sequence
-
-    with pytest.raises(AttributeError):
-        controller.sequence_zh("sequence", platform.qubits, platform.couplers)
-        zhsequence = controller.sequence
+    zhsequence = controller.sequence_zh(sequence, platform.qubits)
 
     assert len(zhsequence) == 2
-    assert len(zhsequence["readout0"]) == 2
+    assert len(zhsequence[readout_channel]) == 2
 
 
 def test_zhinst_register_readout_line(dummy_qrc):
     platform = create_platform("zurich")
     IQM5q = platform.instruments["EL_ZURO"]
+    qubit = platform.qubits[0]
 
     options = ExecutionParameters(
         relaxation_time=300e-6,
@@ -201,12 +337,10 @@ def test_zhinst_register_readout_line(dummy_qrc):
         averaging_mode=AveragingMode.CYCLIC,
     )
 
-    IQM5q.register_readout_line(
-        platform.qubits[0], intermediate_frequency=int(1e6), options=options
-    )
+    IQM5q.register_readout_line(qubit, intermediate_frequency=int(1e6), options=options)
 
-    assert "measure0" in IQM5q.signal_map
-    assert "acquire0" in IQM5q.signal_map
+    assert measure_channel_name(qubit) in IQM5q.signal_map
+    assert acquire_channel_name(qubit) in IQM5q.signal_map
     assert (
         "/logical_signal_groups/q0/measure_line" in IQM5q.calibration.calibration_items
     )
@@ -215,22 +349,24 @@ def test_zhinst_register_readout_line(dummy_qrc):
 def test_zhinst_register_drive_line(dummy_qrc):
     platform = create_platform("zurich")
     IQM5q = platform.instruments["EL_ZURO"]
-    IQM5q.register_drive_line(platform.qubits[0], intermediate_frequency=int(1e6))
+    qubit = platform.qubits[0]
+    IQM5q.register_drive_line(qubit, intermediate_frequency=int(1e6))
 
-    assert "drive0" in IQM5q.signal_map
+    assert qubit.drive.name in IQM5q.signal_map
     assert "/logical_signal_groups/q0/drive_line" in IQM5q.calibration.calibration_items
 
 
 def test_zhinst_register_flux_line(dummy_qrc):
     platform = create_platform("zurich")
     IQM5q = platform.instruments["EL_ZURO"]
-    IQM5q.register_flux_line(platform.qubits[0])
+    qubit = platform.qubits[0]
+    IQM5q.register_flux_line(qubit)
 
-    assert "flux0" in IQM5q.signal_map
+    assert qubit.flux.name in IQM5q.signal_map
     assert "/logical_signal_groups/q0/flux_line" in IQM5q.calibration.calibration_items
 
 
-def test_experiment_execute_pulse_sequence(dummy_qrc):
+def test_experiment_flow(dummy_qrc):
     platform = create_platform("zurich")
     IQM5q = platform.instruments["EL_ZURO"]
 
@@ -263,12 +399,12 @@ def test_experiment_execute_pulse_sequence(dummy_qrc):
 
     IQM5q.experiment_flow(qubits, couplers, sequence, options)
 
-    assert "flux0" in IQM5q.experiment.signals
-    assert "measure0" in IQM5q.experiment.signals
-    assert "acquire0" in IQM5q.experiment.signals
+    assert qubits[0].flux.name in IQM5q.experiment.signals
+    assert measure_channel_name(qubits[0]) in IQM5q.experiment.signals
+    assert acquire_channel_name(qubits[0]) in IQM5q.experiment.signals
 
 
-def test_experiment_execute_pulse_sequence_coupler(dummy_qrc):
+def test_experiment_flow_coupler(dummy_qrc):
     platform = create_platform("zurich")
     IQM5q = platform.instruments["EL_ZURO"]
 
@@ -315,89 +451,55 @@ def test_experiment_execute_pulse_sequence_coupler(dummy_qrc):
 
     IQM5q.experiment_flow(qubits, couplers, sequence, options)
 
-    assert "flux0" in IQM5q.experiment.signals
-    assert "measure0" in IQM5q.experiment.signals
-    assert "acquire0" in IQM5q.experiment.signals
+    assert qubits[0].flux.name in IQM5q.experiment.signals
+    assert measure_channel_name(qubits[0]) in IQM5q.experiment.signals
+    assert acquire_channel_name(qubits[0]) in IQM5q.experiment.signals
 
 
-def test_experiment_fast_reset_readout(dummy_qrc):
+def test_sweep_and_play_sim(dummy_qrc):
+    """Test end-to-end experiment run using ZI emulated connection."""
     platform = create_platform("zurich")
     IQM5q = platform.instruments["EL_ZURO"]
 
     sequence = PulseSequence()
-    qubits = {0: platform.qubits[0]}
+    qubits = {0: platform.qubits[0], 2: platform.qubits[2]}
+    platform.qubits = qubits
     couplers = {}
-    platform.qubits = qubits
 
     ro_pulses = {}
-    fr_pulses = {}
-    for qubit in qubits:
-        fr_pulses[qubit] = platform.create_RX_pulse(qubit, start=0)
-        ro_pulses[qubit] = platform.create_qubit_readout_pulse(qubit, start=0)
-        sequence.add(ro_pulses[qubit])
-
-    options = ExecutionParameters(
-        relaxation_time=300e-6,
-        fast_reset=fr_pulses,
-        acquisition_type=AcquisitionType.INTEGRATION,
-        averaging_mode=AveragingMode.CYCLIC,
-    )
-
-    IQM5q.experiment_flow(qubits, couplers, sequence, options)
-
-    assert "drive0" in IQM5q.experiment.signals
-    assert "measure0" in IQM5q.experiment.signals
-    assert "acquire0" in IQM5q.experiment.signals
-
-
-@pytest.mark.parametrize("fast_reset", [True, False])
-def test_experiment_execute_pulse_sequence(dummy_qrc, fast_reset):
-    platform = create_platform("zurich")
-    IQM5q = platform.instruments["EL_ZURO"]
-
-    sequence = PulseSequence()
-    qubits = {0: platform.qubits[0]}
-    platform.qubits = qubits
-
-    ro_pulses = {}
-    qd_pulses = {}
     qf_pulses = {}
-    fr_pulses = {}
-    for qubit in qubits:
-        if fast_reset:
-            fr_pulses[qubit] = platform.create_RX_pulse(qubit, start=0)
-        qd_pulses[qubit] = platform.create_RX_pulse(qubit, start=0)
-        sequence.add(qd_pulses[qubit])
-        ro_pulses[qubit] = platform.create_qubit_readout_pulse(
-            qubit, start=qd_pulses[qubit].finish
-        )
-        sequence.add(ro_pulses[qubit])
-        qf_pulses[qubit] = FluxPulse(
+    for qubit in qubits.values():
+        q = qubit.name
+        qf_pulses[q] = FluxPulse(
             start=0,
-            duration=ro_pulses[qubit].start,
+            duration=500,
             amplitude=1,
             shape=Rectangular(),
-            channel=platform.qubits[qubit].flux.name,
-            qubit=qubit,
+            channel=platform.qubits[q].flux.name,
+            qubit=q,
         )
-        sequence.add(qf_pulses[qubit])
-
-    if fast_reset:
-        fast_reset = fr_pulses
+        sequence.add(qf_pulses[q])
+        ro_pulses[q] = platform.create_qubit_readout_pulse(q, start=qf_pulses[q].finish)
+        sequence.add(ro_pulses[q])
 
     options = ExecutionParameters(
         relaxation_time=300e-6,
-        fast_reset=fast_reset,
         acquisition_type=AcquisitionType.INTEGRATION,
         averaging_mode=AveragingMode.CYCLIC,
+        nshots=12,
     )
 
-    IQM5q.experiment_flow(qubits, sequence, options)
+    IQM5q.session = lo.Session(IQM5q.device_setup)
+    IQM5q.session.connect(do_emulation=True)
+    res = IQM5q.play(qubits, couplers, sequence, options)
+    assert res is not None
+    assert all(qubit in res for qubit in qubits)
 
-    assert "drive0" in IQM5q.experiment.signals
-    assert "flux0" in IQM5q.experiment.signals
-    assert "measure0" in IQM5q.experiment.signals
-    assert "acquire0" in IQM5q.experiment.signals
+    sweep_1 = Sweeper(Parameter.start, np.array([1, 2, 3, 4]), list(qf_pulses.values()))
+    sweep_2 = Sweeper(Parameter.bias, np.array([1, 2, 3]), qubits=[qubits[0]])
+    res = IQM5q.sweep(qubits, couplers, sequence, options, sweep_1, sweep_2)
+    assert res is not None
+    assert all(qubit in res for qubit in qubits)
 
 
 @pytest.mark.parametrize("parameter1", [Parameter.start, Parameter.duration])
@@ -405,7 +507,6 @@ def test_experiment_sweep_single(dummy_qrc, parameter1):
     platform = create_platform("zurich")
     IQM5q = platform.instruments["EL_ZURO"]
 
-    sequence = PulseSequence()
     qubits = {0: platform.qubits[0]}
     couplers = {}
 
@@ -436,13 +537,11 @@ def test_experiment_sweep_single(dummy_qrc, parameter1):
         averaging_mode=AveragingMode.CYCLIC,
     )
 
-    IQM5q.sweepers = sweepers
-
     IQM5q.experiment_flow(qubits, couplers, sequence, options)
 
-    assert "drive0" in IQM5q.experiment.signals
-    assert "measure0" in IQM5q.experiment.signals
-    assert "acquire0" in IQM5q.experiment.signals
+    assert qubits[0].drive.name in IQM5q.experiment.signals
+    assert measure_channel_name(qubits[0]) in IQM5q.experiment.signals
+    assert acquire_channel_name(qubits[0]) in IQM5q.experiment.signals
 
 
 @pytest.mark.parametrize("parameter1", [Parameter.start, Parameter.duration])
@@ -450,7 +549,6 @@ def test_experiment_sweep_single_coupler(dummy_qrc, parameter1):
     platform = create_platform("zurich")
     IQM5q = platform.instruments["EL_ZURO"]
 
-    sequence = PulseSequence()
     qubits = {0: platform.qubits[0], 2: platform.qubits[2]}
     couplers = {0: platform.couplers[0]}
 
@@ -494,14 +592,12 @@ def test_experiment_sweep_single_coupler(dummy_qrc, parameter1):
         averaging_mode=AveragingMode.CYCLIC,
     )
 
-    IQM5q.sweepers = sweepers
-
     IQM5q.experiment_flow(qubits, couplers, sequence, options)
 
-    assert "couplerflux0" in IQM5q.experiment.signals
-    assert "drive0" in IQM5q.experiment.signals
-    assert "measure0" in IQM5q.experiment.signals
-    assert "acquire0" in IQM5q.experiment.signals
+    assert couplers[0].flux.name in IQM5q.experiment.signals
+    assert qubits[0].drive.name in IQM5q.experiment.signals
+    assert measure_channel_name(qubits[0]) in IQM5q.experiment.signals
+    assert acquire_channel_name(qubits[0]) in IQM5q.experiment.signals
 
 
 SweeperParameter = {
@@ -519,7 +615,6 @@ def test_experiment_sweep_2d_general(dummy_qrc, parameter1, parameter2):
     platform = create_platform("zurich")
     IQM5q = platform.instruments["EL_ZURO"]
 
-    sequence = PulseSequence()
     qubits = {0: platform.qubits[0]}
     couplers = {}
 
@@ -566,21 +661,17 @@ def test_experiment_sweep_2d_general(dummy_qrc, parameter1, parameter2):
         averaging_mode=AveragingMode.CYCLIC,
     )
 
-    IQM5q.sweepers = sweepers
-    rearranging_axes, sweepers = IQM5q.rearrange_sweepers(sweepers)
-    IQM5q.sweepers = sweepers  # to be changed
     IQM5q.experiment_flow(qubits, couplers, sequence, options)
 
-    assert "drive0" in IQM5q.experiment.signals
-    assert "measure0" in IQM5q.experiment.signals
-    assert "acquire0" in IQM5q.experiment.signals
+    assert qubits[0].drive.name in IQM5q.experiment.signals
+    assert measure_channel_name(qubits[0]) in IQM5q.experiment.signals
+    assert acquire_channel_name(qubits[0]) in IQM5q.experiment.signals
 
 
 def test_experiment_sweep_2d_specific(dummy_qrc):
     platform = create_platform("zurich")
     IQM5q = platform.instruments["EL_ZURO"]
 
-    sequence = PulseSequence()
     qubits = {0: platform.qubits[0]}
     couplers = {}
 
@@ -621,15 +712,11 @@ def test_experiment_sweep_2d_specific(dummy_qrc):
         averaging_mode=AveragingMode.CYCLIC,
     )
 
-    IQM5q.sweepers = sweepers
-    rearranging_axes, sweepers = IQM5q.rearrange_sweepers(sweepers)
-    IQM5q.sweepers = sweepers  # to be changed
     IQM5q.experiment_flow(qubits, couplers, sequence, options)
 
-    assert "drive0" in IQM5q.experiment.signals
-    assert "measure0" in IQM5q.experiment.signals
-    assert "acquire0" in IQM5q.experiment.signals
-    assert rearranging_axes != [[], []]
+    assert qubits[0].drive.name in IQM5q.experiment.signals
+    assert measure_channel_name(qubits[0]) in IQM5q.experiment.signals
+    assert acquire_channel_name(qubits[0]) in IQM5q.experiment.signals
 
 
 @pytest.mark.parametrize(
@@ -639,7 +726,6 @@ def test_experiment_sweep_punchouts(dummy_qrc, parameter):
     platform = create_platform("zurich")
     IQM5q = platform.instruments["EL_ZURO"]
 
-    sequence = PulseSequence()
     qubits = {0: platform.qubits[0]}
     couplers = {}
 
@@ -687,41 +773,10 @@ def test_experiment_sweep_punchouts(dummy_qrc, parameter):
         averaging_mode=AveragingMode.CYCLIC,
     )
 
-    IQM5q.sweepers = sweepers
-    rearranging_axes, sweepers = IQM5q.rearrange_sweepers(sweepers)
-    IQM5q.sweepers = sweepers  # to be changed
     IQM5q.experiment_flow(qubits, couplers, sequence, options)
 
-    assert "measure0" in IQM5q.experiment.signals
-    assert "acquire0" in IQM5q.experiment.signals
-
-
-# TODO: Fix this
-def test_sim(dummy_qrc):
-    platform = create_platform("zurich")
-    IQM5q = platform.instruments["EL_ZURO"]
-    sequence = PulseSequence()
-    qubits = {0: platform.qubits[0]}
-    platform.qubits = qubits
-    ro_pulses = {}
-    qd_pulses = {}
-    qf_pulses = {}
-    for qubit in qubits:
-        qd_pulses[qubit] = platform.create_RX_pulse(qubit, start=0)
-        sequence.add(qd_pulses[qubit])
-        ro_pulses[qubit] = platform.create_qubit_readout_pulse(
-            qubit, start=qd_pulses[qubit].finish
-        )
-        sequence.add(ro_pulses[qubit])
-        qf_pulses[qubit] = FluxPulse(
-            start=0,
-            duration=500,
-            amplitude=1,
-            shape=Rectangular(),
-            channel=platform.qubits[qubit].flux.name,
-            qubit=qubit,
-        )
-        sequence.add(qf_pulses[qubit])
+    assert measure_channel_name(qubits[0]) in IQM5q.experiment.signals
+    assert acquire_channel_name(qubits[0]) in IQM5q.experiment.signals
 
 
 def test_batching(dummy_qrc):
@@ -756,7 +811,7 @@ def test_connections(instrument):
 
 
 @pytest.mark.qpu
-def test_experiment_execute_pulse_sequence(connected_platform, instrument):
+def test_experiment_execute_pulse_sequence_qpu(connected_platform, instrument):
     platform = connected_platform
     sequence = PulseSequence()
     qubits = {0: platform.qubits[0], "c0": platform.qubits["c0"]}
@@ -795,9 +850,8 @@ def test_experiment_execute_pulse_sequence(connected_platform, instrument):
 
 
 @pytest.mark.qpu
-def test_experiment_sweep_2d_specific(connected_platform, instrument):
+def test_experiment_sweep_2d_specific_qpu(connected_platform, instrument):
     platform = connected_platform
-    sequence = PulseSequence()
     qubits = {0: platform.qubits[0]}
 
     swept_points = 5
@@ -849,25 +903,22 @@ def test_experiment_sweep_2d_specific(connected_platform, instrument):
 
 def get_previous_subsequence_finish(instrument, name):
     """Look recursively for sub_section finish times."""
-    signal_name = re.sub("sequence_", "", name)
-    signal_name = re.sub(r"_\d+$", "", signal_name)
-    signal_name = re.sub(r"flux", "bias", signal_name)
-    finish = 0
-    for section in instrument.experiment.sections[0].children:
-        if section.uid == name:
-            for pulse in section.children:
-                if pulse.signal == signal_name:
-                    try:
-                        finish += pulse.time
-                    except AttributeError:
-                        # not a laboneq Delay class object, skipping
-                        pass
-                    try:
-                        finish += pulse.pulse.length
-                    except AttributeError:
-                        # not a laboneq PlayPulse class object, skipping
-                        pass
-    return finish
+    section = next(
+        iter(ch for ch in instrument.experiment.sections[0].children if ch.uid == name)
+    )
+    finish = defaultdict(int)
+    for pulse in section.children:
+        try:
+            finish[pulse.signal] += pulse.time
+        except AttributeError:
+            # not a laboneq Delay class object, skipping
+            pass
+        try:
+            finish[pulse.signal] += pulse.pulse.length
+        except AttributeError:
+            # not a laboneq PlayPulse class object, skipping
+            pass
+    return max(finish.values())
 
 
 def test_experiment_measurement_sequence(dummy_qrc):
@@ -902,11 +953,11 @@ def test_experiment_measurement_sequence(dummy_qrc):
     IQM5q.experiment_flow(qubits, couplers, sequence, options)
     measure_start = 0
     for section in IQM5q.experiment.sections[0].children:
-        if section.uid == "sequence_measure_0":
+        if section.uid == "measure_0":
             measure_start += get_previous_subsequence_finish(IQM5q, section.play_after)
             for pulse in section.children:
                 try:
-                    if pulse.signal == "measure0":
+                    if pulse.signal == measure_channel_name(qubits[0]):
                         measure_start += pulse.time
                 except AttributeError:
                     # not a laboneq delay class object, skipping


### PR DESCRIPTION
The ZI driver code is unnecessarily complicated and entangled, which makes it very fragile, hard to read and change, easy to introduce bugs. This PR is an attempt to untangle and simplify the code.

What is changed:

- Most of the logic related to analyzing sweeps and deciding how to handle them is extracted into the `ProcessedSweeps` class, and the `classify_sweepers` function. This removes a lot of repetitive code scattered throughout the driver code, plus makes code more linear and easy to follow.
- The functionality of the classes `ZhPulse`, `ZhSweeper`, and `ZhSweeperLine` are combined into one. That lucky one is the `ZhPulse`. The other two are removed.
- Splitting a sequence into subsequences is unified in one place. Previously, for each experiment signal the splitting would happen separately, which gave rise to a lot of code duplication, and need to have functions like `find_subsequence_finish`, and weird phenomena like `self.sequence[f"readout{q}"]` returning non empty list of measurements when `q` is a coupler. Now all signal lines are split together and they are represented together with the measurements responsible for split via the newly introduced `SubSequence` class.
- For laboneq logical signal names the names of channels are used (with some caveats related to measurement and acquire channels) directly, instead of inventing yet another set of names.
- The need to access `Qubit` and `Coupler` object throughout the driver code is greatly reduced. This moves the driver towards a direction where it is easier to implement upcoming plans for logical channels.
- Methods `play_sweep_select_single` and `play_sweep_select_dual` are unified into the method `play_sweep` and generalized - in principle the driver should be able to handle any number of sweeps, not only 1 and 2.
- Removed the `fast_reset` functionality. Such functionality does not belong to the driver, and should be handled either in higher levels of qibolab, or even outside of it. I believe there is no known user of that functionality for now, hence I thought I could afford removing it for now and then later reintroducing it properly.
- A lot of redundant instance variables are removed.
- Some outdated code is removed.
- Minor esthetic changes here and there

Bugfixes:
- Fixed sweeper rearrangement not working for experiment with more than 1 qubits.
- Fixed readout pulse amplitude not being scaled up after the sweeper values are normalized.

There are still some things that could be polished, however I tried avoiding to touch everything as much as possible. The structure of the code is largely still the same. The goal was to rewrite the minimum possible as an intermediate step towards the upcoming introduction of logical channels in qibolab. Now it should be easier to adapt to those new concepts.

TODO: still need to fix the tests

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
