### PR TITLE
Fix drag pulse helper method

### DIFF
--- a/src/qibolab/platform.py
+++ b/src/qibolab/platform.py
@@ -415,6 +415,7 @@ class Platform:
         qubit = self.get_qubit(qubit)
         pulse = self.qubits[qubit].native_gates.RX90.pulse(start, relative_phase)
         pulse.shape = Drag(rel_sigma=pulse.shape.rel_sigma, beta=beta)
+        pulse.shape.pulse = pulse
         return pulse
 
     def create_RX_drag_pulse(self, qubit, start, beta, relative_phase=0):
@@ -422,4 +423,5 @@ class Platform:
         qubit = self.get_qubit(qubit)
         pulse = self.qubits[qubit].native_gates.RX.pulse(start, relative_phase)
         pulse.shape = Drag(rel_sigma=pulse.shape.rel_sigma, beta=beta)
+        pulse.shape.pulse = pulse
         return pulse

--- a/src/qibolab/platform.py
+++ b/src/qibolab/platform.py
@@ -410,18 +410,16 @@ class Platform:
     # TODO Remove RX90_drag_pulse and RX_drag_pulse, replace them with create_qubit_drive_pulse
     # TODO Add RY90 and RY pulses
 
-    def create_RX90_drag_pulse(self, qubit, start, relative_phase=0, beta=None):
+    def create_RX90_drag_pulse(self, qubit, start, beta, relative_phase=0):
         """Create native RX90 pulse with Drag shape."""
         qubit = self.get_qubit(qubit)
         pulse = self.qubits[qubit].native_gates.RX90.pulse(start, relative_phase)
-        if beta is not None:
-            pulse.shape = Drag(rel_sigma=pulse.shape.rel_sigma, beta=beta)
+        pulse.shape = Drag(rel_sigma=pulse.shape.rel_sigma, beta=beta)
         return pulse
 
-    def create_RX_drag_pulse(self, qubit, start, relative_phase=0, beta=None):
+    def create_RX_drag_pulse(self, qubit, start, beta, relative_phase=0):
         """Create native RX pulse with Drag shape."""
         qubit = self.get_qubit(qubit)
         pulse = self.qubits[qubit].native_gates.RX.pulse(start, relative_phase)
-        if beta is not None:
-            pulse.shape = Drag(rel_sigma=pulse.shape.rel_sigma, beta=beta)
+        pulse.shape = Drag(rel_sigma=pulse.shape.rel_sigma, beta=beta)
         return pulse

--- a/src/qibolab/platform.py
+++ b/src/qibolab/platform.py
@@ -10,7 +10,7 @@ from qibo.config import log, raise_error
 from .couplers import Coupler
 from .execution_parameters import ExecutionParameters
 from .instruments.abstract import Controller, Instrument, InstrumentId
-from .pulses import FluxPulse, PulseSequence, ReadoutPulse
+from .pulses import Drag, FluxPulse, PulseSequence, ReadoutPulse
 from .qubits import Qubit, QubitId, QubitPair, QubitPairId
 from .sweeper import Sweeper
 from .unrolling import batch
@@ -411,15 +411,17 @@ class Platform:
     # TODO Add RY90 and RY pulses
 
     def create_RX90_drag_pulse(self, qubit, start, relative_phase=0, beta=None):
+        """Create native RX90 pulse with Drag shape."""
         qubit = self.get_qubit(qubit)
         pulse = self.qubits[qubit].native_gates.RX90.pulse(start, relative_phase)
         if beta is not None:
-            pulse.shape = "Drag(5," + str(beta) + ")"
+            pulse.shape = Drag(rel_sigma=pulse.shape.rel_sigma, beta=beta)
         return pulse
 
     def create_RX_drag_pulse(self, qubit, start, relative_phase=0, beta=None):
+        """Create native RX pulse with Drag shape."""
         qubit = self.get_qubit(qubit)
         pulse = self.qubits[qubit].native_gates.RX.pulse(start, relative_phase)
         if beta is not None:
-            pulse.shape = "Drag(5," + str(beta) + ")"
+            pulse.shape = Drag(rel_sigma=pulse.shape.rel_sigma, beta=beta)
         return pulse

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -360,15 +360,17 @@ def test_ground_state_probabilities_pulses(qpu_platform, start_zero):
     np.testing.assert_allclose(probs, target_probs, atol=0.05)
 
 
