### PR TITLE
Remove usage typing classes in favor of builtins

### DIFF
--- a/src/qibolab/couplers.py
+++ b/src/qibolab/couplers.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Dict, Optional, Union
+from typing import Optional, Union
 
 from qibolab.components import DcChannel
 from qibolab.native import SingleQubitNatives
@@ -29,8 +29,8 @@ class Coupler:
     "flux (:class:`qibolab.platforms.utils.Channel`): Channel used to send flux pulses to the qubit."
 
     # TODO: With topology or conectivity
-    # qubits: Optional[Dict[QubitId, Qubit]] = field(default_factory=dict)
-    qubits: Dict = field(default_factory=dict)
+    # qubits: Optional[dict[QubitId, Qubit]] = field(default_factory=dict)
+    qubits: dict = field(default_factory=dict)
     "Qubits the coupler acts on"
 
     @property

--- a/src/qibolab/instruments/abstract.py
+++ b/src/qibolab/instruments/abstract.py
@@ -2,6 +2,11 @@ from abc import ABC, abstractmethod
 from dataclasses import asdict, dataclass
 from typing import Optional
 
+import numpy.typing as npt
+
+from qibolab.execution_parameters import ConfigUpdate, ExecutionParameters
+from qibolab.pulses.sequence import PulseSequence
+from qibolab.sweeper import ParallelSweepers
 from qibolab.unrolling import Bounds
 
 InstrumentId = str
@@ -73,7 +78,14 @@ class Controller(Instrument):
         (GSps)."""
 
     @abstractmethod
-    def play(self, *args, **kwargs):
+    def play(
+        self,
+        updates: list[ConfigUpdate],
+        sequences: list[PulseSequence],
+        options: ExecutionParameters,
+        integration_setup,
+        sweepers: list[ParallelSweepers],
+    ) -> dict[int, npt.NDArray]:
         """Play a pulse sequence and retrieve feedback.
 
         If :cls:`qibolab.sweeper.Sweeper` objects are passed as arguments, they are

--- a/src/qibolab/instruments/abstract.py
+++ b/src/qibolab/instruments/abstract.py
@@ -80,7 +80,7 @@ class Controller(Instrument):
         executed in real-time. If not possible, an error is raised.
 
         Returns:
-            (Dict[ResultType]) mapping the serial of the readout pulses used to
+            (dict[ResultType]) mapping the serial of the readout pulses used to
             the acquired :class:`qibolab.result.ExecutionResults` object.
         """
 

--- a/src/qibolab/instruments/abstract.py
+++ b/src/qibolab/instruments/abstract.py
@@ -79,9 +79,7 @@ class Controller(Instrument):
         If :cls:`qibolab.sweeper.Sweeper` objects are passed as arguments, they are
         executed in real-time. If not possible, an error is raised.
 
-        Returns:
-            (dict[ResultType]) mapping the serial of the readout pulses used to
-            the acquired :class:`qibolab.result.ExecutionResults` object.
+        Returns a mapping with the id of the probe pulses used to acquired data.
         """
 
 

--- a/src/qibolab/instruments/emulator/engines/generic.py
+++ b/src/qibolab/instruments/emulator/engines/generic.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import List, Optional
+from typing import Optional
 
 import numpy as np
 
@@ -121,7 +121,7 @@ def op_from_instruction(
         )
         op_connectors_dict = op_connectors_dict_check
 
-    def process_op(op_list: list, connector_list: List[str], connector: str) -> list:
+    def process_op(op_list: list, connector_list: list[str], connector: str) -> list:
         """Implements connectors between operators."""
         index_list = []
         for i in range(connector_list.count(connector)):

--- a/src/qibolab/instruments/emulator/engines/qutip_engine.py
+++ b/src/qibolab/instruments/emulator/engines/qutip_engine.py
@@ -6,7 +6,7 @@ This module provides a engine for Quantum Toolbox in Python (QuTiP) to simulate 
 
 from collections import OrderedDict
 from timeit import default_timer as timer
-from typing import List, Optional
+from typing import Optional
 
 import numpy as np
 from qutip import Options, Qobj, basis, expect, ket2dm, mesolve, ptrace
