### PR TITLE
Minor adjustments in result objects

### DIFF
--- a/src/qibolab/result.py
+++ b/src/qibolab/result.py
@@ -84,13 +84,18 @@ class AveragedIntegratedResults(IntegratedResults):
 
     @property
     def average(self):
-        """Perform average over i and q."""
+        """Average on AveragedIntegratedResults is itself."""
         return self
 
     @cached_property
     def phase_std(self):
-        """Signal phase in radians."""
+        """Standard deviation is None for AveragedIntegratedResults."""
         return None
+
+    @cached_property
+    def phase(self):
+        """Phase not unwrapped because it is a single value."""
+        return np.arctan2(self.voltage_i, self.voltage_q)
 
 
 class RawWaveformResults(IntegratedResults):

--- a/src/qibolab/result.py
+++ b/src/qibolab/result.py
@@ -40,6 +40,11 @@ class IntegratedResults:
         """Signal phase in radians."""
         return np.angle(self.voltage_i + 1.0j * self.voltage_q)
 
+    @cached_property
+    def phase_std(self):
+        """Signal phase in radians."""
+        return np.std(self.phase, axis=0, ddof=1) / np.sqrt(self.phase.shape[0])
+
     @property
     def serialize(self):
         """Serialize as a dictionary."""
@@ -76,6 +81,16 @@ class AveragedIntegratedResults(IntegratedResults):
         new_res = super().__add__(data)
         new_res.std = np.append(self.std, data.std)
         return new_res
+
+    @property
+    def average(self):
+        """Perform average over i and q."""
+        return self
+
+    @cached_property
+    def phase_std(self):
+        """Signal phase in radians."""
+        return np.array([])
 
 
 class RawWaveformResults(IntegratedResults):

--- a/src/qibolab/result.py
+++ b/src/qibolab/result.py
@@ -73,7 +73,7 @@ class AveragedIntegratedResults(IntegratedResults):
     or the averages of ``IntegratedResults``
     """
 
-    def __init__(self, data: np.ndarray, std: np.ndarray = np.array([])):
+    def __init__(self, data: np.ndarray, std: Optional[np.ndarray] = None):
         super().__init__(data)
         self.std: Optional[npt.NDArray[np.float64]] = std
 
@@ -90,7 +90,7 @@ class AveragedIntegratedResults(IntegratedResults):
     @cached_property
     def phase_std(self):
         """Signal phase in radians."""
-        return np.array([])
+        return None
 
 
 class RawWaveformResults(IntegratedResults):

--- a/src/qibolab/result.py
+++ b/src/qibolab/result.py
@@ -38,7 +38,7 @@ class IntegratedResults:
     @cached_property
     def phase(self):
         """Signal phase in radians."""
-        return np.angle(self.voltage_i + 1.0j * self.voltage_q)
+        return np.unwrap(np.angle(self.voltage_i + 1.0j * self.voltage_q))
 
     @cached_property
     def phase_std(self):

--- a/src/qibolab/result.py
+++ b/src/qibolab/result.py
@@ -38,7 +38,7 @@ class IntegratedResults:
     @cached_property
     def phase(self):
         """Signal phase in radians."""
-        return np.unwrap(np.angle(self.voltage_i + 1.0j * self.voltage_q))
+        return np.unwrap(np.arctan2(self.voltage_i, self.voltage_q))
 
     @cached_property
     def phase_std(self):

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -71,7 +71,7 @@ def test_integrated_result_properties(result):
         np.sqrt(results.voltage_i**2 + results.voltage_q**2), results.magnitude
     )
     np.testing.assert_equal(
-        np.angle(results.voltage_i + 1.0j * results.voltage_q), results.phase
+        np.unwrap(np.arctan2(results.voltage_i, results.voltage_q)), results.phase
     )
 
 
@@ -119,7 +119,7 @@ def test_serialize(average, result):
             "MSR[V]": np.sqrt(avg.voltage_i**2 + avg.voltage_q**2),
             "i[V]": avg.voltage_i,
             "q[V]": avg.voltage_q,
-            "phase[rad]": np.angle(avg.voltage_i + 1.0j * avg.voltage_q),
+            "phase[rad]": np.unwrap(np.arctan2(avg.voltage_i, avg.voltage_q)),
         }
         assert avg.serialize.keys() == target_dict.keys()
         for key in output:
@@ -155,7 +155,7 @@ def test_serialize_averaged_iq_results(result):
         "MSR[V]": np.sqrt(results.voltage_i**2 + results.voltage_q**2),
         "i[V]": results.voltage_i,
         "q[V]": results.voltage_q,
-        "phase[rad]": np.angle(results.voltage_i + 1.0j * results.voltage_q),
+        "phase[rad]": np.unwrap(np.arctan2(results.voltage_i, results.voltage_q)),
     }
     assert output.keys() == target_dict.keys()
     for key in output:


### PR DESCRIPTION
Required by https://github.com/qiboteam/qibocal/pull/832
This PR "corrects" the `average` property of `AveragedIntegratedResults` by returning the object itself without performing the average again.
I've also added the property `phase_std` which is useful for qibocal (if you think that it is not necessary I can always drop it and do it directly in qibocal).
I'm keeping it as draft to account for any possible changes in https://github.com/qiboteam/qibocal/pull/832

EDIT: I've also implemented #897 here.
Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
