### PR TITLE
Fix result shapes

### DIFF
--- a/tests/test_result_shapes.py
+++ b/tests/test_result_shapes.py
@@ -29,8 +29,8 @@ def execute(platform, acquisition_type, averaging_mode, sweep=False):
         nshots=NSHOTS, acquisition_type=acquisition_type, averaging_mode=averaging_mode
     )
     if sweep:
-        amp_values = np.arange(0.01, 0.06, 0.01)
-        freq_values = np.arange(-4e6, 4e6, 1e6)
+        amp_values = np.linspace(0.01, 0.06, NSWEEP1)
+        freq_values = np.linspace(-4e6, 4e6, NSWEEP2)
         sweeper1 = Sweeper(Parameter.bias, amp_values, qubits=[platform.qubits[qubit]])
         # sweeper1 = Sweeper(Parameter.amplitude, amp_values, pulses=[qd_pulse])
         sweeper2 = Sweeper(Parameter.frequency, freq_values, pulses=[ro_pulse])


### PR DESCRIPTION
Currently, result shapes are broken for the QICK drivers, as reported by @JavierSerranoGarcia in https://github.com/qiboteam/qibocal/issues/737

However, it seems like the tests in https://github.com/qiboteam/qibolab/blob/595351782d55a20fa2b8c35104c000092e42f585/tests/test_result_shapes.py are also broken for `iqm5q` (currently [using Zurich](https://github.com/qiboteam/qibolab_platforms_qrc/blob/4f2605e1cf8638879438308a875ee463d7e4e71f/iqm5q/platform.py#L34), in a pretty weird way.

I'm trying to understand how this is happening, but Qibocal seems properly compensating, since the `resonator_spectroscopy` routine is then properly working.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