@@ -206,7 +206,7 @@ class QutipSimulator:
         return arbitrary_state
 
     def extend_op_dim(
-        self, op_qobj: Qobj, op_indices_q: List[int] = [0], op_indices_c: List[int] = []
+        self, op_qobj: Qobj, op_indices_q: list[int] = [0], op_indices_c: list[int] = []
     ) -> Qobj:
         """Extends the dimension of an operator from its local Hilbert space to
         the full system Hilbert space.
@@ -272,7 +272,7 @@ class QutipSimulator:
         self,
         channel_waveforms: dict,
         simulate_dissipation: bool = False,
-    ) -> tuple[np.ndarray, List[int]]:
+    ) -> tuple[np.ndarray, list[int]]:
         """Performs the quantum dynamics simulation.
 
         Args:
@@ -347,8 +347,8 @@ class QutipSimulator:
         )
 
     def qobj_to_reduced_dm(
-        self, emu_qstate: Qobj, qubit_list: List[int]
-    ) -> tuple[np.ndarray, List[int]]:
+        self, emu_qstate: Qobj, qubit_list: list[int]
+    ) -> tuple[np.ndarray, list[int]]:
         """Computes the reduced density matrix of the emulator quantum state
         specified by `qubit_list`.
 
@@ -370,14 +370,14 @@ class QutipSimulator:
         return reduced_dm, rdm_qubit_list
 
     def state_from_basis_vector(
-        self, basis_vector: List[int], cbasis_vector: List[int] = None
+        self, basis_vector: list[int], cbasis_vector: list[int] = None
     ) -> Qobj:
         """Constructs the corresponding computational basis state of the
         generalized Hilbert space specified by qubit_list.
 
         Args:
-            basis_vector (List[int]): Generalized bitstring that specifies the computational basis state corresponding to the qubits in big endian order.
-            cbasis_vector (List[int]): Generalized bitstring that specifies the computational basis state corresponding to the couplers in big endian order.
+            basis_vector (list[int]): Generalized bitstring that specifies the computational basis state corresponding to the qubits in big endian order.
+            cbasis_vector (list[int]): Generalized bitstring that specifies the computational basis state corresponding to the couplers in big endian order.
 
         Returns:
             `qutip.Qobj`: Computational basis state consistent with Hilbert space
@@ -411,7 +411,7 @@ class QutipSimulator:
 
     def compute_overlaps(
         self,
-        target_states: List[Qobj],
+        target_states: list[Qobj],
         reference_states: Optional[dict[str, Qobj]] = None,
     ) -> dict:
         """Calculates the overlaps between a list of target device states, with
@@ -466,10 +466,10 @@ def make_arbitrary_state(statedata: np.ndarray, dims: list[int]) -> Qobj:
 
 def extend_op_dim(
     op_qobj: Qobj,
-    op_indices_q: List[int] = [0],
-    op_indices_c: List[int] = [],
-    nlevels_q: List[int] = [2],
-    nlevels_c: List[int] = [],
+    op_indices_q: list[int] = [0],
+    op_indices_c: list[int] = [],
+    nlevels_q: list[int] = [2],
+    nlevels_c: list[int] = [],
 ) -> Qobj:
     """Extenda the dimension of the input operator from its local Hilbert space
     to a larger n-body Hilbert space.

--- a/src/qibolab/instruments/emulator/engines/qutip_engine.py
+++ b/src/qibolab/instruments/emulator/engines/qutip_engine.py
@@ -6,7 +6,7 @@ This module provides a engine for Quantum Toolbox in Python (QuTiP) to simulate 
 
 from collections import OrderedDict
 from timeit import default_timer as timer
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 import numpy as np
 from qutip import Options, Qobj, basis, expect, ket2dm, mesolve, ptrace
@@ -412,7 +412,7 @@ class QutipSimulator:
     def compute_overlaps(
         self,
         target_states: List[Qobj],
-        reference_states: Optional[Dict[str, Qobj]] = None,
+        reference_states: Optional[dict[str, Qobj]] = None,
     ) -> dict:
         """Calculates the overlaps between a list of target device states, with
         respect to a list of reference device states.

--- a/src/qibolab/instruments/emulator/pulse_simulator.py
+++ b/src/qibolab/instruments/emulator/pulse_simulator.py
@@ -3,7 +3,7 @@ device."""
 
 import copy
 import operator
-from typing import List, Union
+from typing import Union
 
 import numpy as np
 import numpy.typing as npt
@@ -189,7 +189,7 @@ class PulseSimulator(Controller):
         couplers: dict[QubitId, Coupler],
         sequence: PulseSequence,
         execution_parameters: ExecutionParameters,
