### PR TITLE
Disconnect after circuit execution

### DIFF
--- a/src/qibolab/backends.py
+++ b/src/qibolab/backends.py
@@ -102,6 +102,9 @@ class QibolabBackend(NumpyBackend):
             sequence,
             ExecutionParameters(nshots=nshots),
         )
+
+        self.platform.disconnect()
+
         result = MeasurementOutcomes(circuit.measurements, self, nshots=nshots)
         self.assign_measurements(measurement_map, readout)
         return result
@@ -148,6 +151,8 @@ class QibolabBackend(NumpyBackend):
             sequences,
             ExecutionParameters(nshots=nshots),
         )
+
+        self.platform.disconnect()
 
         results = []
         readout = {k: deque(v) for k, v in readout.items()}

--- a/src/qibolab/instruments/erasynth.py
+++ b/src/qibolab/instruments/erasynth.py
@@ -136,6 +136,3 @@ class ERA(LocalOscillator):
             return ERASynthEthernet(self.name, self.address)
         else:
             return ERASynthPlusPlus(f"{self.name}", f"TCPIP::{self.address}::INSTR")
-
-    def __del__(self):
-        self.disconnect()

--- a/src/qibolab/instruments/rohde_schwarz.py
+++ b/src/qibolab/instruments/rohde_schwarz.py
@@ -14,6 +14,3 @@ class SGS100A(LocalOscillator):
         return LO_SGS100A.RohdeSchwarz_SGS100A(
             self.name, f"TCPIP0::{self.address}::5025::SOCKET"
         )
-
-    def __del__(self):
-        self.disconnect()


### PR DESCRIPTION
This PR addresses two small issues related to the usage of local oscillators when executing circuits (using the `QibolabBackend`).

First, I get a weird exception warning from qblox after executing a circuit on a platform that contains a Rohde Scharz LO (in my case the qw5q_platinum platform from qiboteam/qibolab_platforms_qrc#125). I didn't copy the exact thing but should be easy to reproduce by running any circuit, ie
```py
from qibo import Circuit, gates
from qibolab.backends import QibolabBackend

c = Circuit(5)
c.add(gates.GPI2(3, theta=0)) # using qubit 3 because it is calibrated
c.add(gates.M(3))

backend = QibolabBackend("qw5q_platinum")
result = backend.execute_circuit(c, nshots=1000)
```
This issue is fixed by removing the `__del__` methods from the LO drivers. I don't think these are needed since Python/qcodes should already take care of destructing the objects.

Second, I added an explicit `platform.disconnect()` after executing circuits because otherwise LOs stay on forever after execution (this happens even with the destructor).