### PR TITLE
Fix the hotfix: Single unsplit section

### DIFF
--- a/src/qibolab/instruments/zhinst/executor.py
+++ b/src/qibolab/instruments/zhinst/executor.py
@@ -565,6 +565,7 @@ class Zurich(Controller):
         with exp.section(uid="unsplit_channels"):
             for ch in self.unsplit_channels:
                 for pulse in self.sequence[ch]:
+                    exp.delay(signal=ch, time=pulse.pulse.start)
                     self.play_sweep(exp, ch, pulse)
 
         weights = {}

--- a/src/qibolab/instruments/zhinst/executor.py
+++ b/src/qibolab/instruments/zhinst/executor.py
@@ -562,8 +562,8 @@ class Zurich(Controller):
     def select_exp(self, exp, qubits, exp_options):
         """Build Zurich Experiment selecting the relevant sections."""
         # channels that were not split are just applied in parallel to the rest of the experiment
-        for ch in self.unsplit_channels:
-            with exp.section(uid="unsplit_channels"):
+        with exp.section(uid="unsplit_channels"):
+            for ch in self.unsplit_channels:
                 for pulse in self.sequence[ch]:
                     self.play_sweep(exp, ch, pulse)
 


### PR DESCRIPTION
https://github.com/qiboteam/qibolab/pull/848 introduced the section for unsplit channels, but it would face issues if a single experiment applies long flux pulses on multiple places (e.g. on qubit and coupler flux channels). The issue being the non-uniqueness of the section name. All unsplit channels should just constitute a single section. Additionally, the pulse start time is accounted for as well, although there is no known use case for it.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
