### PR TITLE
Add MZ1 pulse

### DIFF
--- a/src/qibolab/dummy/parameters.json
+++ b/src/qibolab/dummy/parameters.json
@@ -77,7 +77,17 @@
                     "relative_start": 0,
                     "phase": 0,
                     "type": "ro"
+                },
+                "MZ1": {
+                    "duration": 2000,
+                    "amplitude": 0.1,
+                    "shape": "GaussianSquare(5, 0)",
+                    "frequency": 1.0,
+                    "relative_start": 0,
+                    "phase": 0,
+                    "type": "ro"
                 }
+
             },
             "1": {
                 "RX": {
@@ -103,6 +113,16 @@
                     "amplitude": 0.1,
                     "shape": "GaussianSquare(5, 0.75)",
                     "frequency": 4900000000.0,
+                    "relative_start": 0,
+                    "phase": 0,
+                    "type": "ro"
+                },
+
+                "MZ1": {
+                    "duration": 2000,
+                    "amplitude": 0.1,
+                    "shape": "GaussianSquare(5, 0)",
+                    "frequency": 1.0,
                     "relative_start": 0,
                     "phase": 0,
                     "type": "ro"
@@ -135,6 +155,15 @@
                     "relative_start": 0,
                     "phase": 0,
                     "type": "ro"
+                },
+                "MZ1": {
+                    "duration": 2000,
+                    "amplitude": 0.1,
+                    "shape": "GaussianSquare(5, 0)",
+                    "frequency": 1.0,
+                    "relative_start": 0,
+                    "phase": 0,
+                    "type": "ro"
                 }
             },
             "3": {
@@ -164,6 +193,15 @@
                     "relative_start": 0,
                     "phase": 0,
                     "type": "ro"
+                },
+                "MZ1": {
+                    "duration": 2000,
+                    "amplitude": 0.1,
+                    "shape": "GaussianSquare(5, 0)",
+                    "frequency": 1.0,
+                    "relative_start": 0,
+                    "phase": 0,
+                    "type": "ro"
                 }
             },
             "4": {
@@ -190,6 +228,15 @@
                     "amplitude": 0.1,
                     "shape": "GaussianSquare(5, 0.75)",
                     "frequency": 5500000000.0,
+                    "relative_start": 0,
+                    "phase": 0,
+                    "type": "ro"
+                },
+                "MZ1": {
+                    "duration": 2000,
+                    "amplitude": 0.1,
+                    "shape": "GaussianSquare(5, 0)",
+                    "frequency": 1.0,
                     "relative_start": 0,
                     "phase": 0,
                     "type": "ro"

--- a/src/qibolab/native.py
+++ b/src/qibolab/native.py
@@ -267,9 +267,8 @@ class SingleQubitNatives:
     MZ: Optional[NativePulse] = None
     """Measurement pulse."""
     MZ1: Optional[NativePulse] = None
-    """Measurement pulse at the frequency of the resonator when the qubit
-    is in the first excited state.
-    """
+    """Measurement pulse at the frequency of the resonator when the qubit is in
+    the first excited state."""
 
     @property
     def RX90(self) -> NativePulse:

--- a/src/qibolab/native.py
+++ b/src/qibolab/native.py
@@ -266,6 +266,8 @@ class SingleQubitNatives:
     """Pulse to drive to qubit from state 1 to state 2."""
     MZ: Optional[NativePulse] = None
     """Measurement pulse."""
+    MZ1: Optional[NativePulse] = None
+    """Measurement pulse."""
 
     @property
     def RX90(self) -> NativePulse:

--- a/src/qibolab/native.py
+++ b/src/qibolab/native.py
@@ -267,7 +267,9 @@ class SingleQubitNatives:
     MZ: Optional[NativePulse] = None
     """Measurement pulse."""
     MZ1: Optional[NativePulse] = None
-    """Measurement pulse."""
+    """Measurement pulse at the frequency of the resonator when the qubit
+    is in the first excited state.
+    """
 
     @property
     def RX90(self) -> NativePulse:

--- a/src/qibolab/platform.py
+++ b/src/qibolab/platform.py
@@ -375,6 +375,10 @@ class Platform:
         qubit = self.get_qubit(qubit)
         return self.qubits[qubit].native_gates.MZ.pulse(start)
 
+    def create_MZ1_pulse(self, qubit, start):
+        qubit = self.get_qubit(qubit)
+        return self.qubits[qubit].native_gates.MZ1.pulse(start)
+
     def create_qubit_drive_pulse(self, qubit, start, duration, relative_phase=0):
         qubit = self.get_qubit(qubit)
         pulse = self.qubits[qubit].native_gates.RX.pulse(start, relative_phase)


### PR DESCRIPTION
This PR implements the readout pulse at the resonator peak when the qubit is in the first excited state.
Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