-        *sweeper: List[Sweeper],
+        *sweeper: list[Sweeper],
     ) -> dict[str, Union[npt.NDArray, dict]]:
         """Executes the sweep and generates readout results, as well as
         simulation-related time and states data.
@@ -618,7 +618,7 @@ def apply_readout_noise(
 
 
 def make_comp_basis(
-    qubit_list: List[Union[int, str]], qid_nlevels_map: dict[Union[int, str], int]
+    qubit_list: list[Union[int, str]], qid_nlevels_map: dict[Union[int, str], int]
 ) -> np.ndarray:
     """Generates the computational basis states of the Hilbert space.
 

--- a/src/qibolab/instruments/emulator/pulse_simulator.py
+++ b/src/qibolab/instruments/emulator/pulse_simulator.py
@@ -3,7 +3,7 @@ device."""
 
 import copy
 import operator
-from typing import Dict, List, Union
+from typing import List, Union
 
 import numpy as np
 import numpy.typing as npt
@@ -132,8 +132,8 @@ class PulseSimulator(Controller):
 
     def play(
         self,
-        qubits: Dict[QubitId, Qubit],
-        couplers: Dict[QubitId, Coupler],
+        qubits: dict[QubitId, Qubit],
+        couplers: dict[QubitId, Coupler],
         sequence: PulseSequence,
         execution_parameters: ExecutionParameters,
     ) -> dict[str, npt.NDArray]:
@@ -185,8 +185,8 @@ class PulseSimulator(Controller):
     ### sweeper adapted from icarusqfpga ###
     def sweep(
         self,
-        qubits: Dict[QubitId, Qubit],
-        couplers: Dict[QubitId, Coupler],
+        qubits: dict[QubitId, Qubit],
+        couplers: dict[QubitId, Coupler],
         sequence: PulseSequence,
         execution_parameters: ExecutionParameters,
         *sweeper: List[Sweeper],
@@ -278,8 +278,8 @@ class PulseSimulator(Controller):
 
     def _sweep_recursion(
         self,
-        qubits: Dict[QubitId, Qubit],
-        couplers: Dict[QubitId, Coupler],
+        qubits: dict[QubitId, Qubit],
+        couplers: dict[QubitId, Coupler],
         sequence: PulseSequence,
         execution_parameters: ExecutionParameters,
         *sweeper: Sweeper,
@@ -337,8 +337,8 @@ class PulseSimulator(Controller):
 
     def _sweep_play(
         self,
-        qubits: Dict[QubitId, Qubit],
-        couplers: Dict[QubitId, Coupler],
+        qubits: dict[QubitId, Qubit],
+        couplers: dict[QubitId, Coupler],
         sequence: PulseSequence,
         execution_parameters: ExecutionParameters,
     ) -> dict[Union[str, int], list]:

--- a/src/qibolab/instruments/icarusqfpga.py
+++ b/src/qibolab/instruments/icarusqfpga.py
@@ -1,6 +1,6 @@
 import operator
 from dataclasses import dataclass
-from typing import Dict, List, Union
+from typing import List, Union
 
 import numpy as np
 from icarusq_rfsoc_driver import IcarusQRFSoC  # pylint: disable=E0401
@@ -68,7 +68,7 @@ class RFSOC(Controller):
 
     def play(
         self,
-        qubits: Dict[QubitId, Qubit],
+        qubits: dict[QubitId, Qubit],
         couplers,
         sequence: PulseSequence,
         options: ExecutionParameters,
@@ -222,7 +222,7 @@ class RFSOC_RO(RFSOC):
 
     def play(
         self,
-        qubits: Dict[QubitId, Qubit],
+        qubits: dict[QubitId, Qubit],
         couplers,
         sequence: PulseSequence,
         options: ExecutionParameters,
@@ -284,9 +284,9 @@ class RFSOC_RO(RFSOC):
 
     def process_readout_signal(
         self,
-        adc_raw_data: Dict[int, np.ndarray],
+        adc_raw_data: dict[int, np.ndarray],
         sequence: List[Pulse],
-        qubits: Dict[QubitId, Qubit],
+        qubits: dict[QubitId, Qubit],
         options: ExecutionParameters,
     ):
         """Processes the raw signal from the ADC into IQ values."""
@@ -318,7 +318,7 @@ class RFSOC_RO(RFSOC):
 
     def sweep(
         self,
-        qubits: Dict[QubitId, Qubit],
+        qubits: dict[QubitId, Qubit],
         couplers,
         sequence: PulseSequence,
         options: ExecutionParameters,
@@ -353,7 +353,7 @@ class RFSOC_RO(RFSOC):
 
     def _sweep_recursion(
         self,
-        qubits: Dict[QubitId, Qubit],
+        qubits: dict[QubitId, Qubit],
         couplers,
         sequence: PulseSequence,
         options: ExecutionParameters,

--- a/src/qibolab/instruments/icarusqfpga.py
+++ b/src/qibolab/instruments/icarusqfpga.py
@@ -1,6 +1,6 @@
 import operator
 from dataclasses import dataclass
-from typing import List, Union
+from typing import Union
 
 import numpy as np
 from icarusq_rfsoc_driver import IcarusQRFSoC  # pylint: disable=E0401
@@ -208,7 +208,7 @@ class RFSOC_RO(RFSOC):
         address,
         delay_samples_offset_dac: int = 0,
         delay_samples_offset_adc: int = 0,
-        adcs_to_read: List[int] = [],
+        adcs_to_read: list[int] = [],
     ):
         super().__init__(
             name, address, delay_samples_offset_dac, delay_samples_offset_adc
@@ -285,7 +285,7 @@ class RFSOC_RO(RFSOC):
     def process_readout_signal(
         self,
         adc_raw_data: dict[int, np.ndarray],
-        sequence: List[Pulse],
+        sequence: list[Pulse],
         qubits: dict[QubitId, Qubit],
         options: ExecutionParameters,
     ):

--- a/src/qibolab/instruments/qblox/acquisition.py
+++ b/src/qibolab/instruments/qblox/acquisition.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import Optional
 
 import numpy as np
 
@@ -32,8 +32,8 @@ class AveragedAcquisition:
     frequency: int
     """Frequency of the readout pulse used for demodulation."""
 
-    i: Optional[List[float]] = None
-    q: Optional[List[float]] = None
+    i: Optional[list[float]] = None
+    q: Optional[list[float]] = None
 
     @property
     def scope(self):

--- a/src/qibolab/instruments/qm/controller.py
+++ b/src/qibolab/instruments/qm/controller.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Dict, Optional
+from typing import Optional
 
 from qm import QuantumMachinesManager, SimulationConfig, generate_qua_script, qua
 from qm.octave import QmOctaveConfig
@@ -112,10 +112,10 @@ class QMController(Controller):
     Has the form XXX.XXX.XXX.XXX:XXX.
     """
 
