### PR TITLE
Remove `FluxPulse` from serialization PR

### DIFF
--- a/src/qibolab/dummy/parameters.json
+++ b/src/qibolab/dummy/parameters.json
@@ -173,6 +173,7 @@
             "rel_sigma": 5,
             "width": 0.75
           },
+          "frequency": 0,
           "type": "cf"
         }
       },
@@ -185,6 +186,7 @@
             "rel_sigma": 5,
             "width": 0.75
           },
+          "frequency": 0,
           "type": "cf"
         }
       },
@@ -197,6 +199,7 @@
             "rel_sigma": 5,
             "width": 0.75
           },
+          "frequency": 0,
           "type": "cf"
         }
       },
@@ -209,6 +212,7 @@
             "rel_sigma": 5,
             "width": 0.75
           },
+          "frequency": 0,
           "type": "cf"
         }
       }
@@ -225,6 +229,7 @@
               "width": 0.75
             },
             "qubit": 2,
+            "frequency": 0,
             "type": "qf"
           },
           {
@@ -246,6 +251,7 @@
               "width": 0.75
             },
             "coupler": 0,
+            "frequency": 0,
             "type": "cf"
           }
         ],
@@ -259,6 +265,7 @@
               "width": 0.75
             },
             "qubit": 2,
+            "frequency": 0,
             "type": "qf"
           },
           {
@@ -280,6 +287,7 @@
               "width": 0.75
             },
             "coupler": 0,
+            "frequency": 0,
             "type": "cf"
           }
         ]
@@ -295,6 +303,7 @@
               "width": 0.75
             },
             "qubit": 2,
+            "frequency": 0,
             "type": "qf"
           },
           {
@@ -316,6 +325,7 @@
               "width": 0.75
             },
             "coupler": 1,
+            "frequency": 0,
             "type": "cf"
           }
         ],
@@ -329,6 +339,7 @@
               "width": 0.75
             },
             "qubit": 2,
+            "frequency": 0,
             "type": "qf"
           },
           {
@@ -350,6 +361,7 @@
               "width": 0.75
             },
             "coupler": 1,
+            "frequency": 0,
             "type": "cf"
           }
         ]
@@ -365,6 +377,7 @@
               "width": 0.75
             },
             "qubit": 2,
+            "frequency": 0,
             "type": "qf"
           },
           {
@@ -386,6 +399,7 @@
               "width": 0.75
             },
             "coupler": 3,
+            "frequency": 0,
             "type": "cf"
           }
         ],
@@ -399,6 +413,7 @@
               "width": 0.75
             },
             "qubit": 2,
+            "frequency": 0,
             "type": "qf"
           },
           {
@@ -420,6 +435,7 @@
               "width": 0.75
             },
             "coupler": 3,
+            "frequency": 0,
             "type": "cf"
           }
         ],
@@ -455,6 +471,7 @@
               "width": 0.75
             },
             "qubit": 2,
+            "frequency": 0,
             "type": "qf"
           },
           {
@@ -476,6 +493,7 @@
               "width": 0.75
             },
             "coupler": 4,
+            "frequency": 0,
             "type": "cf"
           }
         ],
@@ -489,6 +507,7 @@
               "width": 0.75
             },
             "qubit": 2,
+            "frequency": 0,
             "type": "qf"
           },
           {
@@ -510,6 +529,7 @@
               "width": 0.75
             },
             "coupler": 4,
+            "frequency": 0,
             "type": "cf"
           }
         ]

--- a/src/qibolab/pulses/pulse.py
+++ b/src/qibolab/pulses/pulse.py
@@ -119,12 +119,6 @@ class Pulse(Model):
         )
 
 
-class FluxPulse(Pulse):
-    frequency: float = 0.0
-    relative_phase: float = 0.0
-    type: PulseType = PulseType.FLUX
-
-
 class Delay(Model):
     """A wait instruction during which we are not sending any pulses to the
     QPU."""