-@pytest.mark.qpu
-@pytest.mark.skip(reason="no way of currently testing this")
-def test_create_RX_drag_pulses(qpu_platform):
-    platform = qpu_platform
+def test_create_RX_drag_pulses():
+    platform = create_dummy()
     qubits = [q for q, qb in platform.qubits.items() if qb.drive is not None]
     beta = 0.1234
     for qubit in qubits:
         drag_pi = platform.create_RX_drag_pulse(qubit, 0, beta=beta)
         assert drag_pi.shape == Drag(drag_pi.shape.rel_sigma, beta=beta)
-        drag_pi_half = platform.create_RX_drag_pulse(qubit, 0, beta=beta)
+        drag_pi_half = platform.create_RX90_drag_pulse(qubit, drag_pi.finish, beta=beta)
         assert drag_pi_half.shape == Drag(drag_pi_half.shape.rel_sigma, beta=beta)
-        assert drag_pi.amplitude == 2 * drag_pi_half.amplitude
+        np.testing.assert_almost_equal(drag_pi.amplitude, 2 * drag_pi_half.amplitude)
+
+        # to check ShapeInitError
+        drag_pi.shape.envelope_waveforms()
+        drag_pi_half.shape.envelope_waveforms()

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -362,15 +362,10 @@ def test_ground_state_probabilities_pulses(qpu_platform, start_zero):
 
 @pytest.mark.qpu
 @pytest.mark.skip(reason="no way of currently testing this")
-@pytest.mark.parametrize("beta", [None, 0.123])
-def test_create_RX_pulses(qpu_platform, beta):
+def test_create_RX_pulses(qpu_platform):
     platform = qpu_platform
     qubits = [q for q, qb in platform.qubits.items() if qb.drive is not None]
-
+    beta = 0.1234
     for qubit in qubits:
         drag = platform.create_RX_drag_pulse(qubit, 0, beta=beta)
-        drive = platform.create_RX_pulse(qubit, 0)
-        if beta is None:
-            assert drag == drive
-        else:
-            drive.shape = Drag(drive.shape.rel_sigma, beta=beta)
+        assert drag.shape == Drag(drag.shape.rel_sigma, beta=beta)

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -19,7 +19,7 @@ from qibolab.instruments.qblox.controller import QbloxController
 from qibolab.instruments.rfsoc.driver import RFSoC
 from qibolab.kernels import Kernels
 from qibolab.platform import Platform, unroll_sequences
-from qibolab.pulses import PulseSequence, Rectangular
+from qibolab.pulses import Drag, PulseSequence, Rectangular
 from qibolab.serialize import (
     dump_kernels,
     dump_platform,
@@ -358,3 +358,19 @@ def test_ground_state_probabilities_pulses(qpu_platform, start_zero):
     target_probs = np.zeros((nqubits, 2))
     target_probs[:, 0] = 1
     np.testing.assert_allclose(probs, target_probs, atol=0.05)
+
+
+@pytest.mark.qpu
+@pytest.mark.skip(reason="no way of currently testing this")
+@pytest.mark.parametrize("beta", [None, 0.123])
+def test_create_RX_pulses(qpu_platform, beta):
+    platform = qpu_platform
+    qubits = [q for q, qb in platform.qubits.items() if qb.drive is not None]
+
+    for qubit in qubits:
+        drag = platform.create_RX_drag_pulse(qubit, 0, beta=beta)
+        drive = platform.create_RX_pulse(qubit, 0)
+        if beta is None:
+            assert drag == drive
+        else:
+            drive.shape = Drag(drive.shape.rel_sigma, beta=beta)

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -362,10 +362,13 @@ def test_ground_state_probabilities_pulses(qpu_platform, start_zero):
 
 @pytest.mark.qpu
 @pytest.mark.skip(reason="no way of currently testing this")
-def test_create_RX_pulses(qpu_platform):
+def test_create_RX_drag_pulses(qpu_platform):
     platform = qpu_platform
     qubits = [q for q, qb in platform.qubits.items() if qb.drive is not None]
     beta = 0.1234
     for qubit in qubits:
-        drag = platform.create_RX_drag_pulse(qubit, 0, beta=beta)
-        assert drag.shape == Drag(drag.shape.rel_sigma, beta=beta)
+        drag_pi = platform.create_RX_drag_pulse(qubit, 0, beta=beta)
+        assert drag_pi.shape == Drag(drag_pi.shape.rel_sigma, beta=beta)
+        drag_pi_half = platform.create_RX_drag_pulse(qubit, 0, beta=beta)
+        assert drag_pi_half.shape == Drag(drag_pi_half.shape.rel_sigma, beta=beta)
+        assert drag_pi.amplitude == 2 * drag_pi_half.amplitude


### PR DESCRIPTION
While testing https://github.com/qiboteam/qibocal/pull/689 I noticed that the platform's helper methods for creating drag pulses were broken (I was the one who implemented them...). This PR fixes the issue.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
