### PR TITLE
Fix qm-qua version to 1.1.6

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1244,13 +1244,13 @@ grpcio-gcp = ["grpcio-gcp (>=0.2.2,<1.0.dev0)"]
 
 [[package]]
 name = "google-auth"
-version = "2.28.2"
+version = "2.29.0"
 description = "Google Authentication Library"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "google-auth-2.28.2.tar.gz", hash = "sha256:80b8b4969aa9ed5938c7828308f20f035bc79f9d8fb8120bf9dc8db20b41ba30"},
-    {file = "google_auth-2.28.2-py2.py3-none-any.whl", hash = "sha256:9fd67bbcd40f16d9d42f950228e9cf02a2ded4ae49198b27432d0cded5a74c38"},
+    {file = "google-auth-2.29.0.tar.gz", hash = "sha256:672dff332d073227550ffc7457868ac4218d6c500b155fe6cc17d2b13602c360"},
+    {file = "google_auth-2.29.0-py2.py3-none-any.whl", hash = "sha256:d452ad095688cd52bae0ad6fafe027f6a6d6f560e810fec20914e17a09526415"},
 ]
 
 [package.dependencies]
@@ -1575,13 +1575,13 @@ files = [
 
 [[package]]
 name = "importlib-metadata"
-version = "7.0.2"
+version = "7.1.0"
 description = "Read metadata from Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "importlib_metadata-7.0.2-py3-none-any.whl", hash = "sha256:f4bc4c0c070c490abf4ce96d715f68e95923320370efb66143df00199bb6c100"},
-    {file = "importlib_metadata-7.0.2.tar.gz", hash = "sha256:198f568f3230878cb1b44fbd7975f87906c22336dba2e4a7f05278c281fbd792"},
+    {file = "importlib_metadata-7.1.0-py3-none-any.whl", hash = "sha256:30962b96c0c223483ed6cc7280e7f0199feb01a0e40cfae4d4450fc6fab1f570"},
+    {file = "importlib_metadata-7.1.0.tar.gz", hash = "sha256:b78938b926ee8d5f020fc4772d487045805a55ddbad2ecf21c6d60938dc7fcd2"},
 ]
 
 [package.dependencies]
@@ -1590,7 +1590,7 @@ zipp = ">=0.5"
 [package.extras]
 docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
 perf = ["ipython"]
-testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-perf (>=0.9.2)", "pytest-ruff (>=0.2.1)"]
+testing = ["flufl.flake8", "importlib-resources (>=1.3)", "jaraco.test (>=5.4)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-perf (>=0.9.2)", "pytest-ruff (>=0.2.1)"]
 
 [[package]]
 name = "importlib-resources"