@@ -154,4 +148,4 @@ class VirtualZ(Model):
         return 0
 
 
-PulseLike = Union[Pulse, FluxPulse, Delay, VirtualZ]
+PulseLike = Union[Pulse, Delay, VirtualZ]

--- a/src/qibolab/serialize.py
+++ b/src/qibolab/serialize.py
@@ -182,8 +182,6 @@ def load_instrument_settings(
 
 def _dump_pulse(pulse: Pulse):
     data = pulse.model_dump()
-    if pulse.type in (PulseType.FLUX, PulseType.COUPLERFLUX):
-        del data["frequency"]
     data["type"] = data["type"].value
     if "channel" in data:
         del data["channel"]

--- a/tests/dummy_qrc/qblox/parameters.json
+++ b/tests/dummy_qrc/qblox/parameters.json
@@ -208,6 +208,7 @@
               "g": 0.1
             },
             "qubit": 3,
+            "frequency": 0,
             "type": "qf"
           },
           {
@@ -234,6 +235,7 @@
               "g": 0.1
             },
             "qubit": 2,
+            "frequency": 0,
             "type": "qf"
           }
         ]
@@ -250,6 +252,7 @@
               "g": 0.1
             },
             "qubit": 2,
+            "frequency": 0,
             "type": "qf"
           },
           {

--- a/tests/dummy_qrc/qm/parameters.json
+++ b/tests/dummy_qrc/qm/parameters.json
@@ -184,6 +184,7 @@
             "amplitude": 0.055,
             "envelope": { "kind": "rectangular" },
             "qubit": 2,
+            "frequency": 0,
             "type": "qf"
           },
           {
@@ -205,6 +206,7 @@
             "amplitude": -0.0513,
             "envelope": { "kind": "rectangular" },
             "qubit": 3,
+            "frequency": 0,
             "type": "qf"
           },
           {

--- a/tests/dummy_qrc/qm_octave/parameters.json
+++ b/tests/dummy_qrc/qm_octave/parameters.json
@@ -206,6 +206,7 @@
             "amplitude": 0.055,
             "envelope": { "kind": "rectangular" },
             "qubit": 2,
+            "frequency": 0,
             "type": "qf"
           },
           {
@@ -227,6 +228,7 @@
             "amplitude": -0.0513,
             "envelope": { "kind": "rectangular" },
             "qubit": 3,
+            "frequency": 0,
             "type": "qf"
           },
           {

--- a/tests/dummy_qrc/zurich/parameters.json
+++ b/tests/dummy_qrc/zurich/parameters.json
@@ -157,6 +157,7 @@
           "type": "cf",
           "duration": 1000,
           "amplitude": 0.5,
+          "frequency": 0,
           "envelope": { "kind": "rectangular" }
         }
       },
@@ -165,6 +166,7 @@
           "type": "cf",
           "duration": 1000,
           "amplitude": 0.5,
+          "frequency": 0,
           "envelope": { "kind": "rectangular" }
         }
       },
@@ -173,6 +175,7 @@
           "type": "cf",
           "duration": 1000,
           "amplitude": 0.5,
+          "frequency": 0,
           "envelope": { "kind": "rectangular" }
         }
       },
@@ -181,6 +184,7 @@
           "type": "cf",
           "duration": 1000,
           "amplitude": 0.5,
+          "frequency": 0,
           "envelope": { "kind": "rectangular" }
         }
       }
@@ -198,6 +202,7 @@
               "g": 0.1
             },
             "qubit": 3,
+            "frequency": 0,
             "type": "qf"
           },
           {


### PR DESCRIPTION
Addresses https://github.com/qiboteam/qibolab/pull/870#discussion_r1576109435.

Of course the platforms in qibolab_platforms_qrc also need to be updated, but these are already broken in 0.2 for other reasons, so I wouldn't bother for now. We will update them anyway when 0.2 is ready.