### PR TITLE
Hotfix: Exclude flux pulses from subsection splitting logic if they overlap (in time) with readout

### DIFF
--- a/src/qibolab/instruments/zhinst/executor.py
+++ b/src/qibolab/instruments/zhinst/executor.py
@@ -115,7 +115,7 @@ class Zurich(Controller):
         self.sub_sequences: list[SubSequence] = []
         "Sub sequences between each measurement"
         self.unsplit_channels: set[str] = set()
-        "Names of channels that were not split into seb-sequences"
+        "Names of channels that were not split into sub-sequences"
 
         self.processed_sweeps: Optional[ProcessedSweeps] = None
         self.nt_sweeps: list[Sweeper] = []

--- a/src/qibolab/instruments/zhinst/executor.py
+++ b/src/qibolab/instruments/zhinst/executor.py
@@ -334,7 +334,7 @@ class Zurich(Controller):
                 max(ends),
             )  # max is intended for float arithmetic errors only
 
-        # FIXME: this is a hotfix specifically made for the qubit_flux experiment in flux pulse mode, where the flux
+        # FIXME: this is a hotfix specifically made for any flux experiments in flux pulse mode, where the flux
         # pulses extend through the entire duration of the experiment. This should be removed once the sub-sequence
         # splitting logic is removed from the driver.
         channels_overlapping_measurement = set()


### PR DESCRIPTION
Historically, the ZI driver was designed so that it splits incoming pulse sequence based on the locations of measurement. This was motivated by some limitations in laboneq, (at least) part of which no longer exist. Eventually the driver will be rewritten to remove the assumptions related to this logic, but for now to make [this](https://github.com/qiboteam/qibocal/pull/691) experiment work, this PR implements a hotfix.

See also discussion in https://github.com/qiboteam/qibolab/issues/840

Tested for qubit 1 with https://github.com/qiboteam/qibocal/pull/691 and https://github.com/qiboteam/qibolab_platforms_qrc/pull/126 (but updated the power range of flux lines from 9 to 1).

Qubit flux dependence:

<img width="1115" alt="qubit_flux" src="https://github.com/qiboteam/qibolab/assets/52532457/ab23eaea-fe30-471f-9b8e-ab53ed9974d9">

Resonator flux dependence:

<img width="1115" alt="resonator_flux" src="https://github.com/qiboteam/qibolab/assets/52532457/447cc210-ff33-4856-9632-361d70263e52">

P.S. The amplitude sweeps are indeed flux pulse amplitude sweeps. The axis is incorrectly named bias (see https://github.com/qiboteam/qibocal/pull/691#pullrequestreview-1954194087)


Before this change, the right plots (i.e. the ones with flux pulse amplitude sweep) would look like as below (example plot for qubit flux dependence). I.e. the sweep wouldn't happen at all. This is because the long flux pulse overlapping with measurement was dropped.
<img width="485" alt="image" src="https://github.com/qiboteam/qibolab/assets/52532457/8d24a899-0130-4667-bb7c-0a8cc4009b34">


Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
