### PR TITLE
Collect frequencies before processing sweeps

### DIFF
--- a/src/qibolab/instruments/zhinst/executor.py
+++ b/src/qibolab/instruments/zhinst/executor.py
@@ -702,9 +702,9 @@ class Zurich(Controller):
         """Play pulse and sweepers sequence."""
 
         self.signal_map = {}
+        self.frequency_from_pulses(qubits, sequence)
         self.processed_sweeps = ProcessedSweeps(sweepers, qubits)
         self.nt_sweeps, self.rt_sweeps = classify_sweepers(sweepers)
-        self.frequency_from_pulses(qubits, sequence)
 
         self.acquisition_type = None
         for sweeper in sweepers:


### PR DESCRIPTION
Processed sweeps uses frequency from characterization section. This leads to inconsistency when user updates the frequency of native pulse, but does not update the characterization section (e.g. readout_frequency). This change fixes this inconsistency.  

All of this is being removed for 0.2 release (https://github.com/qiboteam/qibolab/pull/885). This fix is needed for short term, before the realease.


Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
