### PR TITLE
Qblox recursion fix

### DIFF
--- a/src/qibolab/instruments/qblox/controller.py
+++ b/src/qibolab/instruments/qblox/controller.py
@@ -507,37 +507,10 @@ class QbloxController(Controller):
                         result = self._combine_result_chunks(result_chunks)
                         self._add_to_results(sequence, results, result)
                     else:
-                        for _ in range(nshots):
-                            num_bins = 1
-                            for sweeper in sweepers[1:]:
-                                num_bins *= len(sweeper.values)
-                            sweeper = sweepers[0]
-                            max_rt_iterations = (SEQUENCER_MEMORY) // num_bins
-                            num_full_sft_iterations = (
-                                len(sweeper.values) // max_rt_iterations
-                            )
-                            num_bins = nshots * max_rt_iterations
-                            for sft_iteration in range(num_full_sft_iterations + 1):
-                                _from = sft_iteration * max_rt_iterations
-                                _to = min(
-                                    (sft_iteration + 1) * max_rt_iterations,
-                                    len(sweeper.values),
-                                )
-                                _values = sweeper.values[_from:_to]
-                                split_sweeper = Sweeper(
-                                    parameter=sweeper.parameter,
-                                    values=_values,
-                                    pulses=sweeper.pulses,
-                                    qubits=sweeper.qubits,
-                                )
-
-                                self._sweep_recursion(
-                                    qubits,
-                                    sequence,
-                                    options,
-                                    *((split_sweeper,) + sweepers[1:]),
-                                    results=results,
-                                )
+                        raise ValueError(
+                            f"Requested sweep has {sweepers_repetitions} total number of sweep points. "
+                            f"Maximum supported is {SEQUENCER_MEMORY}"
+                        )
 
     @staticmethod
     def _combine_result_chunks(result_chunks):

--- a/tests/test_instruments_qblox_controller.py
+++ b/tests/test_instruments_qblox_controller.py
@@ -1,6 +1,13 @@
+from unittest.mock import Mock
+
+import numpy as np
 import pytest
 
-from qibolab.instruments.qblox.controller import QbloxController
+from qibolab import AveragingMode, ExecutionParameters
+from qibolab.instruments.qblox.controller import SEQUENCER_MEMORY, QbloxController
+from qibolab.pulses import Gaussian, Pulse, PulseSequence, ReadoutPulse, Rectangular
+from qibolab.result import IntegratedResults
+from qibolab.sweeper import Parameter, Sweeper
 
 from .qblox_fixtures import connected_controller, controller
 
@@ -10,6 +17,48 @@ def test_init(controller: QbloxController):
     assert type(controller.modules) == dict
     assert controller.cluster == None
     assert controller._reference_clock in ["internal", "external"]
+
+
+def test_sweep_too_many_bins(platform, controller):
+    """Sweeps that require more bins than the hardware supports should be split
+    and executed."""
+    qubit = platform.qubits[0]
+    pulse = Pulse(0, 40, 0.05, int(3e9), 0.0, Gaussian(5), qubit.drive.name, qubit=0)
+    ro_pulse = ReadoutPulse(
+        0, 40, 0.05, int(3e9), 0.0, Rectangular(), qubit.readout.name, qubit=0
+    )
+    sequence = PulseSequence(pulse, ro_pulse)
+
+    # These values shall result into execution in two rounds
+    shots = 128
+    sweep_len = (SEQUENCER_MEMORY + 431) // shots
+
+    mock_data = np.array([1, 2, 3, 4])
+    sweep_ampl = Sweeper(Parameter.amplitude, np.random.rand(sweep_len), pulses=[pulse])
+    params = ExecutionParameters(
+        nshots=shots, relaxation_time=10, averaging_mode=AveragingMode.SINGLESHOT
+    )
+    controller._execute_pulse_sequence = Mock(
+        return_value={ro_pulse.serial: IntegratedResults(mock_data)}
+    )
+    res = controller.sweep(
+        {0: platform.qubits[0]}, platform.couplers, sequence, params, sweep_ampl
+    )
+    expected_data = np.append(mock_data, mock_data)  #
+    assert np.array_equal(res[ro_pulse.serial].voltage, expected_data)
+
+
+def test_sweep_too_many_sweep_points(platform, controller):
+    """Sweeps that require too many bins because simply the number of sweep
+    points is too large should be rejected."""
+    qubit = platform.qubits[0]
+    pulse = Pulse(0, 40, 0.05, int(3e9), 0.0, Gaussian(5), qubit.drive.name, qubit=0)
+    sweep = Sweeper(
+        Parameter.amplitude, np.random.rand(SEQUENCER_MEMORY + 17), pulses=[pulse]
+    )
+    params = ExecutionParameters(nshots=12, relaxation_time=10)
+    with pytest.raises(ValueError, match="total number of sweep points"):
+        controller.sweep({0: qubit}, {}, PulseSequence(pulse), params, sweep)
 
 
 @pytest.mark.qpu


### PR DESCRIPTION
Fixes https://github.com/qiboteam/qibolab/issues/830

When the number of bins (`nshots * total_number_of_sweep_points`) is larger than the maximum supported by the instrument (`2**17`), the execution is done in batches. Previously the `_sweep_recursion` was called which resulted into infinite recursion stack.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
