### PR TITLE
Add support for multiple platform paths

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,7 +43,7 @@
 
           modules = [
             {
-              packages = with pkgs; [pre-commit poethepoet jupyter stdenv.cc.cc.lib zlib];
+              packages = with pkgs; [pre-commit poethepoet jupyter];
 
               env.QIBOLAB_PLATFORMS = platforms;
 

--- a/src/qibolab/__init__.py
+++ b/src/qibolab/__init__.py
@@ -27,7 +27,6 @@ __all__ = [
 ]
 
 PLATFORMS = "QIBOLAB_PLATFORMS"
-_SEPARATOR = ":"
 
 
 def _platforms_paths() -> list[Path]:
@@ -39,7 +38,7 @@ def _platforms_paths() -> list[Path]:
     if paths is None:
         raise_error(RuntimeError, f"Platforms path ${PLATFORMS} unset.")
 
-    return [Path(p) for p in paths.split(_SEPARATOR)]
+    return [Path(p) for p in paths.split(os.pathsep)]
 
 
 def _search(name: str, paths: list[Path]) -> Path:

--- a/src/qibolab/__init__.py
+++ b/src/qibolab/__init__.py
@@ -1,20 +1,7 @@
-import importlib.metadata as im
-import importlib.util
-import os
-from pathlib import Path
-
-from qibo import Circuit
-from qibo.config import raise_error
-
-from qibolab.execution_parameters import (
-    AcquisitionType,
-    AveragingMode,
-    ExecutionParameters,
-)
-from qibolab.platform import Platform
-from qibolab.serialize import PLATFORM
-
-__version__ = im.version(__package__)
+from .backends import MetaBackend, QibolabBackend, execute_qasm
+from .execution_parameters import AcquisitionType, AveragingMode, ExecutionParameters
+from .platform import Platform, create_platform
+from .version import __version__
 
 __all__ = [
     "AcquisitionType",
@@ -22,114 +9,8 @@ __all__ = [
     "ExecutionParameters",
     "MetaBackend",
     "Platform",
+    "QibolabBackend",
     "create_platform",
     "execute_qasm",
+    "__version__",
 ]
-
-PLATFORMS = "QIBOLAB_PLATFORMS"
-
-
-def _platforms_paths() -> list[Path]:
-    """Get path to repository containing the platforms.
-
-    Path is specified using the environment variable QIBOLAB_PLATFORMS.
-    """
-    paths = os.environ.get(PLATFORMS)
-    if paths is None:
-        raise_error(RuntimeError, f"Platforms path ${PLATFORMS} unset.")
-
-    return [Path(p) for p in paths.split(os.pathsep)]
-
-
-def _search(name: str, paths: list[Path]) -> Path:
-    """Search paths for given platform name."""
-    for path in _platforms_paths():
-        platform = path / name
-        if platform.exists():
-            return platform
-
-    raise_error(
-        ValueError,
-        f"Platform {name} not found. Check ${PLATFORMS} environment variable.",
-    )
-
-
-def _load(platform: Path) -> Platform:
-    """Load the platform module."""
-    module_name = "platform"
-    spec = importlib.util.spec_from_file_location(module_name, platform / PLATFORM)
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module.create()
-
-
-def create_platform(name: str) -> Platform:
-    """A platform for executing quantum algorithms.
-
-    It consists of a quantum processor QPU and a set of controlling instruments.
-
-    Args:
-        name (str): name of the platform. Options are 'tiiq', 'qili' and 'icarusq'.
-        path (pathlib.Path): path with platform serialization
-    Returns:
-        The plaform class.
-    """
-    if name == "dummy" or name == "dummy_couplers":
-        from qibolab.dummy import create_dummy
-
-        return create_dummy(with_couplers=name == "dummy_couplers")
-
-    return _load(_search(name, _platforms_paths()))
-
-
-def execute_qasm(circuit: str, platform, initial_state=None, nshots=1000):
-    """Executes a QASM circuit.
-
-    Args:
-        circuit (str): the QASM circuit.
-        platform (str): the platform where to execute the circuit.
-        initial_state (:class:`qibo.models.circuit.Circuit`): Circuit to prepare the initial state.
-                If ``None`` the default ``|00...0>`` state is used.
-        nshots (int): Number of shots to sample from the experiment.
-
-    Returns:
-        ``MeasurementOutcomes`` object containing the results acquired from the execution.
-    """
-    from qibolab.backends import QibolabBackend
-
-    circuit = Circuit.from_qasm(circuit)
-    return QibolabBackend(platform).execute_circuit(
-        circuit, initial_state=initial_state, nshots=nshots
-    )
-
-
-def _available_platforms() -> list[str]:
-    """Returns the platforms found in the $QIBOLAB_PLATFORMS directory."""
-    return [
-        d.name
-        for platforms in _platforms_paths()
-        for d in platforms.iterdir()
-        if d.is_dir()
-        and Path(f"{os.environ.get(PLATFORMS)}/{d.name}/platform.py") in d.iterdir()
-    ]
-
-
-class MetaBackend:
-    """Meta-backend class which takes care of loading the qibolab backend."""
-
-    @staticmethod
-    def load(platform: str):
-        """Loads the backend.
-
-        Args:
-            platform (str): Name of the platform to load.
-        Returns:
-            qibo.backends.abstract.Backend: The loaded backend.
-        """
-        from qibolab.backends import QibolabBackend
-
-        return QibolabBackend(platform=platform)
-
-    def list_available(self) -> dict:
-        """Lists all the available qibolab platforms."""
-        return {platform: True for platform in _available_platforms()}

--- a/src/qibolab/__init__.py
+++ b/src/qibolab/__init__.py
@@ -108,7 +108,8 @@ def _available_platforms() -> list[str]:
     """Returns the platforms found in the $QIBOLAB_PLATFORMS directory."""
     return [
         d.name
-        for d in _platforms_paths().iterdir()
+        for platforms in _platforms_paths()
+        for d in platforms.iterdir()
         if d.is_dir()
         and Path(f"{os.environ.get(PLATFORMS)}/{d.name}/platform.py") in d.iterdir()
     ]

--- a/src/qibolab/instruments/dummy.py
+++ b/src/qibolab/instruments/dummy.py
@@ -4,10 +4,14 @@ from typing import Dict, List, Optional
 import numpy as np
 from qibo.config import log
 
-from qibolab import AcquisitionType, AveragingMode, ExecutionParameters
-from qibolab.platform import Coupler, Qubit
+from qibolab.couplers import Coupler
+from qibolab.execution_parameters import (
+    AcquisitionType,
+    AveragingMode,
+    ExecutionParameters,
+)
 from qibolab.pulses import PulseSequence
-from qibolab.qubits import QubitId
+from qibolab.qubits import Qubit, QubitId
 from qibolab.sweeper import Sweeper
 from qibolab.unrolling import Bounds
 

--- a/src/qibolab/instruments/rfsoc/convert.py
+++ b/src/qibolab/instruments/rfsoc/convert.py
@@ -7,8 +7,8 @@ import numpy as np
 import qibosoq.components.base as rfsoc
 import qibosoq.components.pulses as rfsoc_pulses
 
-from qibolab.platform import Qubit
 from qibolab.pulses import Pulse, PulseSequence, PulseShape
+from qibolab.qubits import Qubit
 from qibolab.sweeper import BIAS, DURATION, START, Parameter, Sweeper
 
 HZ_TO_MHZ = 1e-6

--- a/src/qibolab/instruments/rfsoc/driver.py
+++ b/src/qibolab/instruments/rfsoc/driver.py
@@ -11,10 +11,11 @@ from qibo.config import log
 from qibosoq import client
 
 from qibolab import AcquisitionType, AveragingMode, ExecutionParameters
+from qibolab.couplers import Coupler
 from qibolab.instruments.abstract import Controller
 from qibolab.instruments.port import Port
-from qibolab.platform import Coupler, Qubit
 from qibolab.pulses import PulseSequence, PulseType
+from qibolab.qubits import Qubit
 from qibolab.result import IntegratedResults, SampleResults
 from qibolab.sweeper import BIAS, Sweeper
 

--- a/src/qibolab/platform/__init__.py
+++ b/src/qibolab/platform/__init__.py
@@ -1,0 +1,4 @@
+from .load import create_platform
+from .platform import Platform, unroll_sequences
+
+__all__ = ["Platform", "create_platform", "unroll_sequences"]

--- a/src/qibolab/platform/load.py
+++ b/src/qibolab/platform/load.py
@@ -1,0 +1,75 @@
+import importlib.util
+import os
+from pathlib import Path
+
+from qibo.config import raise_error
+
+from qibolab.serialize import PLATFORM
+
+from .platform import Platform
+
+PLATFORMS = "QIBOLAB_PLATFORMS"
+
+
+def _platforms_paths() -> list[Path]:
+    """Get path to repository containing the platforms.
+
+    Path is specified using the environment variable QIBOLAB_PLATFORMS.
+    """
+    paths = os.environ.get(PLATFORMS)
+    if paths is None:
+        raise_error(RuntimeError, f"Platforms path ${PLATFORMS} unset.")
+
+    return [Path(p) for p in paths.split(os.pathsep)]
+
+
+def _search(name: str, paths: list[Path]) -> Path:
+    """Search paths for given platform name."""
+    for path in _platforms_paths():
+        platform = path / name
+        if platform.exists():
+            return platform
+
+    raise_error(
+        ValueError,
+        f"Platform {name} not found. Check ${PLATFORMS} environment variable.",
+    )
+
+
+def _load(platform: Path) -> Platform:
+    """Load the platform module."""
+    module_name = "platform"
+    spec = importlib.util.spec_from_file_location(module_name, platform / PLATFORM)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.create()
+
+
+def create_platform(name: str) -> Platform:
+    """A platform for executing quantum algorithms.
+
+    It consists of a quantum processor QPU and a set of controlling instruments.
+
+    Args:
+        name (str): name of the platform. Options are 'tiiq', 'qili' and 'icarusq'.
+        path (pathlib.Path): path with platform serialization
+    Returns:
+        The plaform class.
+    """
+    if name == "dummy" or name == "dummy_couplers":
+        from qibolab.dummy import create_dummy
+
+        return create_dummy(with_couplers=name == "dummy_couplers")
+
+    return _load(_search(name, _platforms_paths()))
+
+
+def available_platforms() -> list[str]:
+    """Returns the platforms found in the $QIBOLAB_PLATFORMS directory."""
+    return [
+        d.name
+        for platforms in _platforms_paths()
+        for d in platforms.iterdir()
+        if d.is_dir()
+        and Path(f"{os.environ.get(PLATFORMS)}/{d.name}/platform.py") in d.iterdir()
+    ]

--- a/src/qibolab/platform/platform.py
+++ b/src/qibolab/platform/platform.py
@@ -7,13 +7,13 @@ from typing import Dict, List, Optional, Tuple
 import networkx as nx
 from qibo.config import log, raise_error
 
-from .couplers import Coupler
-from .execution_parameters import ExecutionParameters
-from .instruments.abstract import Controller, Instrument, InstrumentId
-from .pulses import Drag, FluxPulse, PulseSequence, ReadoutPulse
-from .qubits import Qubit, QubitId, QubitPair, QubitPairId
-from .sweeper import Sweeper
-from .unrolling import batch
+from qibolab.couplers import Coupler
+from qibolab.execution_parameters import ExecutionParameters
+from qibolab.instruments.abstract import Controller, Instrument, InstrumentId
+from qibolab.pulses import Drag, FluxPulse, PulseSequence, ReadoutPulse
+from qibolab.qubits import Qubit, QubitId, QubitPair, QubitPairId
+from qibolab.sweeper import Sweeper
+from qibolab.unrolling import batch
 
 InstrumentMap = Dict[InstrumentId, Instrument]
 QubitMap = Dict[QubitId, Qubit]

--- a/src/qibolab/serialize.py
+++ b/src/qibolab/serialize.py
@@ -13,7 +13,7 @@ from typing import Tuple
 from qibolab.couplers import Coupler
 from qibolab.kernels import Kernels
 from qibolab.native import CouplerNatives, SingleQubitNatives, TwoQubitNatives
-from qibolab.platform import (
+from qibolab.platform.platform import (
     CouplerMap,
     InstrumentMap,
     Platform,

--- a/src/qibolab/version.py
+++ b/src/qibolab/version.py
@@ -1,0 +1,3 @@
+import importlib.metadata as im
+
+__version__ = im.version(__package__)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,8 @@ import pathlib
 
 import pytest
 
-from qibolab import PLATFORMS, create_platform
+from qibolab.platform import create_platform
+from qibolab.platform.load import PLATFORMS
 
 ORIGINAL_PLATFORMS = os.environ.get(PLATFORMS, "")
 TESTING_PLATFORM_NAMES = [

--- a/tests/test_instruments_rfsoc.py
+++ b/tests/test_instruments_rfsoc.py
@@ -14,8 +14,8 @@ from qibolab.instruments.rfsoc.convert import (
     convert_units_sweeper,
     replace_pulse_shape,
 )
-from qibolab.platform import Qubit
 from qibolab.pulses import Drag, Gaussian, Pulse, PulseSequence, PulseType, Rectangular
+from qibolab.qubits import Qubit
 from qibolab.result import (
     AveragedIntegratedResults,
     AveragedSampleResults,

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -81,16 +81,19 @@ def test_create_platform_multipath(tmp_path: Path):
                 from qibolab.platform import Platform
 
                 def create():
-                    return Platform("{p}", {{}}, {{}}, {{}})
+                    return Platform("{p.parent.name}-{p.name}", {{}}, {{}}, {{}})
                 """
             )
         )
 
     os.environ[PLATFORMS] = f"{some}{os.pathsep}{others}"
 
-    assert Path(create_platform("platform0").name).relative_to(some)
-    assert Path(create_platform("platform1").name).relative_to(some)
-    assert Path(create_platform("platform2").name).relative_to(others)
+    def path(name):
+        return tmp_path / Path(create_platform(name).name.replace("-", os.sep))
+
+    assert path("platform0").relative_to(some)
+    assert path("platform1").relative_to(some)
+    assert path("platform2").relative_to(others)
     with pytest.raises(ValueError):
         create_platform("platform3")
 

--- a/tests/test_sweeper.py
+++ b/tests/test_sweeper.py
@@ -1,8 +1,8 @@
 import numpy as np
 import pytest
 
-from qibolab.platform import Qubit
 from qibolab.pulses import Pulse, Rectangular
+from qibolab.qubits import Qubit
 from qibolab.sweeper import Parameter, QubitParameter, Sweeper
 
 


### PR DESCRIPTION
This is mainly an extension of the platform loading feature that I had in mind since long (i.e. just treat `$QIBOLAB_PLATFORMS` as most of the other `$PATH`-like variables, with multiple paths and fallback).

I started implementing this as a service for #849, to have both `dummy_qrc` and `emulators` in scope. However, I doubt it will be useful there, since I will just implement a separate fixture for that (though I could convert `dummy_qrc` to a more generic `platforms` fixture, up for voting).

In the process, I started narrowing the exports of Qibolab, since I was already touching `__init__.py`. More or less going in the direction of #790.

Ok, this is usually not a great idea, and I'm already kind of regretting...
I hope that is not breaking anything (things not listed in `__all__` are exported by accident, and should not be used), but I might split it anyhow...