### PR TITLE
Emulator readout module

### DIFF
--- a/src/qibolab/instruments/emulator/readout.py
+++ b/src/qibolab/instruments/emulator/readout.py
@@ -1,0 +1,142 @@
+"""Module for simulating qubit readout."""
+
+import numpy as np
+
+from qibolab.pulses import ReadoutPulse
+from qibolab.qubits import Qubit
+
+
+def lamb_shift(g, delta):
+    """Calculates the lamb shift of the readout resonator from its bare
+    frequency.
+
+    Args:
+        g (float): Coupling strength between readout resonator and qubit in Hz.
+        delta (float): Detuning between readout resonator and qubit in Hz.
+
+    Returns:
+        Lambda (float): Lamb shift in Hz
+    """
+    return g * g / delta
+
+
+def dispersive_shift(g, delta, alpha):
+    """Calculates the dispersive shift of the readout resonator for the first excited state of the qubit
+    @see https://arxiv.org/abs/2106.06173, equation 35
+
+    Args:
+        g (float): Coupling strength between readout resonator and qubit in Hz.
+        delta (float): Detuning between readout resonator and qubit in Hz.
+        alpha (float): Qubit anharmonicity in Hz.
+
+    Returns:
+        chi (float): Dispersive shift in Hz.
+    """
+    return 2 * alpha * g * g / delta / delta
+
+
+def s21_function(resonator_frequency, total_Q, coupling_Q):
+    """Provides a function that calculates the transmission through the readout
+    line at a given frequency.
+
+    Args:
+        resonator_frequency (float): Frequency of the resonator.
+        total_Q (float): Total Q factor of the resonator.
+        coupling_Q (float): Coupling/external Q of the resonator.
+    """
+    return lambda frequency: 1 - total_Q / np.abs(coupling_Q) / (
+        1 + 2j * total_Q * (frequency / resonator_frequency - 1)
+    )
+
+
+class ReadoutSimulator:
+    """Module for simulating a readout event based on simulated qubit state."""
+
+    def __init__(
+        self, qubit: Qubit, g, noise_model, internal_Q, coupling_Q, sampling_rate=1e9
+    ):
+        """Initalizer for the readout simulator.
+
+        Args:
+            qubit (qibolab.qubits.Qubit): Qibolab qubit object.
+            g (float): Coupling strength between readout resonator and qubit in Hz.
+            noise_model (function): Time (in)dependent function that models the signal noise.
+            internal_Q (float): Internal Q factor of the readout resonator.
+            coupling_Q (float): Coupling/external Q factor of the readout resonator.
+            sampling_rate (float): Sampling rate of the ADC/digitizer.
+        """
+
+        delta = qubit.bare_resonator_frequency - qubit.drive_frequency
+        ground_state_frequency = qubit.bare_resonator_frequency + lamb_shift(g, delta)
+        excited_state_frequency = ground_state_frequency + dispersive_shift(
+            g, delta, qubit.anharmonicity
+        )
+        self.noise_model = noise_model
+        self.sampling_rate = sampling_rate
+
+        total_Q = 1 / (1 / internal_Q + 1 / coupling_Q)
+        self.ground_s21 = s21_function(ground_state_frequency, total_Q, coupling_Q)
+        self.excited_s21 = s21_function(excited_state_frequency, total_Q, coupling_Q)
+
+    def simulate_ground_state_iq(self, pulse: ReadoutPulse):
+        """Simulates the IQ result for a given readout pulse when the qubit is
+        in the ground state.
+
+        Args:
+            pulse (qibolab.pulses.ReadoutPulse): Qibolab readout pulse.
+        """
+        s21 = self.ground_s21(pulse.frequency)
+        return self.simulate_and_demodulate(s21, pulse)
+
+    def simulate_excited_state_iq(self, pulse: ReadoutPulse):
+        """Simulates the IQ result for a given readout pulse when the qubit is
+        in the excited state.
+
+        Args:
+            pulse (qibolab.pulses.ReadoutPulse): Qibolab readout pulse.
+        """
+        s21 = self.excited_s21(pulse.frequency)
+        return self.simulate_and_demodulate(s21, pulse)
+
+    def simulate_and_demodulate(self, s21: complex, pulse: ReadoutPulse):
+        """Simulates the readout pulse for a given S21-parameter and
+        demodulates it.
+
+        Args:
+            s21 (complex): Complex S21 parameter.
+            pulse (qibolab.pulses.ReadoutPulse): Qibolab readout pulse.
+
+        Returns:
+            IQ (complex): IQ data for a shot.
+        """
+        logmag = np.abs(s21)
+        phase = np.angle(s21)
+
+        env_I, env_Q = pulse.envelope_waveforms(self.sampling_rate / 1e9)
+
+        start = int(pulse.start * 1e-9 * self.sampling_rate)
+        t = np.arange(start, start + len(env_I)) / self.sampling_rate
+        reference_signal_I = np.sin(
+            2 * np.pi * pulse.frequency * t + pulse.relative_phase
+        )
+        reference_signal_Q = np.cos(
+            2 * np.pi * pulse.frequency * t + pulse.relative_phase
+        )
+
+        waveform = (
+            logmag
+            * pulse.amplitude
+            * (
+                env_I.data
+                * np.cos(pulse.relative_phase + phase)
+                * np.sin(2 * np.pi * pulse.frequency * t)
+                + env_Q.data
+                * np.sin(pulse.relative_phase + phase)
+                * np.cos(2 * np.pi * pulse.frequency * t)
+                + self.noise_model(t)
+            )
+        )
+
+        return np.dot(waveform, reference_signal_I) + 1j * np.dot(
+            waveform, reference_signal_Q
+        )