@@ -2217,21 +2217,19 @@ files = [
 
 [[package]]
 name = "marshmallow"
-version = "3.21.1"
+version = "3.0.0"
 description = "A lightweight library for converting complex datatypes to and from native Python datatypes."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.5"
 files = [
-    {file = "marshmallow-3.21.1-py3-none-any.whl", hash = "sha256:f085493f79efb0644f270a9bf2892843142d80d7174bbbd2f3713f2a589dc633"},
-    {file = "marshmallow-3.21.1.tar.gz", hash = "sha256:4e65e9e0d80fc9e609574b9983cf32579f305c718afb30d7233ab818571768c3"},
+    {file = "marshmallow-3.0.0-py2.py3-none-any.whl", hash = "sha256:e5e9fd0c2e919b4ece915eb30808206349a49a45df72e99ed20e27a9053d574b"},
+    {file = "marshmallow-3.0.0.tar.gz", hash = "sha256:fa2d8a4b61d09b0e161a14acc5ad8ab7aaaf1477f3dd52819ddd6c6c8275733a"},
 ]
 
-[package.dependencies]
-packaging = ">=17.0"
-
 [package.extras]
-dev = ["marshmallow[tests]", "pre-commit (>=3.5,<4.0)", "tox"]
-docs = ["alabaster (==0.7.16)", "autodocsumm (==0.2.12)", "sphinx (==7.2.6)", "sphinx-issues (==4.0.0)", "sphinx-version-warning (==1.1.2)"]
+dev = ["flake8 (==3.7.8)", "flake8-bugbear (==19.8.0)", "pre-commit (>=1.17,<2.0)", "pytest", "pytz", "simplejson", "tox"]
+docs = ["alabaster (==0.7.12)", "sphinx (==2.1.2)", "sphinx-issues (==1.2.0)", "sphinx-version-warning (==1.1.2)"]
+lint = ["flake8 (==3.7.8)", "flake8-bugbear (==19.8.0)", "pre-commit (>=1.17,<2.0)"]
 tests = ["pytest", "pytz", "simplejson"]
 
 [[package]]
@@ -4311,13 +4309,13 @@ full = ["pyro4"]
 
 [[package]]
 name = "qm-octave"
-version = "2.1.0"
+version = "2.0.1"
 description = "SDK to control an Octave with QUA"
 optional = false
 python-versions = ">=3.7,<3.12"
 files = [
-    {file = "qm_octave-2.1.0-py3-none-any.whl", hash = "sha256:b909596fbbb183af3555cd737fa12ffb899afef0c3f804762e0aedd29abd9838"},
-    {file = "qm_octave-2.1.0.tar.gz", hash = "sha256:ca142a6656a0e1cd83ecbb8a2050096274468656a724ad041db6178c28864bfe"},
+    {file = "qm_octave-2.0.1-py3-none-any.whl", hash = "sha256:ef2607101b978beb306f30bfc56656f087fe7764133ba22e3ce5739a409c4edb"},
+    {file = "qm_octave-2.0.1.tar.gz", hash = "sha256:f20844d98e493a253bedb72f86fcb665bc7461a46d502de3cc7c91f3d54416d6"},
 ]
 
 [package.dependencies]
@@ -4334,35 +4332,41 @@ protobuf = [
 
 [[package]]
 name = "qm-qua"
-version = "1.1.7"
+version = "1.1.6"
 description = "QUA language SDK to control a Quantum Computer"
 optional = false
-python-versions = ">=3.8,<3.12"
+python-versions = ">=3.7,<3.12"
 files = [
-    {file = "qm_qua-1.1.7-py3-none-any.whl", hash = "sha256:6466d8925478c615fb41c10d92661f9a514f77ed6ce93d7b8385e07d87d43aa4"},
-    {file = "qm_qua-1.1.7.tar.gz", hash = "sha256:ef1d586a439116ef3da2b153be850969c15ee29a3d3a53abce869a73ab8706db"},
+    {file = "qm_qua-1.1.6-py3-none-any.whl", hash = "sha256:69f8159805889fe9389b1acb4e94afacc37d68e1455017ec0e58a4fcc238bd8c"},
+    {file = "qm_qua-1.1.6.tar.gz", hash = "sha256:9e09240bf1d9623c0f5b15fb2bc955f7387da15280d0b02c266e42a40818a2b1"},
 ]
 
 [package.dependencies]
 betterproto = [
-    {version = "2.0.0b5", markers = "python_version >= \"3.8\" and python_version < \"3.11\""},
+    {version = "2.0.0b5", markers = "python_version >= \"3.7\" and python_version < \"3.11\""},
     {version = "2.0.0b6", markers = "python_version == \"3.11\""},
 ]
 datadog-api-client = ">=2.6.0,<3.0.0"
 dependency_injector = ">=4.41.0,<5.0.0"
 deprecation = ">=2.1.0,<3.0.0"
 grpcio = [
-    {version = ">=1.39.0,<2.0.0", markers = "python_version >= \"3.8\" and python_version < \"3.11\""},
+    {version = ">=1.39.0,<2.0.0", markers = "python_version >= \"3.7\" and python_version < \"3.11\""},
     {version = ">=1.57,<2.0", markers = "python_version >= \"3.11\""},
 ]
 grpclib = {version = ">=0.4.5,<0.5.0", markers = "python_version >= \"3.10\""}
 httpx = {version = ">=0.23.3,<0.24.0", extras = ["http2"]}
-marshmallow = ">=3.20.1,<4.0.0"
+marshmallow = "3"
 marshmallow-polyfield = ">=5.7,<6.0"
-numpy = ">=1.17.0,<2.0.0"
+numpy = [
+    {version = ">=1.17.0,<2.0.0", markers = "python_version >= \"3.7\" and python_version < \"3.11\""},
+    {version = ">=1.24,<2.0", markers = "python_version >= \"3.11\""},
+]
 plotly = ">=5.13.0,<6.0.0"
-protobuf = ">=3.17.3,<5"
-qm-octave = "2.1.0"
+protobuf = [
+    {version = ">=3.17.3,<4.0.0", markers = "python_version >= \"3.7\" and python_version < \"3.11\""},
+    {version = ">=4.24,<5.0", markers = "python_version >= \"3.11\""},
+]
+qm-octave = ">=2.0.1,<2.1.0"
 tinydb = ">=4.6.1,<5.0.0"
 typing-extensions = ">=4.5,<5.0"
 
@@ -5167,13 +5171,13 @@ doc = ["reno", "sphinx", "tornado (>=4.5)"]
 
 [[package]]
 name = "threadpoolctl"
-version = "3.3.0"
+version = "3.4.0"
 description = "threadpoolctl"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "threadpoolctl-3.3.0-py3-none-any.whl", hash = "sha256:6155be1f4a39f31a18ea70f94a77e0ccd57dced08122ea61109e7da89883781e"},
-    {file = "threadpoolctl-3.3.0.tar.gz", hash = "sha256:5dac632b4fa2d43f42130267929af3ba01399ef4bd1882918e92dbc30365d30c"},
+    {file = "threadpoolctl-3.4.0-py3-none-any.whl", hash = "sha256:8f4c689a65b23e5ed825c8436a92b818aac005e0f3715f6a1664d7c7ee29d262"},
+    {file = "threadpoolctl-3.4.0.tar.gz", hash = "sha256:f11b491a03661d6dd7ef692dd422ab34185d982466c49c8f98c8f716b5c93196"},
 ]
 
 [[package]]
@@ -5746,4 +5750,4 @@ zh = ["laboneq"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.12"
-content-hash = "a3a2138ae94c7d963b92758515d242d48e37807d44e54beaf5748ca2ddb91e90"
+content-hash = "b97996ad9756490bf10c7dc841f549c1341117770ae24d770c443e9d3bfb831e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ qblox-instruments = { version = "0.11.0", optional = true }
 qcodes = { version = "^0.37.0", optional = true }
 qcodes_contrib_drivers = { version = "0.18.0", optional = true }
 pyvisa-py = { version = "0.5.3", optional = true }
-qm-qua = { version = "^1.1.6", optional = true }
+qm-qua = { version = "==1.1.6", optional = true }
 qualang-tools = { version = "^0.15.0", optional = true}
 setuptools = { version = ">67.0.0", optional = true }
 laboneq = { version = "==2.25.0", optional = true }


### PR DESCRIPTION
A new qm-qua version (1.1.7) was released which seems to cause an issue. I am not sure if this is driver or firmware related, I will investigate when the instrument is available.

@andrea-pasquale @Edoardo-Pedicillo this should fix #844.