### PR TITLE
Fix imports in 'slightly more complex circuit'

### DIFF
--- a/doc/source/tutorials/circuits.rst
+++ b/doc/source/tutorials/circuits.rst
@@ -71,6 +71,7 @@ results:
 
     import matplotlib.pyplot as plt
     import numpy as np
+    import qibo
     from qibo import Circuit, gates
 
 


### PR DESCRIPTION
In this example `qibo` is accessed directly in

```
# execute on quantum hardware
qibo.set_backend("qibolab", "dummy")
```

therefore an import of `qibo` is needed.


Checklist:
- [x] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
