### PR TITLE
Add rule for GPI gate

### DIFF
--- a/src/qibolab/compilers/compiler.py
+++ b/src/qibolab/compilers/compiler.py
@@ -8,6 +8,7 @@ from qibolab.compilers.default import (
     cnot_rule,
     cz_rule,
     gpi2_rule,
+    gpi_rule,
     identity_rule,
     measurement_rule,
     rz_rule,
@@ -52,6 +53,7 @@ class Compiler:
                 gates.CZ: cz_rule,
                 gates.CNOT: cnot_rule,
                 gates.GPI2: gpi2_rule,
+                gates.GPI: gpi_rule,
                 gates.M: measurement_rule,
             }
         )

--- a/src/qibolab/compilers/default.py
+++ b/src/qibolab/compilers/default.py
@@ -40,6 +40,10 @@ def gpi_rule(gate, platform):
     qubit = gate.target_qubits[0]
     theta = gate.parameters[0]
     sequence = PulseSequence()
+    # the following definition has a global phase difference compare to
+    # to the matrix representation. See
+    # https://github.com/qiboteam/qibolab/pull/804#pullrequestreview-1890205509
+    # for more detail.
     pulse = platform.create_RX_pulse(qubit, start=0, relative_phase=theta)
     sequence.add(pulse)
     return sequence, {}

--- a/src/qibolab/compilers/default.py
+++ b/src/qibolab/compilers/default.py
@@ -35,6 +35,16 @@ def gpi2_rule(gate, platform):
     return sequence, {}
 
 
+def gpi_rule(gate, platform):
+    """Rule for GPI."""
+    qubit = gate.target_qubits[0]
+    theta = gate.parameters[0]
+    sequence = PulseSequence()
+    pulse = platform.create_RX_pulse(qubit, start=0, relative_phase=theta)
+    sequence.add(pulse)
+    return sequence, {}
+
+
 def u3_rule(gate, platform):
     """U3 applied as RZ-RX90-RZ-RX90-RZ."""
     qubit = gate.target_qubits[0]

--- a/tests/test_compilers_default.py
+++ b/tests/test_compilers_default.py
@@ -104,6 +104,20 @@ def test_rz_to_sequence(platform):
     assert len(sequence) == 0
 
 
+def test_gpi_to_sequence(platform):
+    circuit = Circuit(1)
+    circuit.add(gates.GPI(0, phi=0.2))
+    sequence = compile_circuit(circuit, platform)
+    assert len(sequence.pulses) == 1
+    assert len(sequence.qd_pulses) == 1
+
+    RX_pulse = platform.create_RX_pulse(0, start=0, relative_phase=0.2)
+    s = PulseSequence(RX_pulse)
+
+    np.testing.assert_allclose(sequence.duration, RX_pulse.duration)
+    assert sequence.serial == s.serial
+
+
 def test_gpi2_to_sequence(platform):
     circuit = Circuit(1)
     circuit.add(gates.GPI2(0, phi=0.2))


### PR DESCRIPTION
Closes #551.

Adding rule for implementing GPI gate as R(pi) gate with arbitrary azimuthal angle.
I believe that I don't need to do anything in Qibo, right?

Checklist:
- [x] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
