### PR TITLE
Hotfix for minus sign in DRAG shape

### DIFF
--- a/src/qibolab/pulses.py
+++ b/src/qibolab/pulses.py
@@ -218,7 +218,7 @@ class PulseShape(ABC):
         shape_name = re.findall(r"(\w+)", value)[0]
         if shape_name not in globals():
             raise ValueError(f"shape {value} not found")
-        shape_parameters = re.findall(r"[\w+\d\.\d]+", value)[1:]
+        shape_parameters = re.findall(r"[-\w+\d\.\d]+", value)[1:]
         # TODO: create multiple tests to prove regex working correctly
         return globals()[shape_name](*shape_parameters)
 

--- a/tests/test_pulses.py
+++ b/tests/test_pulses.py
@@ -275,10 +275,16 @@ def test_pulses_pulseshape_sampling_rate(shape):
 def test_pulseshape_eval():
     shape = PulseShape.eval("Rectangular()")
     assert isinstance(shape, Rectangular)
-    shape = PulseShape.eval("Drag(5, 1)")
-    assert isinstance(shape, Drag)
     with pytest.raises(ValueError):
         shape = PulseShape.eval("Ciao()")
+
+
+@pytest.mark.parametrize("rel_sigma,beta", [(5, 1), (5, -1), (3, -0.03), (4, 0.02)])
+def test_drag_shape_eval(rel_sigma, beta):
+    shape = PulseShape.eval(f"Drag({rel_sigma}, {beta})")
+    assert isinstance(shape, Drag)
+    assert shape.rel_sigma == rel_sigma
+    assert shape.beta == beta
 
 
 def test_raise_shapeiniterror():


### PR DESCRIPTION
Fixes #826. We were originally planning to postpone this to 0.2, where it is automatically fixed, however since it is relevant for some experiments done now (see https://github.com/qiboteam/qibocal/pull/689#issuecomment-2041002106) and the fix was easy, it would be good to merge it now.

I repeated the experiments from https://github.com/qiboteam/qibocal/pull/689#pullrequestreview-1982457594 using Sergi's runcards from the reports uploaded in that comment before and after DRAG calibration. Here are my reports after the sign correction:

Before: http://login.qrccluster.com:9000/2LXRRtnlTV-dnJXpxoN7BQ==
After: http://login.qrccluster.com:9000/Ov8k7evxSfuy7GburXvBiQ==

The difference is small, but I believe DRAG now works more consistently over all qubits (in contrast to before that was only working for qubit 0 for which beta > 0). @igres26 @andrea-pasquale you can also confirm if you like.

(@alecandido maybe you can double check the fix - it is only one line but it's in regex which, as you know, is my favorite!)