### PR TITLE
Use triggered mode for QM local oscillators

### DIFF
--- a/src/qibolab/instruments/qm/config.py
+++ b/src/qibolab/instruments/qm/config.py
@@ -53,15 +53,19 @@ class QMConfig:
                 controllers[port.device] = {}
                 if not is_octave:
                     controllers[port.device]["analog_inputs"] = DEFAULT_INPUTS
+                    controllers[port.device]["digital_outputs"] = {}
 
             device = controllers[port.device]
             if port.key in device:
                 device[port.key].update(port.config)
             else:
                 device[port.key] = port.config
+
             if is_octave:
                 device["connectivity"] = port.opx_port.i.device
                 self.register_port(port.opx_port)
+            else:
+                device["digital_outputs"][port.number] = {}
 
     @staticmethod
     def iq_imbalance(g, phi):
@@ -168,9 +172,18 @@ class QMConfig:
                     }
                 ]
             else:
+                opx = qubit.readout.port.opx_port.i.device
+                port_number = qubit.readout.port.number
                 self.elements[f"readout{qubit.name}"] = {
                     "RF_inputs": {"port": qubit.readout.port.pair},
                     "RF_outputs": {"port": qubit.feedback.port.pair},
+                    "digitalInputs": {
+                        "output_switch": {
+                            "port": (opx, port_number),
+                            "delay": 57,
+                            "buffer": 18,
+                        },
+                    },
                 }
             self.elements[f"readout{qubit.name}"].update(
                 {

--- a/src/qibolab/instruments/qm/config.py
+++ b/src/qibolab/instruments/qm/config.py
@@ -66,9 +66,10 @@ class QMConfig:
 
             if is_octave:
                 con = port.opx_port.i.device
+                number = port.opx_port.i.number
                 device["connectivity"] = con
                 self.register_port(port.opx_port)
-                self.controllers[con]["digital_outputs"][port.number] = {}
+                self.controllers[con]["digital_outputs"][number] = {}
 
     @staticmethod
     def iq_imbalance(g, phi):

--- a/src/qibolab/instruments/qm/ports.py
+++ b/src/qibolab/instruments/qm/ports.py
@@ -1,6 +1,15 @@
 from dataclasses import dataclass, field, fields
 from typing import ClassVar, Dict, Optional, Union
 
+DIGITAL_DELAY = 57
+DIGITAL_BUFFER = 18
+"""Default calibration parameters for digital pulses.
+
+https://docs.quantum-machines.co/1.1.7/qm-qua-sdk/docs/Guides/octave/#calibrating-the-digital-pulse
+
+Digital markers are used for LO triggering.
+"""
+
 
 @dataclass
 class QMPort:
@@ -142,16 +151,9 @@ class OctaveOutput(QMOutput):
     """
     output_mode: str = field(default="triggered", metadata={"config": "output_mode"})
     """Can be: "always_on" / "always_off"/ "triggered" / "triggered_reversed"."""
-    digital_delay: int = 57
-    """Delay for digital output channel.
-
-    Digital markers are used for LO triggering.
-
-    See
-    https://docs.quantum-machines.co/1.1.7/qm-qua-sdk/docs/Guides/octave/#calibrating-the-digital-pulse
-    for more details on the default values.
-    """
-    digital_buffer: int = 18
+    digital_delay: int = DIGITAL_DELAY
+    """Delay for digital output channel."""
+    digital_buffer: int = DIGITAL_BUFFER
     """Buffer for digital output channel."""
 
     opx_port: Optional[OPXOutput] = None

--- a/src/qibolab/instruments/qm/ports.py
+++ b/src/qibolab/instruments/qm/ports.py
@@ -140,7 +140,7 @@ class OctaveOutput(QMOutput):
 
     Can be external or internal.
     """
-    output_mode: str = field(default="always_on", metadata={"config": "output_mode"})
+    output_mode: str = field(default="triggered", metadata={"config": "output_mode"})
     """Can be: "always_on" / "always_off"/ "triggered" / "triggered_reversed"."""
 
     opx_port: Optional[OPXOutput] = None

--- a/src/qibolab/instruments/qm/ports.py
+++ b/src/qibolab/instruments/qm/ports.py
@@ -1,6 +1,12 @@
 from dataclasses import dataclass, field, fields
 from typing import ClassVar, Dict, Optional, Union
 
+DIGITAL_PULSE_CALIBRATION = {"delay": 57, "buffer": 18}
+"""Calibration of digital pulses used for LO triggering.
+
+https://docs.quantum-machines.co/1.1.7/qm-qua-sdk/docs/Guides/octave/#calibrating-the-digital-pulse
+"""
+
 
 @dataclass
 class QMPort:
@@ -145,6 +151,17 @@ class OctaveOutput(QMOutput):
 
     opx_port: Optional[OPXOutput] = None
     """OPX+ port that is connected to the Octave port."""
+
+    @property
+    def digital_inputs(self):
+        """Generates `digitalInputs` entry for elements in QM config.
+
+        Digital markers are used to switch LOs on in triggered mode.
+        """
+        opx = self.opx_port.i.device
+        return {
+            "output_switch": {"port": (opx, self.number)} | DIGITAL_PULSE_CALIBRATION
+        }
 
 
 @dataclass

--- a/src/qibolab/instruments/qm/ports.py
+++ b/src/qibolab/instruments/qm/ports.py
@@ -159,9 +159,8 @@ class OctaveOutput(QMOutput):
         Digital markers are used to switch LOs on in triggered mode.
         """
         opx = self.opx_port.i.device
-        return {
-            "output_switch": {"port": (opx, self.number)} | DIGITAL_PULSE_CALIBRATION
-        }
+        number = self.opx_port.i.number
+        return {"output_switch": {"port": (opx, number)} | DIGITAL_PULSE_CALIBRATION}
 
 
 @dataclass

--- a/tests/test_instruments_qm.py
+++ b/tests/test_instruments_qm.py
@@ -160,6 +160,7 @@ def test_qm_register_port(qmcontroller, offset):
         "con1": {
             "analog_inputs": {1: {}, 2: {}},
             "analog_outputs": {1: {"offset": offset, "filter": {}}},
+            "digital_outputs": {},
         }
     }
 
@@ -179,6 +180,7 @@ def test_qm_register_port_filter(qmcontroller):
                     "offset": 0.005,
                 }
             },
+            "digital_outputs": {},
         }
     }
 
@@ -234,6 +236,9 @@ def test_qm_register_drive_element(qmplatform):
     else:
         target_element = {
             "RF_inputs": {"port": ("octave3", 1)},
+            "digitalInputs": {
+                "output_switch": {"buffer": 18, "delay": 57, "port": ("con3", 1)}
+            },
             "intermediate_frequency": 1000000,
             "operations": {},
         }
@@ -278,6 +283,9 @@ def test_qm_register_readout_element(qmplatform):
         target_element = {
             "RF_inputs": {"port": ("octave2", 5)},
             "RF_outputs": {"port": ("octave2", 1)},
+            "digitalInputs": {
+                "output_switch": {"buffer": 18, "delay": 57, "port": ("con2", 9)}
+            },
             "intermediate_frequency": 1000000,
             "operations": {},
             "time_of_flight": 280,
@@ -296,6 +304,7 @@ def test_qm_register_pulse(qmplatform, pulse_type, qubit):
         target_pulse = {
             "operation": "control",
             "length": pulse.duration,
+            "digital_marker": "ON",
             "waveforms": {
                 "I": pulse.envelope_waveform_i().serial,
                 "Q": pulse.envelope_waveform_q().serial,


### PR DESCRIPTION
We found that using the `always_on` mode leaves the LOs on even after execution. This may cause issues related to LO leakage, if the mixers are not calibrated and the LO gain is very high.
Using the `triggered` mode allows the LO signal to pass only when something is playing in the corresponding port, by sending a simultaneous digital trigger.

I have done some quick tests with qw5q_platinum and this seems to maintain results. I have not confirmed whether the LOs are really turned off.