### PR DESCRIPTION
As discussed in https://github.com/qiboteam/qibolab/issues/941, to enable the emulation of the readout pulse.

This relies on knowing the bare resonator frequency, SNR of the syst-em, ADC sampling rate, Q factors of the resonator (which can be acquired from https://github.com/qiboteam/qibocal/pull/917), qubit-resonator coupling, qubit frequency and anharmonicity. Though, the Q factors are power dependent, so these would only hold true for the calibrated readout amplitude.

Here is some sample code using this module to measure the transmission of the readout resonator for the ground and excited states across different readout frequencies.
```python
import numpy as np
import matplotlib.pyplot as plt
from qibolab.qubits import Qubit
from qibolab.instruments.emulator.readout import ReadoutSimulator

bare_resonator_frequency = 5.045e9

qb = Qubit(0, bare_resonator_frequency=bare_resonator_frequency, drive_frequency=3.99e9, anharmonicity=-191.78e6)
readout = ReadoutSimulator(qubit=qb, g=30e6, noise_model=None, internal_Q=2.5e6, coupling_Q=6e4, sampling_rate=1966.08e6)

span = 1e6
center_frequency = bare_resonator_frequency + 0.75e6
freq_sweep = np.linspace(center_frequency - span / 2, center_frequency + span / 2, 1000)
y_gnd = np.abs(readout.ground_s21(freq_sweep))
y_exc = np.abs(readout.excited_s21(freq_sweep))

freq_sweep /= 1e9
plt.plot(freq_sweep, y_gnd, label=r"$|0\rangle$")
plt.plot(freq_sweep, y_exc, label=r"$|1\rangle$")
plt.ylabel("|S21| [arb. units]")
plt.xlabel("Readout Frequency [GHz]")
plt.legend()
plt.grid()
plt.tight_layout()
plt.savefig("S21.png", dpi=300)
plt.show()
```
![image](https://github.com/user-attachments/assets/001ec4c0-00df-4998-ab3e-986df4e9f650)

Here is some sample code of using the readout module to emulate single shot readout for 100 shots.
```python
import numpy as np
import matplotlib.pyplot as plt
from qibolab.qubits import Qubit
from qibolab.instruments.emulator.readout import ReadoutSimulator
from qibolab.pulses import ReadoutPulse

bare_resonator_frequency = 5.045e9
nshots = 100

SNR = 50 # dB
READOUT_AMPLITUDE = 1
NOISE_AMP = np.power(10, -SNR / 20)
AWGN = lambda t: np.random.normal(loc=0, scale=NOISE_AMP, size=len(t))

qb = Qubit(0, bare_resonator_frequency=bare_resonator_frequency, drive_frequency=3.99e9, anharmonicity=-191.78e6)
readout = ReadoutSimulator(qubit=qb, g=10e6, noise_model=AWGN, internal_Q=2.5e6, coupling_Q=6e4, sampling_rate=1966.08e6)
ro_pulse = ReadoutPulse(start=0, duration=1000, amplitude=READOUT_AMPLITUDE, frequency=5.04585e9, shape="Rectangular()", relative_phase=0)

rgnd = [readout.simulate_ground_state_iq(ro_pulse) for k in range(nshots)]
rexc = [readout.simulate_excited_state_iq(ro_pulse) for k in range(nshots)]
plt.scatter(np.real(rgnd), np.imag(rgnd), label=r"$|0\rangle$")
plt.scatter(np.real(rexc), np.imag(rexc), label=r"$|1\rangle$")
plt.xlabel("I")
plt.ylabel("Q")
plt.legend()
plt.tight_layout()
plt.savefig("IQ.png", dpi=300)
plt.show()
```

![image](https://github.com/user-attachments/assets/5076e3fe-d33a-4d12-a85e-d0128503817f)


Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
- [ ] Connect the results emulator to this readout module
- [ ] Add the relevant parameters needed to the `Qubit` object
- [ ] Add tests
- [ ] Use readout IF frequency instead of exact frequency for systems with mixers


@alecandido Just to confirm that this is what you mean by readout emulation.