-    opxs: Dict[int, OPXplus] = field(default_factory=dict)
+    opxs: dict[int, OPXplus] = field(default_factory=dict)
     """Dictionary containing the
     :class:`qibolab.instruments.qm.devices.OPXplus` instruments being used."""
-    octaves: Dict[int, Octave] = field(default_factory=dict)
+    octaves: dict[int, Octave] = field(default_factory=dict)
     """Dictionary containing the :class:`qibolab.instruments.qm.devices.Octave`
     instruments being used."""
 

--- a/src/qibolab/instruments/qm/devices.py
+++ b/src/qibolab/instruments/qm/devices.py
@@ -1,7 +1,6 @@
 from collections import defaultdict
 from dataclasses import dataclass, field
 from itertools import chain
-from typing import Dict
 
 from qibolab.instruments.abstract import Instrument
 
@@ -38,9 +37,9 @@ class QMDevice(Instrument):
     name: str
     """Name of the device."""
 
-    outputs: Dict[int, QMOutput] = field(init=False)
+    outputs: dict[int, QMOutput] = field(init=False)
     """Dictionary containing the instrument's output ports."""
-    inputs: Dict[int, QMInput] = field(init=False)
+    inputs: dict[int, QMInput] = field(init=False)
     """Dictionary containing the instrument's input ports."""
 
     def ports(self, number, output=True):

--- a/src/qibolab/instruments/qm/ports.py
+++ b/src/qibolab/instruments/qm/ports.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field, fields
-from typing import ClassVar, Dict, Optional, Union
+from typing import ClassVar, Optional, Union
 
 DIGITAL_DELAY = 57
 DIGITAL_BUFFER = 18
@@ -94,7 +94,7 @@ class OPXOutput(QMOutput):
 
     offset: float = field(default=0.0, metadata={"config": "offset"})
     """Constant voltage to be applied on the output."""
