### PR TITLE
Add emulator support for fake integrated acquisition

### DIFF
--- a/src/qibolab/instruments/emulator/pulse_simulator.py
+++ b/src/qibolab/instruments/emulator/pulse_simulator.py
@@ -650,26 +650,31 @@ def get_results_from_samples(
                                                     averaging_mode)
 
     Returns:
-        dict: Qibolab results for AcquisitionType.DISCRIMINATION.
+        dict: Qibolab result data.
 
     Raises:
-        ValueError: If execution_parameters.acquisition_type is not AcquisitionType.DISCRIMINATION.
+        ValueError: If execution_parameters.acquisition_type is not supported.
     """
     shape = [execution_parameters.nshots] + append_to_shape
     results = {}
     for ro_pulse in ro_pulse_list:
+        values = np.array(samples[ro_pulse.qubit]).reshape(shape)
+
         if execution_parameters.acquisition_type is AcquisitionType.DISCRIMINATION:
-            values = np.array(samples[ro_pulse.qubit]).reshape(shape)
             processed_values = SampleResults(values)
 
-            if execution_parameters.averaging_mode is AveragingMode.CYCLIC:
-                processed_values = (
-                    processed_values.average
-                )  # generates AveragedSampleResults
+        elif execution_parameters.acquisition_type is AcquisitionType.INTEGRATION:
+            processed_values = IntegratedResults(values.astype(np.complex128))
+
         else:
             raise ValueError(
-                "Current emulator only supports AcquisitionType.DISCRIMINATION!"
+                "Current emulator does not support requested AcquisitionType"
             )
+
+        if execution_parameters.averaging_mode is AveragingMode.CYCLIC:
+            processed_values = (
+                processed_values.average
+            )  # generates AveragedSampleResults
 
         results[ro_pulse.qubit] = results[ro_pulse.serial] = processed_values
     return results


### PR DESCRIPTION
As discussed in the Qibo meeting, I have added the option to use `IntegratedResults` from the results so that we can run other Qibocal routines. I have done some testing for T1 sequences, but because of the sampling rate boost, it takes a long while to complete.

![image](https://github.com/qiboteam/qibolab/assets/26541502/4c1f4870-4ed0-4736-93d8-48fdc3d2152f)


Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
