### PR TITLE
Fix emulator imports

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -42,7 +42,7 @@
           inherit inputs pkgs;
 
           modules = [
-            {
+            ({lib, ...}: {
               packages = with pkgs; [pre-commit poethepoet jupyter];
 
               env.QIBOLAB_PLATFORMS = platforms;
@@ -59,9 +59,15 @@
                 enable = true;
                 poetry = {
                   enable = true;
-                  install.enable = true;
-                  install.groups = ["dev" "tests"];
-                  install.allExtras = true;
+                  install = {
+                    enable = true;
+                    groups = ["dev" "tests"];
+                    extras = [
+                      (lib.strings.concatStrings
+                        (lib.strings.intersperse " -E "
+                          ["qblox" "qm" "zh" "rfsoc" "los"]))
+                    ];
+                  };
                 };
                 version = "3.11";
               };
@@ -70,7 +76,7 @@
                 enable = true;
                 channel = "stable";
               };
-            }
+            })
           ];
         };
       });

--- a/src/qibolab/instruments/emulator/pulse_simulator.py
+++ b/src/qibolab/instruments/emulator/pulse_simulator.py
@@ -8,12 +8,12 @@ from typing import Dict, List, Union
 import numpy as np
 
 from qibolab import AcquisitionType, AveragingMode, ExecutionParameters
+from qibolab.couplers import Coupler
 from qibolab.instruments.abstract import Controller
 from qibolab.instruments.emulator.engines.qutip_engine import QutipSimulator
 from qibolab.instruments.emulator.models import general_no_coupler_model
-from qibolab.platform import Coupler, Qubit
 from qibolab.pulses import PulseSequence, PulseType, ReadoutPulse
-from qibolab.qubits import QubitId
+from qibolab.qubits import Qubit, QubitId
 from qibolab.result import IntegratedResults, SampleResults
 from qibolab.sweeper import Parameter, Sweeper, SweeperType
 

--- a/tests/test_emulator.py
+++ b/tests/test_emulator.py
@@ -5,13 +5,7 @@ import numpy as np
 import pytest
 from qutip import Options, identity, tensor
 
-from qibolab import (
-    PLATFORMS,
-    AcquisitionType,
-    AveragingMode,
-    ExecutionParameters,
-    create_platform,
-)
+from qibolab import AcquisitionType, AveragingMode, ExecutionParameters, create_platform
 from qibolab.instruments.emulator.engines.generic import op_from_instruction
 from qibolab.instruments.emulator.engines.qutip_engine import (
     QutipSimulator,
@@ -23,6 +17,7 @@ from qibolab.instruments.emulator.models import (
     models_template,
 )
 from qibolab.instruments.emulator.pulse_simulator import AVAILABLE_SWEEP_PARAMETERS
+from qibolab.platform.load import PLATFORMS
 from qibolab.pulses import PulseSequence
 from qibolab.sweeper import Parameter, QubitParameter, Sweeper
 


### PR DESCRIPTION
The just merged #849 was based on a previous version of `main`, and it haven't been updated recently.

Because of this, it was prone to a recent change denying re-exports for objects defined somewhere else (in particular, `Qubit` and `Coupler` objects are not the defined in `qibolab.platform`, but in their own modules).

More tests may have to be fixed.