-    filter: Dict[str, float] = field(
+    filter: dict[str, float] = field(
         default_factory=dict, metadata={"config": "filter", "settings": True}
     )
     """FIR and IIR filters to be applied to correct signal distortions."""

--- a/src/qibolab/instruments/qm/sequence.py
+++ b/src/qibolab/instruments/qm/sequence.py
@@ -1,6 +1,6 @@
 import collections
 from dataclasses import dataclass, field
-from typing import Optional, Set, Union
+from typing import Optional, Union
 
 import numpy as np
 from numpy import typing as npt
@@ -57,13 +57,13 @@ class QMPulse:
     """Data class containing the variables required for data acquisition for
     the instrument."""
 
-    next_: Set["QMPulse"] = field(default_factory=set)
+    next_: set["QMPulse"] = field(default_factory=set)
     """Pulses that will be played after the current pulse.
 
     These pulses need to be re-aligned if we are sweeping the start or
     duration.
     """
-    elements_to_align: Set[str] = field(default_factory=set)
+    elements_to_align: set[str] = field(default_factory=set)
 
     def __post_init__(self):
         pulse_type = self.pulse.type.name.lower()

--- a/src/qibolab/instruments/qm/sequence.py
+++ b/src/qibolab/instruments/qm/sequence.py
@@ -1,6 +1,6 @@
 import collections
 from dataclasses import dataclass, field
-from typing import List, Optional, Set, Union
+from typing import Optional, Set, Union
 
 import numpy as np
 from numpy import typing as npt
@@ -14,7 +14,7 @@ from qibolab.pulses import Pulse, PulseType
 from .acquisition import Acquisition
 from .config import SAMPLING_RATE, QMConfig
 
-DurationsType = Union[List[int], npt.NDArray[int]]
+DurationsType = Union[list[int], npt.NDArray[int]]
 """Type of values that can be accepted in a duration sweeper."""
 
 
@@ -115,7 +115,7 @@ class QMPulse:
 class BakedPulse(QMPulse):
     """Baking allows 1ns resolution in the pulse waveforms."""
 
-    segments: List[Baking] = field(default_factory=list)
+    segments: list[Baking] = field(default_factory=list)
     """Baked segments implementing the pulse."""
     amplitude: Optional[float] = None
     """Amplitude of the baked pulse.
@@ -186,7 +186,7 @@ class Sequence:
     corresponds to each pulse, as defined in the QM config.
     """
 
-    qmpulses: List[QMPulse] = field(default_factory=list)
+    qmpulses: list[QMPulse] = field(default_factory=list)
     """List of :class:`qibolab.instruments.qm.QMPulse` objects corresponding to
     the original pulses."""
     pulse_to_qmpulse: dict[Pulse, QMPulse] = field(default_factory=dict)
@@ -194,7 +194,7 @@ class Sequence:
     clock: dict[str, int] = field(default_factory=lambda: collections.defaultdict(int))
     """Dictionary used to keep track of times of each element, in order to
     calculate wait times."""
-    pulse_finish: dict[int, List[QMPulse]] = field(
+    pulse_finish: dict[int, list[QMPulse]] = field(
         default_factory=lambda: collections.defaultdict(list)
     )
     """Map to find all pulses that finish at a given time (useful for

--- a/src/qibolab/instruments/qm/sequence.py
+++ b/src/qibolab/instruments/qm/sequence.py
@@ -1,6 +1,6 @@
 import collections
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Set, Union
+from typing import List, Optional, Set, Union
 
 import numpy as np
 from numpy import typing as npt
@@ -189,12 +189,12 @@ class Sequence:
     qmpulses: List[QMPulse] = field(default_factory=list)
     """List of :class:`qibolab.instruments.qm.QMPulse` objects corresponding to
     the original pulses."""
-    pulse_to_qmpulse: Dict[Pulse, QMPulse] = field(default_factory=dict)
+    pulse_to_qmpulse: dict[Pulse, QMPulse] = field(default_factory=dict)
     """Map from qibolab pulses to QMPulses (useful when sweeping)."""
-    clock: Dict[str, int] = field(default_factory=lambda: collections.defaultdict(int))
+    clock: dict[str, int] = field(default_factory=lambda: collections.defaultdict(int))
     """Dictionary used to keep track of times of each element, in order to
     calculate wait times."""
-    pulse_finish: Dict[int, List[QMPulse]] = field(
+    pulse_finish: dict[int, List[QMPulse]] = field(
         default_factory=lambda: collections.defaultdict(list)
     )
     """Map to find all pulses that finish at a given time (useful for

--- a/src/qibolab/platform/platform.py
+++ b/src/qibolab/platform/platform.py
@@ -4,7 +4,7 @@ import dataclasses
 from collections import defaultdict
 from dataclasses import asdict, dataclass, field
 from math import prod
-from typing import Any, Dict, List, Optional, Tuple, TypeVar
+from typing import Any, Optional, TypeVar
 
 import numpy as np
 from qibo.config import log, raise_error
@@ -19,10 +19,10 @@ from qibolab.serialize_ import replace
 from qibolab.sweeper import ParallelSweepers
 from qibolab.unrolling import batch
 
-InstrumentMap = Dict[InstrumentId, Instrument]
-QubitMap = Dict[QubitId, Qubit]
-CouplerMap = Dict[QubitId, Coupler]
-QubitPairMap = Dict[QubitPairId, QubitPair]
+InstrumentMap = dict[InstrumentId, Instrument]
+QubitMap = dict[QubitId, Qubit]
+CouplerMap = dict[QubitId, Coupler]
+QubitPairMap = dict[QubitPairId, QubitPair]
 
 NS_TO_SEC = 1e-9
 
@@ -37,8 +37,8 @@ def default(value: Optional[T], default: T) -> T:
 
 
 def unroll_sequences(
-    sequences: List[PulseSequence], relaxation_time: int
-) -> Tuple[PulseSequence, dict[str, list[str]]]:
+    sequences: list[PulseSequence], relaxation_time: int
+) -> tuple[PulseSequence, dict[str, list[str]]]:
     """Unrolls a list of pulse sequences to a single pulse sequence with
     multiple measurements.
 
@@ -131,15 +131,14 @@ class Platform:
     name: str
     """Name of the platform."""
     qubits: QubitMap
-    """Dictionary mapping qubit names to :class:`qibolab.qubits.Qubit`
-    objects."""
+    """Mapping qubit names to :class:`qibolab.qubits.Qubit` objects."""
     pairs: QubitPairMap
-    """Dictionary mapping tuples of qubit names to
-    :class:`qibolab.qubits.QubitPair` objects."""
+    """Mapping tuples of qubit names to :class:`qibolab.qubits.QubitPair`
+    objects."""
     configs: dict[str, Config]
-    """Maps name of component to its default config."""
+    """Mapping name of component to its default config."""
     instruments: InstrumentMap
-    """Dictionary mapping instrument names to
+    """Mapping instrument names to
     :class:`qibolab.instruments.abstract.Instrument` objects."""
 
     settings: Settings = field(default_factory=Settings)
@@ -151,8 +150,7 @@ class Platform:
     """
 
     couplers: CouplerMap = field(default_factory=dict)
-    """Dictionary mapping coupler names to :class:`qibolab.couplers.Coupler`
-    objects."""
+    """Mapping coupler names to :class:`qibolab.couplers.Coupler` objects."""
 
     is_connected: bool = False
     """Flag for whether we are connected to the physical instruments."""
@@ -251,7 +249,7 @@ class Platform:
 
     def execute(
         self,
-        sequences: List[PulseSequence],
+        sequences: list[PulseSequence],
         options: ExecutionParameters,
         sweepers: Optional[list[ParallelSweepers]] = None,
     ) -> dict[Any, list]:

--- a/src/qibolab/platform/platform.py
+++ b/src/qibolab/platform/platform.py
@@ -39,19 +39,16 @@ def default(value: Optional[T], default: T) -> T:
 def unroll_sequences(
     sequences: list[PulseSequence], relaxation_time: int
 ) -> tuple[PulseSequence, dict[str, list[str]]]:
-    """Unrolls a list of pulse sequences to a single pulse sequence with
-    multiple measurements.
+    """Unrolls a list of pulse sequences to a single sequence.
 
-    Args:
-        sequences (list): List of pulse sequences to unroll.
-        relaxation_time (int): Time in ns to wait for the qubit to relax between
-            playing different sequences.
+    The resulting sequence may contain multiple measurements.
 
-    Returns:
-        total_sequence (:class:`qibolab.pulses.PulseSequence`): Unrolled pulse sequence containing
-            multiple measurements.
-        readout_map (dict): Map from original readout pulse serials to the unrolled readout pulse
-            serials. Required to construct the results dictionary that is returned after execution.
+    `relaxation_time` is the time in ns to wait for the qubit to relax between playing
+    different sequences.
+
+    It returns both the unrolled pulse sequence, and the map from original readout pulse
+    serials to the unrolled readout pulse serials. Required to construct the results
+    dictionary that is returned after execution.
     """
     total_sequence = PulseSequence()
     readout_map = defaultdict(list)

--- a/src/qibolab/platform/platform.py
+++ b/src/qibolab/platform/platform.py
@@ -24,6 +24,8 @@ QubitMap = dict[QubitId, Qubit]
 CouplerMap = dict[QubitId, Coupler]
 QubitPairMap = dict[QubitPairId, QubitPair]
 
+IntegrationSetup = dict[str, tuple[np.ndarray, float]]
+
 NS_TO_SEC = 1e-9
 
 # TODO: replace with https://docs.python.org/3/reference/compound_stmts.html#type-params
@@ -230,7 +232,13 @@ class Platform:
         assert len(controllers) == 1
         return controllers[0]
 
-    def _execute(self, sequences, options, integration_setup, sweepers):
+    def _execute(
+        self,
+        sequences: list[PulseSequence],
+        options: ExecutionParameters,
+        integration_setup: IntegrationSetup,
+        sweepers: list[ParallelSweepers],
+    ):
         """Execute sequences on the controllers."""
         result = {}
 
@@ -296,7 +304,7 @@ class Platform:
         # FIXME: this is temporary solution to deliver the information to drivers
         # until we make acquisition channels first class citizens in the sequences
         # so that each acquisition command carries the info with it.
-        integration_setup: dict[str, tuple[np.ndarray, float]] = {}
+        integration_setup: IntegrationSetup = {}
         for qubit in self.qubits.values():
             integration_setup[qubit.acquisition.name] = (qubit.kernel, qubit.iq_angle)
 

--- a/src/qibolab/qubits.py
+++ b/src/qibolab/qubits.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field, fields
-from typing import List, Optional, Tuple, Union
+from typing import Optional, Union
 
 import numpy as np
 
@@ -75,8 +75,8 @@ class Qubit:
     T2_spin_echo: int = 0
     state0_voltage: int = 0
     state1_voltage: int = 0
-    mean_gnd_states: List[float] = field(default_factory=lambda: [0, 0])
-    mean_exc_states: List[float] = field(default_factory=lambda: [0, 0])
+    mean_gnd_states: list[float] = field(default_factory=lambda: [0, 0])
+    mean_exc_states: list[float] = field(default_factory=lambda: [0, 0])
 
     # parameters for single shot classification
     threshold: Optional[float] = None
@@ -125,7 +125,7 @@ class Qubit:
         return freqs
 
 
-QubitPairId = Tuple[QubitId, QubitId]
+QubitPairId = tuple[QubitId, QubitId]
 """Type for holding ``QubitPair``s in the ``platform.pairs`` dictionary."""
 
 

--- a/src/qibolab/serialize.py
+++ b/src/qibolab/serialize.py
@@ -8,7 +8,7 @@ example for more details.
 import json
 from dataclasses import asdict, fields
 from pathlib import Path
-from typing import Optional, Tuple, Union
+from typing import Optional, Union
 
 from pydantic import ConfigDict, TypeAdapter
 
@@ -58,7 +58,7 @@ def load_qubit_name(name: str) -> QubitId:
 
 def load_qubits(
     runcard: dict, kernels: Kernels = None
-) -> Tuple[QubitMap, CouplerMap, QubitPairMap]:
+) -> tuple[QubitMap, CouplerMap, QubitPairMap]:
     """Load qubits and pairs from the runcard.
 
     Uses the native gate and characterization sections of the runcard to
@@ -159,7 +159,7 @@ def _load_two_qubit_natives(gates) -> TwoQubitNatives:
 
 def register_gates(
     runcard: dict, qubits: QubitMap, pairs: QubitPairMap, couplers: CouplerMap = None
-) -> Tuple[QubitMap, QubitPairMap]:
+) -> tuple[QubitMap, QubitPairMap]:
     """Register single qubit native gates to ``Qubit`` objects from the
     runcard.
 


### PR DESCRIPTION
This is a migration we could have done at any time, since we have dropped support for py3.8