### PR TITLE
Fix deserialization of crosstalk_matrix

### DIFF
--- a/src/qibolab/serialize.py
+++ b/src/qibolab/serialize.py
@@ -48,10 +48,14 @@ def load_qubits(
     :class: `qibolab.qubits.QubitPair`
     objects.
     """
-    qubits = {
-        json.loads(q): Qubit(json.loads(q), **char)
-        for q, char in runcard["characterization"]["single_qubit"].items()
-    }
+    qubits = {}
+    for q, char in runcard["characterization"]["single_qubit"].items():
+        raw_qubit = Qubit(json.loads(q), **char)
+        raw_qubit.crosstalk_matrix = {
+            json.loads(key): value for key, value in raw_qubit.crosstalk_matrix.items()
+        }
+        qubits[json.loads(q)] = raw_qubit
+
     if kernels is not None:
         for q in kernels:
             qubits[q].kernel = kernels[q]


### PR DESCRIPTION
This PR fixes the crosstalk_matrix deserialization which was broken after switching from `yaml` to `json`.
I found this bug while testing https://github.com/qiboteam/qibocal/pull/684.
If someone knows a more elegant solution let me know.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
