### PR TITLE
Modify qrm_rf driver so that qrm_rf modules can be used as qcm_rf to generate drive pulses.

### DIFF
--- a/src/qibolab/instruments/qblox/cluster_qrm_rf.py
+++ b/src/qibolab/instruments/qblox/cluster_qrm_rf.py
@@ -623,7 +623,7 @@ class QrmRf(ClusterModule):
                 # Add scope_acquisition to default sequencer
                 if (
                     sequencer.number == self.DEFAULT_SEQUENCERS[port]
-                    and not pulse == None
+                    and pulse is not None
                 ):
                     sequencer.acquisitions["scope_acquisition"] = {
                         "num_bins": 1,

--- a/src/qibolab/instruments/qblox/cluster_qrm_rf.py
+++ b/src/qibolab/instruments/qblox/cluster_qrm_rf.py
@@ -613,6 +613,7 @@ class QrmRf(ClusterModule):
                     }
 
                 # Acquisitions
+                pulse = None
                 for acquisition_index, pulse in enumerate(sequencer.pulses.ro_pulses):
                     sequencer.acquisitions[pulse.serial] = {
                         "num_bins": num_bins,
@@ -620,7 +621,10 @@ class QrmRf(ClusterModule):
                     }
 
                 # Add scope_acquisition to default sequencer
-                if sequencer.number == self.DEFAULT_SEQUENCERS[port]:
+                if (
+                    sequencer.number == self.DEFAULT_SEQUENCERS[port]
+                    and not pulse == None
+                ):
                     sequencer.acquisitions["scope_acquisition"] = {
                         "num_bins": 1,
                         "index": acquisition_index + 1,


### PR DESCRIPTION
The driver of the qrm_rf is modified so that if the qrm_rf does not receive any readout pulses, it does not trigger any acquisitions, allowing the use of the module for drive only.

The cluster connected to tii1q_d28 has 2 qrm_rf modules, due to the lack of acm_rf modules.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
