### PR TITLE
Patch RFSoC result shape

### DIFF
--- a/src/qibolab/instruments/rfsoc/convert.py
+++ b/src/qibolab/instruments/rfsoc/convert.py
@@ -55,8 +55,9 @@ def pulse_lo_frequency(pulse: Pulse, qubits: dict[int, Qubit]) -> int:
 
 def convert_units_sweeper(
     sweeper: rfsoc.Sweeper, sequence: PulseSequence, qubits: dict[int, Qubit]
-):
+) -> rfsoc.Sweeper:
     """Convert units for `qibosoq.abstract.Sweeper` considering also LOs."""
+    sweeper = rfsoc.Sweeper(**asdict(sweeper))
     for idx, jdx in enumerate(sweeper.indexes):
         parameter = sweeper.parameters[idx]
         if parameter is rfsoc.Parameter.FREQUENCY:
@@ -70,6 +71,7 @@ def convert_units_sweeper(
         elif parameter is rfsoc.Parameter.RELATIVE_PHASE:
             sweeper.starts[idx] = np.degrees(sweeper.starts[idx])
             sweeper.stops[idx] = np.degrees(sweeper.stops[idx])
+    return sweeper
 
 
 @singledispatch

--- a/src/qibolab/instruments/rfsoc/convert.py
+++ b/src/qibolab/instruments/rfsoc/convert.py
@@ -1,5 +1,6 @@
 """Convert helper functions for rfsoc driver."""
 
+from copy import deepcopy
 from dataclasses import asdict
 from functools import singledispatch
 
@@ -57,7 +58,7 @@ def convert_units_sweeper(
     sweeper: rfsoc.Sweeper, sequence: PulseSequence, qubits: dict[int, Qubit]
 ) -> rfsoc.Sweeper:
     """Convert units for `qibosoq.abstract.Sweeper` considering also LOs."""
-    sweeper = rfsoc.Sweeper(**asdict(sweeper))
+    sweeper = deepcopy(sweeper)
     for idx, jdx in enumerate(sweeper.indexes):
         parameter = sweeper.parameters[idx]
         if parameter is rfsoc.Parameter.FREQUENCY:

--- a/src/qibolab/instruments/rfsoc/driver.py
+++ b/src/qibolab/instruments/rfsoc/driver.py
@@ -127,14 +127,15 @@ class RFSoC(Controller):
         Returns:
             Lists of I and Q value measured
         """
-        for sweeper in sweepers:
-            convert_units_sweeper(sweeper, sequence, qubits)
+        converted_sweepers = [
+            convert_units_sweeper(sweeper, sequence, qubits) for sweeper in sweepers
+        ]
         server_commands = {
             "operation_code": rfsoc.OperationCode.EXECUTE_SWEEPS,
             "cfg": asdict(self.cfg),
             "sequence": convert(sequence, qubits, self.sampling_rate),
             "qubits": [asdict(convert(qubits[idx])) for idx in qubits],
-            "sweepers": [sweeper.serialized for sweeper in sweepers],
+            "sweepers": [sweeper.serialized for sweeper in converted_sweepers],
         }
         return self._try_to_execute(server_commands, self.host, self.port)
 
@@ -364,9 +365,9 @@ class RFSoC(Controller):
                     if sweeper_parameter is rfsoc.Parameter.DURATION:
                         for pulse_idx in range(
                             kdx + 1,
-                            len(sequence.get_qubit_pulses(qubits[list(qubits)[kdx]])),
+                            len(sequence.get_qubit_pulses(sequence[kdx].qubit)),
                         ):
-                            sequence[pulse_idx].start = sequence[pulse_idx - 1].duration
+                            sequence[pulse_idx].start = sequence[pulse_idx - 1].finish
                 elif sweeper_parameter is rfsoc.Parameter.DELAY:
                     sequence[kdx].start_delay = values[jdx][idx]
 

--- a/src/qibolab/instruments/rfsoc/driver.py
+++ b/src/qibolab/instruments/rfsoc/driver.py
@@ -366,7 +366,20 @@ class RFSoC(Controller):
                 execution_parameters=execution_parameters,
             )
             results = self.merge_sweep_results(results, res)
+        results = self.squeeze_results(results)
         return results  # already in the right format
+
+    def squeeze_results(self, res):
+        new_res = {}
+        for key in res:
+            cls = res[key].__class__
+            data = (
+                res[key].voltage
+                if isinstance(res[key], IntegratedResults)
+                else res[key].samples
+            )
+            new_res[key] = cls(np.squeeze(data))
+        return new_res
 
     @staticmethod
     def merge_sweep_results(

--- a/src/qibolab/instruments/rfsoc/driver.py
+++ b/src/qibolab/instruments/rfsoc/driver.py
@@ -89,6 +89,80 @@ class RFSoC(Controller):
                 log.warning("Buffer full! Use shorter pulses.")
             raise e
 
+    @staticmethod
+    def convert_and_discriminate_samples(discriminated_shots, execution_parameters):
+        if execution_parameters.averaging_mode is AveragingMode.CYCLIC:
+            _, counts = np.unique(discriminated_shots, return_counts=True, axis=0)
+            freqs = counts / discriminated_shots.shape[0]
+            result = execution_parameters.results_type(freqs, discriminated_shots)
+        else:
+            result = execution_parameters.results_type(discriminated_shots)
+        return result
+
+    @staticmethod
+    def validate_input_command(
+        sequence: PulseSequence, execution_parameters: ExecutionParameters, sweep: bool
+    ):
+        """Check if sequence and execution_parameters are supported."""
+        if execution_parameters.acquisition_type is AcquisitionType.RAW:
+            if sweep:
+                raise NotImplementedError(
+                    "Raw data acquisition is not compatible with sweepers"
+                )
+            if len(sequence.ro_pulses) != 1:
+                raise NotImplementedError(
+                    "Raw data acquisition is compatible only with a single readout"
+                )
+            if execution_parameters.averaging_mode is not AveragingMode.CYCLIC:
+                raise NotImplementedError("Raw data acquisition can only be averaged")
+        if execution_parameters.fast_reset:
+            raise NotImplementedError("Fast reset is not supported")
+
+    @staticmethod
+    def merge_sweep_results(
+        dict_a: dict[str, Union[IntegratedResults, SampleResults]],
+        dict_b: dict[str, Union[IntegratedResults, SampleResults]],
+    ) -> dict[str, Union[IntegratedResults, SampleResults]]:
+        """Merge two dictionary mapping pulse serial to Results object.
+
+        If dict_b has a key (serial) that dict_a does not have, simply add it,
+        otherwise sum the two results
+
+        Args:
+            dict_a (dict): dict mapping ro pulses serial to qibolab res objects
+            dict_b (dict): dict mapping ro pulses serial to qibolab res objects
+        Returns:
+            A dict mapping the readout pulses serial to qibolab results objects
+        """
+        for serial in dict_b:
+            if serial in dict_a:
+                data = lambda res: (
+                    res.voltage if isinstance(res, IntegratedResults) else res.samples
+                )
+                dict_a[serial] = type(dict_a[serial])(
+                    np.append(data(dict_a[serial]), data(dict_b[serial]))
+                )
+            else:
+                dict_a[serial] = dict_b[serial]
+        return dict_a
+
+    @staticmethod
+    def reshape_sweep_results(results, sweepers, execution_parameters):
+        shape = [len(sweeper.values) for sweeper in sweepers]
+        if execution_parameters.averaging_mode is not AveragingMode.CYCLIC:
+            shape.insert(0, execution_parameters.nshots)
+
+        def data(value):
+            if isinstance(value, IntegratedResults):
+                data = value.voltage
+            elif isinstance(value, AveragedSampleResults):
+                data = value.statistical_frequency
+            else:
+                data = value.samples
+            return type(value)(data.reshape(shape))
+
+        return {key: data(value) for key, value in results.items()}
+
     def _execute_pulse_sequence(
         self,
         sequence: PulseSequence,
@@ -200,40 +274,14 @@ class RFSoC(Controller):
                     discriminated_shots = self.classify_shots(
                         i_pulse, q_pulse, qubits[ro_pulse.qubit]
                     )
-                    if execution_parameters.averaging_mode is AveragingMode.CYCLIC:
-                        _, counts = np.unique(
-                            discriminated_shots, return_counts=True, axis=0
-                        )
-                        freqs = counts / np.shape(discriminated_shots)[0]
-                        result = execution_parameters.results_type(
-                            freqs, discriminated_shots
-                        )
-                    else:
-                        result = execution_parameters.results_type(discriminated_shots)
+                    result = self.convert_and_discriminate_samples(
+                        discriminated_shots, execution_parameters
+                    )
                 else:
                     result = execution_parameters.results_type(i_pulse + 1j * q_pulse)
                 results[ro_pulse.qubit] = results[ro_pulse.serial] = result
 
         return results
-
-    @staticmethod
-    def validate_input_command(
-        sequence: PulseSequence, execution_parameters: ExecutionParameters, sweep: bool
-    ):
-        """Check if sequence and execution_parameters are supported."""
-        if execution_parameters.acquisition_type is AcquisitionType.RAW:
-            if sweep:
-                raise NotImplementedError(
-                    "Raw data acquisition is not compatible with sweepers"
-                )
-            if len(sequence.ro_pulses) != 1:
-                raise NotImplementedError(
-                    "Raw data acquisition is compatible only with a single readout"
-                )
-            if execution_parameters.averaging_mode is not AveragingMode.CYCLIC:
-                raise NotImplementedError("Raw data acquisition can only be averaged")
-        if execution_parameters.fast_reset:
-            raise NotImplementedError("Fast reset is not supported")
 
     def update_cfg(self, execution_parameters: ExecutionParameters):
         """Update rfsoc.Config object with new parameters."""
@@ -260,7 +308,7 @@ class RFSoC(Controller):
         )
         shots = np.heaviside(np.array(rotated) - threshold, 0)
         if isinstance(shots, float):
-            return [shots]
+            return np.array([shots])
         return shots
 
     def play_sequence_in_sweep_recursion(
@@ -367,6 +415,7 @@ class RFSoC(Controller):
                             kdx + 1,
                             len(sequence.get_qubit_pulses(sequence[kdx].qubit)),
                         ):
+                            # TODO: this is a patch and works just for simple experiments
                             sequence[pulse_idx].start = sequence[pulse_idx - 1].finish
                 elif sweeper_parameter is rfsoc.Parameter.DELAY:
                     sequence[kdx].start_delay = values[jdx][idx]
@@ -381,34 +430,6 @@ class RFSoC(Controller):
             )
             results = self.merge_sweep_results(results, res)
         return results
-
-    @staticmethod
-    def merge_sweep_results(
-        dict_a: dict[str, Union[IntegratedResults, SampleResults]],
-        dict_b: dict[str, Union[IntegratedResults, SampleResults]],
-    ) -> dict[str, Union[IntegratedResults, SampleResults]]:
-        """Merge two dictionary mapping pulse serial to Results object.
-
-        If dict_b has a key (serial) that dict_a does not have, simply add it,
-        otherwise sum the two results
-
-        Args:
-            dict_a (dict): dict mapping ro pulses serial to qibolab res objects
-            dict_b (dict): dict mapping ro pulses serial to qibolab res objects
-        Returns:
-            A dict mapping the readout pulses serial to qibolab results objects
-        """
-        for serial in dict_b:
-            if serial in dict_a:
-                data = lambda res: (
-                    res.voltage if isinstance(res, IntegratedResults) else res.samples
-                )
-                dict_a[serial] = type(dict_a[serial])(
-                    np.append(data(dict_a[serial]), data(dict_b[serial]))
-                )
-            else:
-                dict_a[serial] = dict_b[serial]
-        return dict_a
 
     def get_if_python_sweep(
         self, sequence: PulseSequence, *sweepers: rfsoc.Sweeper
@@ -509,38 +530,15 @@ class RFSoC(Controller):
                 ):
                     qubit = qubits[ro_pulse.qubit]
                     discriminated_shots = self.classify_shots(i_vals, q_vals, qubit)
-                    if execution_parameters.averaging_mode is AveragingMode.CYCLIC:
-                        _, counts = np.unique(
-                            discriminated_shots, return_counts=True, axis=0
-                        )
-                        freqs = counts / np.shape(discriminated_shots)[0]
-                        result = execution_parameters.results_type(
-                            freqs, discriminated_shots
-                        )
-                    else:
-                        result = execution_parameters.results_type(discriminated_shots)
+                    result = self.convert_and_discriminate_samples(
+                        discriminated_shots, execution_parameters
+                    )
 
                 else:
                     result = execution_parameters.results_type(i_vals + 1j * q_vals)
 
                 results[ro_pulse.qubit] = results[ro_pulse.serial] = result
         return results
-
-    @staticmethod
-    def reshape_sweep_results(results, sweepers, execution_parameters):
-        shape = [len(sweeper.values) for sweeper in sweepers]
-        if execution_parameters.averaging_mode is not AveragingMode.CYCLIC:
-            shape.insert(0, execution_parameters.nshots)
-        new_res = {}
-        for key, value in results.items():
-            if isinstance(value, IntegratedResults):
-                data = value.voltage
-            elif isinstance(value, AveragedSampleResults):
-                data = value.statistical_frequency
-            else:
-                data = value.samples
-            new_res[key] = type(value)(data.reshape(shape))
-        return new_res
 
     def sweep(
         self,

--- a/src/qibolab/instruments/rfsoc/driver.py
+++ b/src/qibolab/instruments/rfsoc/driver.py
@@ -24,8 +24,6 @@ from .convert import convert, convert_units_sweeper
 HZ_TO_MHZ = 1e-6
 NS_TO_US = 1e-3
 
-my_count = 0
-
 
 @dataclass
 class RFSoCPort(Port):
@@ -357,7 +355,8 @@ class RFSoC(Controller):
                         sequence[kdx], sweeper_parameter.name.lower(), values[jdx][idx]
                     )
                     if sweeper_parameter is rfsoc.Parameter.DURATION:
-                        sequence[1].start = sequence[0].duration
+                        for pulse_idx in range(kdx + 1, len(sequence)):
+                            sequence[pulse_idx].start = sequence[pulse_idx - 1].duration
                 elif sweeper_parameter is rfsoc.Parameter.DELAY:
                     sequence[kdx].start_delay = values[jdx][idx]
 

--- a/src/qibolab/instruments/rfsoc/driver.py
+++ b/src/qibolab/instruments/rfsoc/driver.py
@@ -362,7 +362,10 @@ class RFSoC(Controller):
                         sequence[kdx], sweeper_parameter.name.lower(), values[jdx][idx]
                     )
                     if sweeper_parameter is rfsoc.Parameter.DURATION:
-                        for pulse_idx in range(kdx + 1, len(sequence)):
+                        for pulse_idx in range(
+                            kdx + 1,
+                            len(sequence.get_qubit_pulses(qubits[list(qubits)[kdx]])),
+                        ):
                             sequence[pulse_idx].start = sequence[pulse_idx - 1].duration
                 elif sweeper_parameter is rfsoc.Parameter.DELAY:
                     sequence[kdx].start_delay = values[jdx][idx]

--- a/tests/test_instruments_rfsoc.py
+++ b/tests/test_instruments_rfsoc.py
@@ -210,7 +210,7 @@ def test_convert_units_sweeper(dummy_qrc):
         stops=[10e6],
         expts=100,
     )
-    convert_units_sweeper(sweeper, seq, platform.qubits)
+    sweeper = convert_units_sweeper(sweeper, seq, platform.qubits)
 
     assert sweeper.starts == [-1]
     assert sweeper.stops == [9]
@@ -223,7 +223,7 @@ def test_convert_units_sweeper(dummy_qrc):
         stops=[10e6],
         expts=100,
     )
-    convert_units_sweeper(sweeper, seq, platform.qubits)
+    sweeper = convert_units_sweeper(sweeper, seq, platform.qubits)
     assert sweeper.starts == [0]
     assert sweeper.stops == [10]
 
@@ -235,7 +235,7 @@ def test_convert_units_sweeper(dummy_qrc):
         stops=[100, 140],
         expts=100,
     )
-    convert_units_sweeper(sweeper, seq, platform.qubits)
+    sweeper = convert_units_sweeper(sweeper, seq, platform.qubits)
     assert (sweeper.starts == [0, 0.04]).all()
     assert (sweeper.stops == [0.1, 0.14]).all()
 
@@ -247,7 +247,7 @@ def test_convert_units_sweeper(dummy_qrc):
         stops=[np.pi],
         expts=180,
     )
-    convert_units_sweeper(sweeper, seq, platform.qubits)
+    sweeper = convert_units_sweeper(sweeper, seq, platform.qubits)
     assert sweeper.starts == [0]
     assert sweeper.stops == [180]
 

--- a/tests/test_instruments_rfsoc.py
+++ b/tests/test_instruments_rfsoc.py
@@ -428,7 +428,10 @@ def test_sweep(mocker, dummy_qrc):
     )
 
     nshots = 100
-    server_results = ([[np.random.rand(nshots)]], [[np.random.rand(nshots)]])
+    server_results = (
+        [[[np.random.rand(nshots)] * 10]],
+        [[[np.random.rand(nshots)] * 10]],
+    )
     mocker.patch("qibosoq.client.connect", return_value=server_results)
     parameters = ExecutionParameters(
         nshots=nshots,


### PR DESCRIPTION
Closes #913. The patch is quite ugly, moreover I am not sure if it works for every case... I've tested it only for a single qubit sweep (readout frequency).

I guess at some point it was introduced that the results must be squeezed like for dummy:
https://github.com/qiboteam/qibolab/blob/2e6c082e5cfada71f95699e3ea67aca13c12d8d1/src/qibolab/instruments/dummy.py#L130-L134

I was instead always returning values in the form of `[[val1, val2, val3, val4...]]` (not sure why, maybe it was wrong from the beginning). However, downgrading qibolab at my last commit and qibocal at 0.0.8 "solves" the issue, so maybe something was introduced in the middle? Do you, @stavros11, @alecandido , @hay-k, recall something specific?

Moreover, are there plans to introduce again some automatic tests with instruments? I wanted to add a specific test that could have caught this problem before


Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
