### PR TITLE
Do not rearrange real-time sweepers (ZI)

### DIFF
--- a/src/qibolab/instruments/zhinst/executor.py
+++ b/src/qibolab/instruments/zhinst/executor.py
@@ -697,50 +697,12 @@ class Zurich(Controller):
 
         exp.play(signal=channel_name, pulse=pulse.zhpulse, **play_parameters)
 
-    @staticmethod
-    def rearrange_rt_sweepers(
-        sweepers: list[Sweeper],
-    ) -> tuple[Optional[tuple[int, int]], list[Sweeper]]:
-        """Rearranges list of real-time sweepers based on hardware limitations.
-
-        The only known limitation currently is that frequency sweepers must be applied before (on the outer loop) other
-        (e.g. amplitude) sweepers. Consequently, the only thing done here is to swap the frequency sweeper with the
-        first sweeper in the list.
-
-        Args:
-            sweepers: Sweepers to rearrange.
-
-        Returns:
-            swapped_axis_pair: tuple containing indices of the two swapped axes, or None if nothing to rearrange.
-            sweepers: rearranged (or original, if nothing to rearrange) list of sweepers.
-        """
-        freq_sweeper = next(
-            iter(s for s in sweepers if s.parameter is Parameter.frequency), None
-        )
-        if freq_sweeper:
-            sweepers_copy = sweepers.copy()
-            freq_sweeper_idx = sweepers_copy.index(freq_sweeper)
-            sweepers_copy[freq_sweeper_idx] = sweepers_copy[0]
-            sweepers_copy[0] = freq_sweeper
-            log.warning("Sweepers were reordered")
-            return (0, freq_sweeper_idx), sweepers_copy
-        return None, sweepers
-
     def sweep(self, qubits, couplers, sequence: PulseSequence, options, *sweepers):
         """Play pulse and sweepers sequence."""
 
         self.signal_map = {}
         self.processed_sweeps = ProcessedSweeps(sweepers, qubits)
         self.nt_sweeps, self.rt_sweeps = classify_sweepers(sweepers)
-        swapped_axis_pair, self.rt_sweeps = self.rearrange_rt_sweepers(self.rt_sweeps)
-        if swapped_axis_pair:
-            # 1. axes corresponding to NT sweeps appear before axes corresponding to RT sweeps
-            # 2. in singleshot mode, the first axis contains shots, i.e.: (nshots, sweeper_1, sweeper_2)
-            axis_offset = len(self.nt_sweeps) + int(
-                options.averaging_mode is AveragingMode.SINGLESHOT
-            )
-            swapped_axis_pair = tuple(ax + axis_offset for ax in swapped_axis_pair)
-
         self.frequency_from_pulses(qubits, sequence)
 
         self.acquisition_type = None
@@ -760,8 +722,6 @@ class Zurich(Controller):
             for i, ropulse in enumerate(self.sequence[measure_channel_name(qubit)]):
                 data = self.results.get_data(f"sequence{q}_{i}")
 
-                if swapped_axis_pair:
-                    data = np.moveaxis(data, swapped_axis_pair[0], swapped_axis_pair[1])
                 if options.acquisition_type is AcquisitionType.DISCRIMINATION:
                     data = (
                         np.ones(data.shape) - data.real


### PR DESCRIPTION
Currently, the ZI driver may change the order of real-time sweepers in certain situations. This was most probably historically done for the following two reasons:

1. hardware limitation(s)
2. optimization of runtime (frequency sweep is considered to be slow, so it is moved to the outer loop, so it changes the least amount of time)

Recently, we discovered that (and confirmed by laboneq developers), that point 1 does not exist. As for point 2, with @Jacfomg we observed that order of real-time sweeps may affect the quality of acquired data (for physical reasons, and not specific to instrument). In light of this it seems that the better decision is that the driver not change the order of sweeps. It is better to let qibocal decide which order works best for which experiment.

Below is output from qubit flux dependence experiment, where flux sweep is done as an amplitude sweep for a long square flux pulse. So we have nested 2 real-time sweeps (flux pulse amplitude and qubit drive frequency). The first plot corresponds to the case where frequency sweep is the inner loop, and for the second plot the frequency sweep is the outer loop.

<img width="490" alt="image" src="https://github.com/qiboteam/qibolab/assets/52532457/b8892776-f8d8-480f-8233-bb3664655489">

<img width="486" alt="image" src="https://github.com/qiboteam/qibolab/assets/52532457/2fa47e09-6a04-4c90-9a27-ca4190f5308f">

Looks like the rapid changes in amplitude (when the amplitude sweep is the inner one) result into some vertical shadows. The two experiments above were done using `relaxation_time = 2000`. Increasing it mitigates the shadowing issue, as seen from the below plot done with `relaxation_time=20_000`:
<img width="480" alt="image" src="https://github.com/qiboteam/qibolab/assets/52532457/f393e679-df4e-49f0-9fad-694c4a4ed4c5">


Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
