### PR TITLE
Drop `PulseType`

### DIFF
--- a/doc/source/main-documentation/qibolab.rst
+++ b/doc/source/main-documentation/qibolab.rst
@@ -253,7 +253,6 @@ To illustrate, here are some examples of single pulses using the Qibolab API:
         relative_phase=0,  # Phase in radians
         envelope=Rectangular(),
         channel="channel",
-        type="qd",  # Enum type: :class:`qibolab.pulses.PulseType`
         qubit=0,
     )
 
@@ -402,9 +401,9 @@ To effectively specify the sweeping behavior, Qibolab provides the ``values`` at
 
 The ``values`` attribute comprises an array of numerical values that define the sweeper's progression. To facilitate multi-qubit execution, these numbers can be interpreted in three ways:
 
-- Absolute Values: Represented by `qibolab.sweeper.PulseType.ABSOLUTE`, these values are used directly.
-- Relative Values with Offset: Utilizing `qibolab.sweeper.PulseType.OFFSET`, these values are relative to a designated base value, corresponding to the pulse or qubit value.
-- Relative Values with Factor: Employing `qibolab.sweeper.PulseType.FACTOR`, these values are scaled by a factor from the base value, akin to a multiplier.
+- Absolute Values: Represented by `qibolab.sweeper.SweeperType.ABSOLUTE`, these values are used directly.
+- Relative Values with Offset: Utilizing `qibolab.sweeper.SweeperType.OFFSET`, these values are relative to a designated base value, corresponding to the pulse or qubit value.
+- Relative Values with Factor: Employing `qibolab.sweeper.SweeperType.FACTOR`, these values are scaled by a factor from the base value, akin to a multiplier.
 
 For offset and factor sweepers, the base value is determined by the respective pulse or qubit value.
 

--- a/doc/source/tutorials/lab.rst
+++ b/doc/source/tutorials/lab.rst
@@ -25,7 +25,7 @@ using different Qibolab primitives.
     from qibolab import Platform
     from qibolab.components import IqChannel, AcquireChannel, IqConfig
     from qibolab.qubits import Qubit
-    from qibolab.pulses import Gaussian, Pulse, PulseType, Rectangular
+    from qibolab.pulses import Gaussian, Pulse, Rectangular
     from qibolab.native import RxyFactory, FixedSequenceFactory, SingleQubitNatives
     from qibolab.instruments.dummy import DummyInstrument
 
@@ -54,7 +54,6 @@ using different Qibolab primitives.
                 duration=40,
                 amplitude=0.05,
                 envelope=Gaussian(rel_sigma=0.2),
-                type=PulseType.DRIVE,
             )
         )
 
@@ -65,7 +64,6 @@ using different Qibolab primitives.
                 duration=1000,
                 amplitude=0.005,
                 envelope=Rectangular(),
-                type=PulseType.READOUT,
             )
         )
 
@@ -107,7 +105,7 @@ hold the parameters of the two-qubit gates.
 
     from qibolab.components import IqChannel, AcquireChannel, DcChannel, IqConfig
     from qibolab.qubits import Qubit, QubitPair
-    from qibolab.pulses import Gaussian, PulseType, Pulse, PulseSequence, Rectangular
+    from qibolab.pulses import Gaussian, Pulse, PulseSequence, Rectangular
     from qibolab.native import (
         RxyFactory,
         FixedSequenceFactory,
@@ -138,7 +136,6 @@ hold the parameters of the two-qubit gates.
                             duration=40,
                             amplitude=0.05,
                             envelope=Gaussian(rel_sigma=0.2),
-                            type=PulseType.DRIVE,
                         )
                     ]
                 }
@@ -152,7 +149,6 @@ hold the parameters of the two-qubit gates.
                             duration=1000,
                             amplitude=0.005,
                             envelope=Rectangular(),
-                            type=PulseType.READOUT,
                         )
                     ]
                 }
@@ -168,7 +164,6 @@ hold the parameters of the two-qubit gates.
                             duration=40,
                             amplitude=0.05,
                             envelope=Gaussian(rel_sigma=0.2),
-                            type=PulseType.DRIVE,
                         )
                     ]
                 }
@@ -182,7 +177,6 @@ hold the parameters of the two-qubit gates.
                             duration=1000,
                             amplitude=0.005,
                             envelope=Rectangular(),
-                            type=PulseType.READOUT,
                         )
                     ]
                 }
@@ -201,7 +195,6 @@ hold the parameters of the two-qubit gates.
                             duration=30,
                             amplitude=0.005,
                             envelope=Rectangular(),
-                            type=PulseType.FLUX,
                         )
                     ],
                 }
@@ -221,7 +214,7 @@ coupler but qibolab will take them into account when calling :class:`qibolab.nat
     from qibolab.components import DcChannel
     from qibolab.couplers import Coupler
     from qibolab.qubits import Qubit, QubitPair
-    from qibolab.pulses import PulseType, Pulse, PulseSequence
+    from qibolab.pulses import Pulse, PulseSequence
     from qibolab.native import (
         FixedSequenceFactory,
         SingleQubitNatives,
@@ -251,7 +244,6 @@ coupler but qibolab will take them into account when calling :class:`qibolab.nat
                             amplitude=0.005,
                             frequency=1e9,
                             envelope=Rectangular(),
-                            type=PulseType.FLUX,
                             qubit=qubit1.name,
                         )
                     ]

--- a/doc/source/tutorials/pulses.rst
+++ b/doc/source/tutorials/pulses.rst
@@ -8,7 +8,7 @@ pulses (:class:`qibolab.pulses.Pulse`) through the
 
 .. testcode::  python
 
-    from qibolab.pulses import Pulse, PulseSequence, PulseType, Rectangular, Gaussian, Delay
+    from qibolab.pulses import Pulse, PulseSequence, Rectangular, Gaussian, Delay
 
     # Define PulseSequence
     sequence = PulseSequence()
@@ -20,7 +20,6 @@ pulses (:class:`qibolab.pulses.Pulse`) through the
             duration=60,
             relative_phase=0,
             envelope=Gaussian(rel_sigma=0.2),
-            type=PulseType.DRIVE,
         )
     )
     sequence["channel_1"].append(Delay(duration=100, channel="1"))
@@ -30,7 +29,6 @@ pulses (:class:`qibolab.pulses.Pulse`) through the
             duration=3000,
             relative_phase=0,
             envelope=Rectangular(),
-            type=PulseType.READOUT,
         )
     )
 

--- a/src/qibolab/dummy/parameters.json
+++ b/src/qibolab/dummy/parameters.json
@@ -26,64 +26,64 @@
     }
   },
   "components": {
-    "qubit_0/drive" : {
+    "qubit_0/drive": {
       "frequency": 4000000000
     },
-    "qubit_1/drive" : {
+    "qubit_1/drive": {
       "frequency": 4200000000
     },
-    "qubit_2/drive" : {
+    "qubit_2/drive": {
       "frequency": 4500000000
     },
-    "qubit_3/drive" : {
+    "qubit_3/drive": {
       "frequency": 4150000000
     },
-    "qubit_4/drive" : {
+    "qubit_4/drive": {
       "frequency": 4155663000
     },
-    "qubit_0/drive12" : {
+    "qubit_0/drive12": {
       "frequency": 4700000000
     },
-    "qubit_1/drive12" : {
+    "qubit_1/drive12": {
       "frequency": 4855663000
     },
-    "qubit_2/drive12" : {
+    "qubit_2/drive12": {
       "frequency": 2700000000
     },
-    "qubit_3/drive12" : {
+    "qubit_3/drive12": {
       "frequency": 5855663000
     },
-    "qubit_4/drive12" : {
+    "qubit_4/drive12": {
       "frequency": 5855663000
     },
-    "qubit_0/flux" : {
+    "qubit_0/flux": {
       "offset": -0.1
     },
-    "qubit_1/flux" : {
+    "qubit_1/flux": {
       "offset": 0.0
     },
-    "qubit_2/flux" : {
+    "qubit_2/flux": {
       "offset": 0.1
     },
-    "qubit_3/flux" : {
+    "qubit_3/flux": {
       "offset": 0.2
     },
-    "qubit_4/flux" : {
+    "qubit_4/flux": {
       "offset": 0.15
     },
-    "qubit_0/probe" : {
+    "qubit_0/probe": {
       "frequency": 5200000000
     },
-    "qubit_1/probe" : {
+    "qubit_1/probe": {
       "frequency": 4900000000
     },
-    "qubit_2/probe" : {
+    "qubit_2/probe": {
       "frequency": 6100000000
     },
-    "qubit_3/probe" : {
+    "qubit_3/probe": {
       "frequency": 5800000000
     },
-    "qubit_4/probe" : {
+    "qubit_4/probe": {
       "frequency": 5500000000
     },
     "qubit_0/acquire": {
@@ -106,16 +106,16 @@
       "delay": 0,
       "smearing": 0
     },
-    "coupler_0/flux" : {
+    "coupler_0/flux": {
       "offset": 0.0
     },
-    "coupler_1/flux" : {
+    "coupler_1/flux": {
       "offset": 0.0
     },
-    "coupler_3/flux" : {
+    "coupler_3/flux": {
       "offset": 0.0
     },
-    "coupler_4/flux" : {
+    "coupler_4/flux": {
       "offset": 0.0
     },
     "twpa_pump": {
@@ -129,34 +129,31 @@
         "RX": {
           "qubit_0/drive": [
             {
-              "duration": 40,
+              "duration": 40.0,
               "amplitude": 0.1,
-              "envelope": { "kind": "gaussian", "rel_sigma": 5 },
-              "type": "qd"
+              "envelope": { "kind": "gaussian", "rel_sigma": 5.0 }
             }
           ]
         },
         "RX12": {
           "qubit_0/drive12": [
             {
-              "duration": 40,
+              "duration": 40.0,
               "amplitude": 0.005,
-              "envelope": { "kind": "gaussian", "rel_sigma": 5 },
-              "type": "qd"
+              "envelope": { "kind": "gaussian", "rel_sigma": 5.0 }
             }
           ]
         },
         "MZ": {
           "qubit_0/probe": [
             {
-              "duration": 2000,
+              "duration": 2000.0,
               "amplitude": 0.1,
               "envelope": {
                 "kind": "gaussian_square",
-                "rel_sigma": 5,
+                "rel_sigma": 5.0,
                 "width": 0.75
-              },
-              "type": "ro"
+              }
             }
           ]
         }
@@ -165,34 +162,31 @@
         "RX": {
           "qubit_1/drive": [
             {
-              "duration": 40,
+              "duration": 40.0,
               "amplitude": 0.3,
-              "envelope": { "kind": "drag", "rel_sigma": 5, "beta": 0.02 },
-              "type": "qd"
+              "envelope": { "kind": "drag", "rel_sigma": 5.0, "beta": 0.02 }
             }
           ]
         },
         "RX12": {
           "qubit_1/drive12": [
             {
-              "duration": 40,
+              "duration": 40.0,
               "amplitude": 0.0484,
-              "envelope": { "kind": "drag", "rel_sigma": 5, "beta": 0.02 },
-              "type": "qd"
+              "envelope": { "kind": "drag", "rel_sigma": 5.0, "beta": 0.02 }
             }
           ]
-        } ,
+        },
         "MZ": {
           "qubit_1/probe": [
             {
-              "duration": 2000,
+              "duration": 2000.0,
               "amplitude": 0.1,
               "envelope": {
                 "kind": "gaussian_square",
-                "rel_sigma": 5,
+                "rel_sigma": 5.0,
                 "width": 0.75
-              },
-              "type": "ro"
+              }
             }
           ]
         }
@@ -201,34 +195,31 @@
         "RX": {
           "qubit_2/drive": [
             {
-              "duration": 40,
+              "duration": 40.0,
               "amplitude": 0.3,
-              "envelope": { "kind": "drag", "rel_sigma": 5, "beta": 0.02 },
-              "type": "qd"
+              "envelope": { "kind": "drag", "rel_sigma": 5.0, "beta": 0.02 }
             }
           ]
         },
         "RX12": {
           "qubit_2/drive12": [
             {
-              "duration": 40,
+              "duration": 40.0,
               "amplitude": 0.005,
-              "envelope": { "kind": "gaussian", "rel_sigma": 5 },
-              "type": "qd"
+              "envelope": { "kind": "gaussian", "rel_sigma": 5.0 }
             }
           ]
         },
         "MZ": {
           "qubit_2/probe": [
             {
-              "duration": 2000,
+              "duration": 2000.0,
               "amplitude": 0.1,
               "envelope": {
                 "kind": "gaussian_square",
-                "rel_sigma": 5,
+                "rel_sigma": 5.0,
                 "width": 0.75
-              },
-              "type": "ro"
+              }
             }
           ]
         }
@@ -237,34 +228,31 @@
         "RX": {
           "qubit_3/drive": [
             {
-              "duration": 40,
+              "duration": 40.0,
               "amplitude": 0.3,
-              "envelope": { "kind": "drag", "rel_sigma": 5, "beta": 0.02 },
-              "type": "qd"
+              "envelope": { "kind": "drag", "rel_sigma": 5.0, "beta": 0.02 }
             }
           ]
         },
         "RX12": {
           "qubit_3/drive12": [
             {
-              "duration": 40,
+              "duration": 40.0,
               "amplitude": 0.0484,
-              "envelope": { "kind": "drag", "rel_sigma": 5, "beta": 0.02 },
-              "type": "qd"
-           }
+              "envelope": { "kind": "drag", "rel_sigma": 5.0, "beta": 0.02 }
+            }
           ]
         },
         "MZ": {
           "qubit_3/probe": [
             {
-              "duration": 2000,
+              "duration": 2000.0,
               "amplitude": 0.1,
               "envelope": {
                 "kind": "gaussian_square",
-                "rel_sigma": 5,
+                "rel_sigma": 5.0,
                 "width": 0.75
-              },
-              "type": "ro"
+              }
             }
           ]
         }
@@ -273,34 +261,31 @@
         "RX": {
           "qubit_4/drive": [
             {
-              "duration": 40,
+              "duration": 40.0,
               "amplitude": 0.3,
-              "envelope": { "kind": "drag", "rel_sigma": 5, "beta": 0.02 },
-              "type": "qd"
+              "envelope": { "kind": "drag", "rel_sigma": 5.0, "beta": 0.02 }
             }
           ]
         },
         "RX12": {
           "qubit_4/drive12": [
             {
-              "duration": 40,
+              "duration": 40.0,
               "amplitude": 0.0484,
-              "envelope": { "kind": "drag", "rel_sigma": 5, "beta": 0.02 },
-              "type": "qd"
+              "envelope": { "kind": "drag", "rel_sigma": 5.0, "beta": 0.02 }
             }
           ]
         },
         "MZ": {
           "qubit_4/probe": [
             {
-              "duration": 2000,
+              "duration": 2000.0,
               "amplitude": 0.1,
               "envelope": {
                 "kind": "gaussian_square",
-                "rel_sigma": 5,
+                "rel_sigma": 5.0,
                 "width": 0.75
-              },
-              "type": "ro"
+              }
             }
           ]
         }
@@ -311,76 +296,68 @@
         "CZ": {
           "qubit_2/flux": [
             {
-              "duration": 30,
+              "duration": 30.0,
               "amplitude": 0.05,
               "envelope": {
                 "kind": "gaussian_square",
-                "rel_sigma": 5,
+                "rel_sigma": 5.0,
                 "width": 0.75
-              },
-              "type": "qf"
+              }
             }
           ],
           "qubit_0/drive": [
             {
-              "type": "vz",
               "phase": 0.0
             }
           ],
           "qubit_2/drive": [
             {
-              "type": "vz",
               "phase": 0.0
             }
           ],
           "coupler_0/flux": [
             {
-              "duration": 30,
+              "duration": 30.0,
               "amplitude": 0.05,
               "envelope": {
                 "kind": "gaussian_square",
-                "rel_sigma": 5,
+                "rel_sigma": 5.0,
                 "width": 0.75
-              },
-              "type": "cf"
+              }
             }
           ]
         },
         "iSWAP": {
           "qubit_2/flux": [
             {
-              "duration": 30,
+              "duration": 30.0,
               "amplitude": 0.05,
               "envelope": {
                 "kind": "gaussian_square",
-                "rel_sigma": 5,
+                "rel_sigma": 5.0,
                 "width": 0.75
-              },
-              "type": "qf"
+              }
             }
           ],
           "qubit_0/drive": [
             {
-              "type": "vz",
               "phase": 0.0
             }
           ],
           "qubit_2/drive": [
             {
-              "type": "vz",
               "phase": 0.0
             }
           ],
           "coupler_0/flux": [
             {
-              "duration": 30,
+              "duration": 30.0,
               "amplitude": 0.05,
               "envelope": {
                 "kind": "gaussian_square",
-                "rel_sigma": 5,
+                "rel_sigma": 5.0,
                 "width": 0.75
-              },
-              "type": "cf"
+              }
             }
           ]
         }
@@ -389,76 +366,68 @@
         "CZ": {
           "qubit_2/flux": [
             {
-              "duration": 30,
+              "duration": 30.0,
               "amplitude": 0.05,
               "envelope": {
                 "kind": "gaussian_square",
-                "rel_sigma": 5,
+                "rel_sigma": 5.0,
                 "width": 0.75
-              },
-              "type": "qf"
+              }
             }
           ],
           "qubit_1/drive": [
             {
-              "type": "vz",
               "phase": 0.0
             }
           ],
           "qubit_2/drive": [
             {
-              "type": "vz",
               "phase": 0.0
             }
           ],
           "coupler_1/flux": [
             {
-              "duration": 30,
+              "duration": 30.0,
               "amplitude": 0.05,
               "envelope": {
                 "kind": "gaussian_square",
-                "rel_sigma": 5,
+                "rel_sigma": 5.0,
                 "width": 0.75
-              },
-              "type": "cf"
+              }
             }
           ]
         },
         "iSWAP": {
           "qubit_2/flux": [
             {
-              "duration": 30,
+              "duration": 30.0,
               "amplitude": 0.05,
               "envelope": {
                 "kind": "gaussian_square",
-                "rel_sigma": 5,
+                "rel_sigma": 5.0,
                 "width": 0.75
-              },
-              "type": "qf"
+              }
             }
           ],
           "qubit_1/drive": [
             {
-              "type": "vz",
               "phase": 0.0
             }
           ],
           "qubit_2/drive": [
             {
-              "type": "vz",
               "phase": 0.0
             }
           ],
           "coupler_1/flux": [
             {
-              "duration": 30,
+              "duration": 30.0,
               "amplitude": 0.05,
               "envelope": {
                 "kind": "gaussian_square",
-                "rel_sigma": 5,
+                "rel_sigma": 5.0,
                 "width": 0.75
-              },
-              "type": "cf"
+              }
             }
           ]
         }
@@ -467,86 +436,77 @@
         "CZ": {
           "qubit_2/flux": [
             {
-              "duration": 30,
+              "duration": 30.0,
               "amplitude": 0.05,
               "envelope": {
                 "kind": "gaussian_square",
-                "rel_sigma": 5,
+                "rel_sigma": 5.0,
                 "width": 0.75
-              },
-              "type": "qf"
+              }
             }
           ],
           "qubit_2/drive": [
             {
-              "type": "vz",
               "phase": 0.0
             }
           ],
           "qubit_3/drive": [
             {
-              "type": "vz",
               "phase": 0.0
             }
           ],
           "coupler_3/flux": [
             {
-              "duration": 30,
+              "duration": 30.0,
               "amplitude": 0.05,
               "envelope": {
                 "kind": "gaussian_square",
-                "rel_sigma": 5,
+                "rel_sigma": 5.0,
                 "width": 0.75
-              },
-              "type": "cf"
+              }
             }
           ]
         },
         "iSWAP": {
           "qubit_2/flux": [
             {
-              "duration": 30,
+              "duration": 30.0,
               "amplitude": 0.05,
               "envelope": {
                 "kind": "gaussian_square",
-                "rel_sigma": 5,
+                "rel_sigma": 5.0,
                 "width": 0.75
-              },
-              "type": "qf"
+              }
             }
           ],
           "qubit_2/drive": [
             {
-              "type": "vz",
               "phase": 0.0
             }
           ],
           "qubit_3/drive": [
             {
-              "type": "vz",
               "phase": 0.0
             }
           ],
           "coupler_3/flux": [
             {
-              "duration": 30,
+              "duration": 30.0,
               "amplitude": 0.05,
               "envelope": {
                 "kind": "gaussian_square",
-                "rel_sigma": 5,
+                "rel_sigma": 5.0,
                 "width": 0.75
-              },
-              "type": "cf"
+              }
             }
           ]
         },
         "CNOT": {
           "qubit_2/drive": [
             {
-              "duration": 40,
+              "duration": 40.0,
               "amplitude": 0.3,
-              "envelope": { "kind": "drag", "rel_sigma": 5, "beta": 0.02 },
-              "type": "qd"
+              "envelope": { "kind": "drag", "rel_sigma": 5.0, "beta": 0.02 }
             }
           ]
         }
@@ -555,76 +515,63 @@
         "CZ": {
           "qubit_2/flux": [
             {
-              "duration": 30,
+              "duration": 30.0,
               "amplitude": 0.05,
               "envelope": {
                 "kind": "gaussian_square",
-                "rel_sigma": 5,
+                "rel_sigma": 5.0,
                 "width": 0.75
-              },
-              "type": "qf"
-            }
-          ],
-          "qubit_2/drive": [
-            {
-              "type": "vz",
-              "phase": 0.0
+              }
             }
           ],
           "qubit_4/drive": [
             {
-            "type": "vz",
               "phase": 0.0
             }
           ],
           "coupler_4/flux": [
             {
-              "duration": 30,
+              "duration": 30.0,
               "amplitude": 0.05,
               "envelope": {
                 "kind": "gaussian_square",
-                "rel_sigma": 5,
+                "rel_sigma": 5.0,
                 "width": 0.75
-              },
-              "type": "cf"
+              }
             }
           ]
         },
         "iSWAP": {
           "qubit_2/flux": [
             {
-              "duration": 30,
+              "duration": 30.0,
               "amplitude": 0.05,
               "envelope": {
                 "kind": "gaussian_square",
-                "rel_sigma": 5,
+                "rel_sigma": 5.0,
                 "width": 0.75
-              },
-              "type": "qf"
+              }
             }
           ],
           "qubit_2/drive": [
             {
-              "type": "vz",
               "phase": 0.0
             }
           ],
           "qubit_4/drive": [
             {
-            "type": "vz",
               "phase": 0.0
             }
           ],
           "coupler_4/flux": [
             {
-              "duration": 30,
+              "duration": 30.0,
               "amplitude": 0.05,
               "envelope": {
                 "kind": "gaussian_square",
-                "rel_sigma": 5,
+                "rel_sigma": 5.0,
                 "width": 0.75
-              },
-              "type": "cf"
+              }
             }
           ]
         }

--- a/src/qibolab/instruments/emulator/pulse_simulator.py
+++ b/src/qibolab/instruments/emulator/pulse_simulator.py
@@ -258,10 +258,11 @@ class PulseSimulator(Controller):
             param_name = sweep.parameter.name.lower()
             for pulse, value in zip(sweep.pulses, base_sweeper_values):
                 setattr(pulse, param_name, value)
+                # FIXME: this is copy-pasted from IcarusQ, check the comment in there
                 # Since the sweeper will modify the readout pulse serial, we collate the results with the qubit number.
                 # This is only for qibocal compatiability and will be removed with IcarusQ v2.
-                if pulse.type is PulseType.READOUT:
-                    results[pulse.serial] = results[pulse.qubit]
+                # if pulse.type is PulseType.READOUT:
+                #     results[pulse.serial] = results[pulse.qubit]
 
         results.update(
             {
@@ -753,8 +754,7 @@ def truncate_ro_pulses(
         `qibolab.pulses.PulseSequence`: Modified pulse sequence with one time step readout pulses.
     """
     sequence = copy.deepcopy(sequence)
-    for i in range(len(sequence)):
-        if sequence[i].type is PulseType.READOUT:
-            sequence[i].duration = 1
+    for pulse in sequence.probe_pulses:
+        pulse.duration = 1
 
     return sequence

--- a/src/qibolab/instruments/emulator/pulse_simulator.py
+++ b/src/qibolab/instruments/emulator/pulse_simulator.py
@@ -13,7 +13,7 @@ from qibolab.couplers import Coupler
 from qibolab.instruments.abstract import Controller
 from qibolab.instruments.emulator.engines.qutip_engine import QutipSimulator
 from qibolab.instruments.emulator.models import general_no_coupler_model
-from qibolab.pulses import PulseSequence, PulseType
+from qibolab.pulses import PulseSequence
 from qibolab.qubits import Qubit, QubitId
 from qibolab.result import average, collect
 from qibolab.sweeper import Parameter, Sweeper, SweeperType

--- a/src/qibolab/instruments/icarusqfpga.py
+++ b/src/qibolab/instruments/icarusqfpga.py
@@ -100,6 +100,13 @@ class RFSOC(Controller):
                 i_env = pulse.envelope_waveform_i(dac_sr_ghz).data
                 q_env = pulse.envelope_waveform_q(dac_sr_ghz).data
 
+                # FIXME: since pulse types have been deprecated, now channel types
+                # should be used instead. In the following, the code is relying on a
+                # non-standard channels naming convention, and thus fragile (or just
+                # broken)
+                # instead, the channel object should be retrieved from the platform
+                # configuration, and its type should be inspected
+
                 # Flux pulses
                 # TODO: Add envelope support for flux pulses
                 if "flux" in ch:
@@ -352,6 +359,8 @@ class RFSOC_RO(RFSOC):
                 # FIXME: if this was required, now it's completely broken, since it
                 # isn't possible to identify the pulse channel from the pulse itself
                 # (nor it should be needed)
+                # it should be possible to retrieve the information looking for the
+                # channel type
                 # if pulse.type is PulseType.READOUT:
                 #     res[pulse.serial] = res[pulse.qubit]
 

--- a/src/qibolab/instruments/icarusqfpga.py
+++ b/src/qibolab/instruments/icarusqfpga.py
@@ -13,7 +13,7 @@ from qibolab.execution_parameters import (
     ExecutionParameters,
 )
 from qibolab.instruments.abstract import Controller
-from qibolab.pulses import Pulse, PulseSequence, PulseType
+from qibolab.pulses import Pulse, PulseSequence
 from qibolab.qubits import Qubit, QubitId
 from qibolab.result import average, average_iq, collect
 from qibolab.sweeper import Parameter, Sweeper, SweeperType
@@ -88,94 +88,99 @@ class RFSOC(Controller):
         dac_sr_ghz = dac_sampling_rate / 1e9
 
         # We iterate over the seuence of pulses and generate the waveforms for each type of pulses
-        for pulse in sequence.pulses:
-            # pylint: disable=no-member
-            # FIXME: ignore complaint about non-existent ports and _ports properties, until we upgrade this driver to qibolab 0.2
-            if pulse.channel not in self._ports:
-                continue
+        for ch, seq in sequence.items():
+            for pulse in seq:
+                # pylint: disable=no-member
+                # FIXME: ignore complaint about non-existent ports and _ports properties, until we upgrade this driver to qibolab 0.2
+                if pulse.channel not in self._ports:
+                    continue
 
-            dac = self.ports(pulse.channel).dac
-            start = int(pulse.start * 1e-9 * dac_sampling_rate)
-            i_env = pulse.envelope_waveform_i(dac_sr_ghz).data
-            q_env = pulse.envelope_waveform_q(dac_sr_ghz).data
+                dac = self.ports(pulse.channel).dac
+                start = int(pulse.start * 1e-9 * dac_sampling_rate)
+                i_env = pulse.envelope_waveform_i(dac_sr_ghz).data
+                q_env = pulse.envelope_waveform_q(dac_sr_ghz).data
 
-            # Flux pulses
-            # TODO: Add envelope support for flux pulses
-            if pulse.type == PulseType.FLUX:
-                wfm = i_env
-                end = start + len(wfm)
+                # Flux pulses
+                # TODO: Add envelope support for flux pulses
+                if "flux" in ch:
+                    wfm = i_env
+                    end = start + len(wfm)
 
-            # Qubit drive microwave signals
-            elif pulse.type == PulseType.DRIVE:
-                end = start + len(i_env)
-                t = np.arange(start, end) / dac_sampling_rate
-                cosalpha = np.cos(
-                    2 * np.pi * pulse.frequency * t + pulse.relative_phase
-                )
-                sinalpha = np.sin(
-                    2 * np.pi * pulse.frequency * t + pulse.relative_phase
-                )
-                wfm = i_env * sinalpha + q_env * cosalpha
+                # Qubit drive microwave signals
+                elif "drive" in ch:
+                    end = start + len(i_env)
+                    t = np.arange(start, end) / dac_sampling_rate
+                    cosalpha = np.cos(
+                        2 * np.pi * pulse.frequency * t + pulse.relative_phase
+                    )
+                    sinalpha = np.sin(
+                        2 * np.pi * pulse.frequency * t + pulse.relative_phase
+                    )
+                    wfm = i_env * sinalpha + q_env * cosalpha
 
-            elif pulse.type == PulseType.READOUT:
-                # For readout pulses, we move the corresponding DAC/ADC pair to the start of the pulse to save memory
-                # This locks the phase of the readout in the demodulation
-                adc = self.ports(pulse.channel).adc
-                start = 0
+                elif "probe" in ch:
+                    # For readout pulses, we move the corresponding DAC/ADC pair to the start of the pulse to save memory
+                    # This locks the phase of the readout in the demodulation
+                    adc = self.ports(pulse.channel).adc
+                    start = 0
 
-                end = start + len(i_env)
-                t = np.arange(start, end) / dac_sampling_rate
-                cosalpha = np.cos(
-                    2 * np.pi * pulse.frequency * t + pulse.relative_phase
-                )
-                sinalpha = np.sin(
-                    2 * np.pi * pulse.frequency * t + pulse.relative_phase
-                )
-                wfm = i_env * sinalpha + q_env * cosalpha
+                    end = start + len(i_env)
+                    t = np.arange(start, end) / dac_sampling_rate
+                    cosalpha = np.cos(
+                        2 * np.pi * pulse.frequency * t + pulse.relative_phase
+                    )
+                    sinalpha = np.sin(
+                        2 * np.pi * pulse.frequency * t + pulse.relative_phase
+                    )
+                    wfm = i_env * sinalpha + q_env * cosalpha
 
-                # First we convert the pulse starting time to number of ADC samples
-                # Then, we convert this number to the number of ADC clock cycles (8 samples per clock cycle)
-                # Next, we raise it to the next nearest integer to prevent an overlap between drive and readout pulses
-                # Finally, we ensure that the number is even for the DAC delay conversion
-                delay_start_adc = int(
-                    int(
-                        np.ceil(
-                            self.device.adc_sampling_rate * 1e6 * pulse.start * 1e-9 / 8
+                    # First we convert the pulse starting time to number of ADC samples
+                    # Then, we convert this number to the number of ADC clock cycles (8 samples per clock cycle)
+                    # Next, we raise it to the next nearest integer to prevent an overlap between drive and readout pulses
+                    # Finally, we ensure that the number is even for the DAC delay conversion
+                    delay_start_adc = int(
+                        int(
+                            np.ceil(
+                                self.device.adc_sampling_rate
+                                * 1e6
+                                * pulse.start
+                                * 1e-9
+                                / 8
+                            )
+                            / 2
                         )
-                        / 2
-                    )
-                    * 2
-                )
-
-                # For the DAC, currently the sampling rate is 3x higher than the ADC
-                # The number of clock cycles is 16 samples per clock cycle
-                # Hence, we multiply the adc delay clock cycles by 1.5x to align the DAC/ADC pair
-                delay_start_dac = int(delay_start_adc * 1.5)
-
-                self.device.dac[dac].delay = (
-                    delay_start_dac + self.channel_delay_offset_dac
-                )
-                self.device.adc[adc].delay = (
-                    delay_start_adc + self.channel_delay_offset_adc
-                )
-                # ADC0 complete marks the end of acquisition, so we also need to move ADC0
-                self.device.adc[0].delay = (
-                    delay_start_adc + self.channel_delay_offset_adc
-                )
-
-                if (
-                    options.acquisition_type is AcquisitionType.DISCRIMINATION
-                    or AcquisitionType.INTEGRATION
-                ):
-                    self.device.program_qunit(
-                        readout_frequency=pulse.frequency,
-                        readout_time=pulse.duration * 1e-9,
-                        qunit=pulse.qubit,
+                        * 2
                     )
 
-            end = start + len(wfm)
-            waveform_array[dac][start:end] += self.device.dac_max_amplitude * wfm
-            dac_end_addr[dac] = max(end >> 4, dac_end_addr[dac])
+                    # For the DAC, currently the sampling rate is 3x higher than the ADC
+                    # The number of clock cycles is 16 samples per clock cycle
+                    # Hence, we multiply the adc delay clock cycles by 1.5x to align the DAC/ADC pair
+                    delay_start_dac = int(delay_start_adc * 1.5)
+
+                    self.device.dac[dac].delay = (
+                        delay_start_dac + self.channel_delay_offset_dac
+                    )
+                    self.device.adc[adc].delay = (
+                        delay_start_adc + self.channel_delay_offset_adc
+                    )
+                    # ADC0 complete marks the end of acquisition, so we also need to move ADC0
+                    self.device.adc[0].delay = (
+                        delay_start_adc + self.channel_delay_offset_adc
+                    )
+
+                    if (
+                        options.acquisition_type is AcquisitionType.DISCRIMINATION
+                        or AcquisitionType.INTEGRATION
+                    ):
+                        self.device.program_qunit(
+                            readout_frequency=pulse.frequency,
+                            readout_time=pulse.duration * 1e-9,
+                            qunit=pulse.qubit,
+                        )
+
+                end = start + len(wfm)
+                waveform_array[dac][start:end] += self.device.dac_max_amplitude * wfm
+                dac_end_addr[dac] = max(end >> 4, dac_end_addr[dac])
 
         payload = [
             (dac, wfm, dac_end_addr[dac])
@@ -237,9 +242,7 @@ class RFSOC_RO(RFSOC):
         """
         super().play(qubits, couplers, sequence, options)
         self.device.set_adc_trigger_repetition_rate(int(options.relaxation_time / 1e3))
-        readout_pulses = [
-            pulse for pulse in sequence.pulses if pulse.type is PulseType.READOUT
-        ]
+        readout_pulses = sequence.probe_pulses
         readout_qubits = [pulse.qubit for pulse in readout_pulses]
 
         if options.acquisition_type is AcquisitionType.RAW:
@@ -346,8 +349,11 @@ class RFSOC_RO(RFSOC):
 
                 # Since the sweeper will modify the readout pulse serial, we collate the results with the qubit number.
                 # This is only for qibocal compatiability and will be removed with IcarusQ v2.
-                if pulse.type is PulseType.READOUT:
-                    res[pulse.serial] = res[pulse.qubit]
+                # FIXME: if this was required, now it's completely broken, since it
+                # isn't possible to identify the pulse channel from the pulse itself
+                # (nor it should be needed)
+                # if pulse.type is PulseType.READOUT:
+                #     res[pulse.serial] = res[pulse.qubit]
 
         return res
 

--- a/src/qibolab/instruments/qblox/cluster_qcm_bb.py
+++ b/src/qibolab/instruments/qblox/cluster_qcm_bb.py
@@ -18,7 +18,7 @@ from qibolab.instruments.qblox.q1asm import (
 )
 from qibolab.instruments.qblox.sequencer import Sequencer, WaveformsBuffer
 from qibolab.instruments.qblox.sweeper import QbloxSweeper, QbloxSweeperType
-from qibolab.pulses import Pulse, PulseSequence, PulseType
+from qibolab.pulses import Pulse, PulseSequence
 from qibolab.sweeper import Parameter, Sweeper, SweeperType
 
 

--- a/src/qibolab/instruments/qblox/cluster_qcm_bb.py
+++ b/src/qibolab/instruments/qblox/cluster_qcm_bb.py
@@ -616,7 +616,9 @@ class QcmBb(ClusterModule):
                         and pulses[n].sweeper.type == QbloxSweeperType.duration
                     ):
                         RI = pulses[n].sweeper.register
-                        if pulses[n].type == PulseType.FLUX:
+                        # FIXME:
+                        # if pulses[n].type == PulseType.FLUX:
+                        if True:
                             RQ = pulses[n].sweeper.register
                         else:
                             RQ = pulses[n].sweeper.aux_register

--- a/src/qibolab/instruments/qblox/cluster_qcm_rf.py
+++ b/src/qibolab/instruments/qblox/cluster_qcm_rf.py
@@ -18,7 +18,7 @@ from qibolab.instruments.qblox.q1asm import (
 )
 from qibolab.instruments.qblox.sequencer import Sequencer, WaveformsBuffer
 from qibolab.instruments.qblox.sweeper import QbloxSweeper, QbloxSweeperType
-from qibolab.pulses import Pulse, PulseSequence, PulseType
+from qibolab.pulses import Pulse, PulseSequence
 from qibolab.sweeper import Parameter, Sweeper, SweeperType
 
 

--- a/src/qibolab/instruments/qblox/cluster_qcm_rf.py
+++ b/src/qibolab/instruments/qblox/cluster_qcm_rf.py
@@ -610,7 +610,9 @@ class QcmRf(ClusterModule):
                         and pulses[n].sweeper.type == QbloxSweeperType.duration
                     ):
                         RI = pulses[n].sweeper.register
-                        if pulses[n].type == PulseType.FLUX:
+                        # FIXME:
+                        # if pulses[n].type == PulseType.FLUX:
+                        if True:
                             RQ = pulses[n].sweeper.register
                         else:
                             RQ = pulses[n].sweeper.aux_register

--- a/src/qibolab/instruments/qblox/cluster_qrm_rf.py
+++ b/src/qibolab/instruments/qblox/cluster_qrm_rf.py
@@ -711,7 +711,9 @@ class QrmRf(ClusterModule):
                                 comment=f"set relative phase {pulses[n].relative_phase} rads",
                             )
 
-                    if pulses[n].type == PulseType.READOUT:
+                    # FIXME:
+                    # if pulses[n].type == PulseType.READOUT:
+                    if True:
                         delay_after_play = self._ports["i1"].acquisition_hold_off
 
                         if len(pulses) > n + 1:
@@ -742,7 +744,9 @@ class QrmRf(ClusterModule):
                             and pulses[n].sweeper.type == QbloxSweeperType.duration
                         ):
                             RI = pulses[n].sweeper.register
-                            if pulses[n].type == PulseType.FLUX:
+                            # FIXME:
+                            # if pulses[n].type == PulseType.FLUX:
+                            if True:
                                 RQ = pulses[n].sweeper.register
                             else:
                                 RQ = pulses[n].sweeper.aux_register
@@ -789,7 +793,9 @@ class QrmRf(ClusterModule):
                             and pulses[n].sweeper.type == QbloxSweeperType.duration
                         ):
                             RI = pulses[n].sweeper.register
-                            if pulses[n].type == PulseType.FLUX:
+                            # FIXME:
+                            # if pulses[n].type == PulseType.FLUX:
+                            if True:
                                 RQ = pulses[n].sweeper.register
                             else:
                                 RQ = pulses[n].sweeper.aux_register

--- a/src/qibolab/instruments/qblox/cluster_qrm_rf.py
+++ b/src/qibolab/instruments/qblox/cluster_qrm_rf.py
@@ -10,7 +10,7 @@ from qblox_instruments.qcodes_drivers.cluster import Cluster
 from qblox_instruments.qcodes_drivers.module import Module
 from qibo.config import log
 
-from qibolab.pulses import Pulse, PulseSequence, PulseType
+from qibolab.pulses import Pulse, PulseSequence
 from qibolab.sweeper import Parameter, Sweeper, SweeperType
 
 from .acquisition import AveragedAcquisition, DemodulatedAcquisition

--- a/src/qibolab/instruments/qblox/controller.py
+++ b/src/qibolab/instruments/qblox/controller.py
@@ -359,7 +359,9 @@ class QbloxController(Controller):
                 elif sweeper.parameter is Parameter.lo_frequency:
                     initial = {}
                     for pulse in sweeper.pulses:
-                        if pulse.type == PulseType.READOUT:
+                        # FIXME:
+                        # if pulse.type == PulseType.READOUT:
+                        if True:
                             initial[pulse.id] = qubits[pulse.qubit].readout.lo_frequency
                             if sweeper.type == SweeperType.ABSOLUTE:
                                 qubits[pulse.qubit].readout.lo_frequency = value
@@ -371,8 +373,9 @@ class QbloxController(Controller):
                                 qubits[pulse.qubit].readout.lo_frequency = (
                                     initial[pulse.id] * value
                                 )
-
-                        elif pulse.type == PulseType.DRIVE:
+                        # FIXME:
+                        # elif pulse.type == PulseType.DRIVE:
+                        elif True:
                             initial[pulse.id] = qubits[pulse.qubit].drive.lo_frequency
                             if sweeper.type == SweeperType.ABSOLUTE:
                                 qubits[pulse.qubit].drive.lo_frequency = value

--- a/src/qibolab/instruments/qblox/controller.py
+++ b/src/qibolab/instruments/qblox/controller.py
@@ -11,7 +11,7 @@ from qibolab.instruments.qblox.cluster_qcm_bb import QcmBb
 from qibolab.instruments.qblox.cluster_qcm_rf import QcmRf
 from qibolab.instruments.qblox.cluster_qrm_rf import QrmRf
 from qibolab.instruments.qblox.sequencer import SAMPLING_RATE
-from qibolab.pulses import PulseSequence, PulseType
+from qibolab.pulses import PulseSequence
 from qibolab.sweeper import Parameter, Sweeper, SweeperType
 from qibolab.unrolling import Bounds
 

--- a/src/qibolab/instruments/qblox/sequencer.py
+++ b/src/qibolab/instruments/qblox/sequencer.py
@@ -136,7 +136,9 @@ class WaveformsBuffer:
         # there may be other waveforms stored already, set first index as the next available
         first_idx = len(self.unique_waveforms)
 
-        if pulse.type == PulseType.FLUX:
+        # FIXME:
+        # if pulses.type == PulseType.FLUX:
+        if True:
             # for flux pulses, store i waveforms
             idx_range = np.arange(first_idx, first_idx + len(values), 1)
 

--- a/src/qibolab/instruments/qblox/sequencer.py
+++ b/src/qibolab/instruments/qblox/sequencer.py
@@ -4,7 +4,7 @@ import numpy as np
 from qblox_instruments.qcodes_drivers.sequencer import Sequencer as QbloxSequencer
 
 from qibolab.instruments.qblox.q1asm import Program
-from qibolab.pulses import Pulse, PulseSequence, PulseType
+from qibolab.pulses import Pulse, PulseSequence
 from qibolab.pulses.modulation import modulate
 from qibolab.sweeper import Parameter, Sweeper
 

--- a/src/qibolab/instruments/rfsoc/driver.py
+++ b/src/qibolab/instruments/rfsoc/driver.py
@@ -434,6 +434,11 @@ class RFSoC(Controller):
             A boolean value true if the sweeper must be executed by python
             loop, false otherwise
         """
+        # FIXME: since pulse types have been deprecated, now channel types should be
+        # used instead. In the following, the code is relying on a non-standard channels
+        # naming convention, and thus fragile (or just broken)
+        # instead, the channel object should be retrieved from the platform
+        # configuration, and its type should be inspected
         if any("flux" in ch for ch in sequence):
             return True
         for sweeper in sweepers:

--- a/src/qibolab/instruments/rfsoc/driver.py
+++ b/src/qibolab/instruments/rfsoc/driver.py
@@ -12,7 +12,7 @@ from qibosoq import client
 from qibolab import AcquisitionType, AveragingMode, ExecutionParameters
 from qibolab.couplers import Coupler
 from qibolab.instruments.abstract import Controller
-from qibolab.pulses import PulseSequence, PulseType
+from qibolab.pulses import PulseSequence
 from qibolab.qubits import Qubit
 from qibolab.sweeper import BIAS, Sweeper
 

--- a/src/qibolab/instruments/rfsoc/driver.py
+++ b/src/qibolab/instruments/rfsoc/driver.py
@@ -434,7 +434,7 @@ class RFSoC(Controller):
             A boolean value true if the sweeper must be executed by python
             loop, false otherwise
         """
-        if any(pulse.type is PulseType.FLUX for pulse in sequence):
+        if any("flux" in ch for ch in sequence):
             return True
         for sweeper in sweepers:
             if all(
@@ -453,7 +453,9 @@ class RFSoC(Controller):
 
             for sweep_idx, parameter in enumerate(sweeper.parameters):
                 is_freq = parameter is rfsoc.Parameter.FREQUENCY
-                is_ro = sequence[sweeper.indexes[sweep_idx]].type == PulseType.READOUT
+                # FIXME: the sequence can not even be indexed like this any longer
+                # is_ro = sequence[sweeper.indexes[sweep_idx]].type == PulseType.READOUT
+                is_ro = False
                 # if it's a sweep on the readout freq do a python sweep
                 if is_freq and is_ro:
                     return True

--- a/src/qibolab/instruments/zhinst/pulse.py
+++ b/src/qibolab/instruments/zhinst/pulse.py
@@ -15,7 +15,9 @@ from .constants import NANO_TO_SECONDS, SAMPLING_RATE
 def select_pulse(pulse: Pulse):
     """Return laboneq pulse object corresponding to the given qibolab pulse."""
     if isinstance(pulse.envelope, Rectangular):
-        can_compress = pulse.type is not PulseType.READOUT
+        # FIXME:
+        # can_compress = pulse.type is not PulseType.READOUT
+        can_compress = False
         return laboneq.pulse_library.const(
             length=round(pulse.duration * NANO_TO_SECONDS, 9),
             amplitude=pulse.amplitude,
@@ -33,7 +35,9 @@ def select_pulse(pulse: Pulse):
     if isinstance(pulse.envelope, GaussianSquare):
         sigma = pulse.envelope.rel_sigma
         width = pulse.envelope.width
-        can_compress = pulse.type is not PulseType.READOUT
+        # FIXME:
+        # can_compress = pulse.type is not PulseType.READOUT
+        can_compress = False
         return laboneq.pulse_library.gaussian_square(
             length=round(pulse.duration * NANO_TO_SECONDS, 9),
             width=round(pulse.duration * NANO_TO_SECONDS, 9) * width,

--- a/src/qibolab/instruments/zhinst/pulse.py
+++ b/src/qibolab/instruments/zhinst/pulse.py
@@ -7,7 +7,7 @@ from laboneq.dsl.experiment.pulse_library import (
     sampled_pulse_real,
 )
 
-from qibolab.pulses import Drag, Gaussian, GaussianSquare, Pulse, PulseType, Rectangular
+from qibolab.pulses import Drag, Gaussian, GaussianSquare, Pulse, Rectangular
 
 from .constants import NANO_TO_SECONDS, SAMPLING_RATE
 

--- a/src/qibolab/instruments/zhinst/sweep.py
+++ b/src/qibolab/instruments/zhinst/sweep.py
@@ -22,7 +22,9 @@ def classify_sweepers(
     for sweeper in sweepers:
         if sweeper.parameter is Parameter.bias or (
             sweeper.parameter is Parameter.amplitude
-            and sweeper.pulses[0].type is PulseType.READOUT
+            # FIXME:
+            # and sweeper.pulses[0].type is PulseType.READOUT
+            and False
         ):
             nt_sweepers.append(sweeper)
         else:

--- a/src/qibolab/instruments/zhinst/sweep.py
+++ b/src/qibolab/instruments/zhinst/sweep.py
@@ -6,7 +6,7 @@ from copy import copy
 import laboneq.simple as laboneq
 
 from qibolab.components import Config
-from qibolab.pulses import Pulse, PulseType
+from qibolab.pulses import Pulse
 from qibolab.sweeper import Parameter, Sweeper
 
 from . import ZiChannel

--- a/src/qibolab/pulses/__init__.py
+++ b/src/qibolab/pulses/__init__.py
@@ -1,3 +1,3 @@
 from .envelope import *
-from .pulse import Delay, Pulse, PulseType, VirtualZ
+from .pulse import Delay, Pulse, VirtualZ
 from .sequence import PulseSequence

--- a/src/qibolab/pulses/pulse.py
+++ b/src/qibolab/pulses/pulse.py
@@ -1,6 +1,5 @@
 """Pulse class."""
 
-from enum import Enum
 from typing import Union
 
 import numpy as np
@@ -8,22 +7,6 @@ import numpy as np
 from qibolab.serialize_ import Model
 
 from .envelope import Envelope, IqWaveform, Waveform
-
-
-class PulseType(Enum):
-    """An enumeration to distinguish different types of pulses.
-
-    READOUT pulses triger acquisitions. DRIVE pulses are used to control
-    qubit states. FLUX pulses are used to shift the frequency of flux
-    tunable qubits and with it implement two-qubit gates.
-    """
-
-    READOUT = "ro"
-    DRIVE = "qd"
-    FLUX = "qf"
-    COUPLERFLUX = "cf"
-    DELAY = "dl"
-    VIRTUALZ = "vz"
 
 
 class _PulseLike(Model):
@@ -51,8 +34,6 @@ class Pulse(_PulseLike):
     """
     relative_phase: float = 0.0
     """Relative phase of the pulse, in radians."""
-    type: PulseType = PulseType.DRIVE
-    """Pulse type, as an element of PulseType enumeration."""
 
     @classmethod
     def flux(cls, **kwargs):
@@ -62,8 +43,6 @@ class Pulse(_PulseLike):
         suitable defaults.
         """
         kwargs["relative_phase"] = 0
-        if "type" not in kwargs:
-            kwargs["type"] = PulseType.FLUX
         return cls(**kwargs)
 
     def i(self, sampling_rate: float) -> Waveform:
@@ -87,8 +66,6 @@ class Delay(_PulseLike):
 
     duration: int
     """Delay duration in ns."""
-    type: PulseType = PulseType.DELAY
-    """Type fixed to ``DELAY`` to comply with ``Pulse`` interface."""
 
 
 class VirtualZ(_PulseLike):
@@ -96,7 +73,6 @@ class VirtualZ(_PulseLike):
 
     phase: float
     """Phase that implements the rotation."""
-    type: PulseType = PulseType.VIRTUALZ
 
     @property
     def duration(self):

--- a/src/qibolab/pulses/sequence.py
+++ b/src/qibolab/pulses/sequence.py
@@ -3,7 +3,7 @@
 from collections import defaultdict
 from typing import Optional
 
-from .pulse import Delay, PulseLike, PulseType
+from .pulse import Delay, Pulse, PulseLike
 
 
 class PulseSequence(defaultdict[str, list[PulseLike]]):
@@ -21,16 +21,20 @@ class PulseSequence(defaultdict[str, list[PulseLike]]):
     def probe_pulses(self):
         """Return list of the readout pulses in this sequence."""
         pulses = []
-        for seq in self.values():
+        for name, seq in self.items():
+            if "probe" not in name:
+                continue
+
             for pulse in seq:
-                if pulse.type == PulseType.READOUT:
+                # exclude delays
+                if isinstance(pulse, Pulse):
                     pulses.append(pulse)
         return pulses
 
     @property
-    def duration(self) -> int:
+    def duration(self) -> float:
         """Duration of the entire sequence."""
-        return max((self.channel_duration(ch) for ch in self), default=0)
+        return max((self.channel_duration(ch) for ch in self), default=0.0)
 
     def channel_duration(self, channel: str) -> float:
         """Duration of the given channel."""

--- a/src/qibolab/serialize.py
+++ b/src/qibolab/serialize.py
@@ -209,7 +209,6 @@ def dump_qubit_name(name: QubitId) -> str:
 
 def _dump_pulse(pulse: Pulse):
     data = pulse.model_dump()
-    data["type"] = data["type"].value
     if "channel" in data:
         del data["channel"]
     if "relative_phase" in data:

--- a/tests/dummy_qrc/zurich/parameters.json
+++ b/tests/dummy_qrc/zurich/parameters.json
@@ -22,63 +22,63 @@
     }
   },
   "components": {
-    "qubit_0/drive" : {
+    "qubit_0/drive": {
       "frequency": 4000000000,
       "power_range": 5
     },
-    "qubit_1/drive" : {
+    "qubit_1/drive": {
       "frequency": 4200000000,
       "power_range": 0
     },
-    "qubit_2/drive" : {
+    "qubit_2/drive": {
       "frequency": 4500000000,
       "power_range": -5
     },
-    "qubit_3/drive" : {
+    "qubit_3/drive": {
       "frequency": 4150000000,
       "power_range": -10
     },
-    "qubit_4/drive" : {
+    "qubit_4/drive": {
       "frequency": 4155663000,
       "power_range": 5
     },
-    "qubit_0/flux" : {
+    "qubit_0/flux": {
       "offset": -0.1,
       "power_range": 0.2
     },
-    "qubit_1/flux" : {
+    "qubit_1/flux": {
       "offset": 0.0,
       "power_range": 0.6
     },
-    "qubit_2/flux" : {
+    "qubit_2/flux": {
       "offset": 0.1,
       "power_range": 0.4
     },
-    "qubit_3/flux" : {
+    "qubit_3/flux": {
       "offset": 0.2,
       "power_range": 1
     },
-    "qubit_4/flux" : {
+    "qubit_4/flux": {
       "offset": 0.15,
       "power_range": 5
     },
-    "qubit_0/probe" : {
+    "qubit_0/probe": {
       "frequency": 5200000000,
       "power_range": -10
     },
-    "qubit_1/probe" : {
+    "qubit_1/probe": {
       "frequency": 4900000000,
       "power_range": -10
     },
-    "qubit_2/probe" : {
+    "qubit_2/probe": {
       "frequency": 6100000000,
       "power_range": -10
     },
-    "qubit_3/probe" : {
+    "qubit_3/probe": {
       "frequency": 5800000000,
       "power_range": -10
     },
-    "qubit_4/probe" : {
+    "qubit_4/probe": {
       "frequency": 5500000000,
       "power_range": -10
     },
@@ -107,19 +107,19 @@
       "smearing": 0,
       "power_range": 10
     },
-    "coupler_0/flux" : {
+    "coupler_0/flux": {
       "offset": 0.0,
       "power_range": 3
     },
-    "coupler_1/flux" : {
+    "coupler_1/flux": {
       "offset": 0.0,
       "power_range": 1
     },
-    "coupler_3/flux" : {
+    "coupler_3/flux": {
       "offset": 0.0,
       "power_range": 0.4
     },
-    "coupler_4/flux" : {
+    "coupler_4/flux": {
       "offset": 0.0,
       "power_range": 0.4
     },
@@ -142,154 +142,140 @@
   },
   "native_gates": {
     "single_qubit": {
-            "0": {
-                "RX": {
-                    "qubit_0/drive": [
-                        {
-                            "duration": 40,
-                            "amplitude": 0.5,
-                            "envelope": { "kind": "gaussian", "rel_sigma": 2.0 },
-                            "type": "qd"
-                        }
-                    ]
-                },
-                "MZ": {
-                    "qubit_0/probe": [
-                        {
-                            "duration": 2000,
-                            "amplitude": 0.1,
-                            "envelope": { "kind": "rectangular" },
-                            "type": "ro"
-                        }
-                    ]
-                }
-            },
-            "1": {
-                "RX": {
-                    "qubit_1/drive": [
-                        {
-                            "duration": 40,
-                            "amplitude": 0.5,
-                            "envelope": { "kind": "gaussian", "rel_sigma": 2.0 },
-                            "type": "qd"
-                        }
-                    ]
-                },
-                "MZ": {
-                    "qubit_1/probe": [
-                        {
-                            "duration": 2000,
-                            "amplitude": 0.2,
-                            "envelope": { "kind": "rectangular" },
-                            "type": "ro"
-                        }
-                    ]
-                }
-            },
-            "2": {
-                "RX": {
-                    "qubit_2/drive": [
-                        {
-                            "duration": 40,
-                            "amplitude": 0.54,
-                            "envelope": { "kind": "gaussian", "rel_sigma": 2.0 },
-                            "type": "qd"
-                        }
-                    ]
-                },
-                "MZ": {
-                    "qubit_2/probe": [
-                        {
-                            "duration": 2000,
-                            "amplitude": 0.02,
-                            "envelope": { "kind": "rectangular" },
-                            "type": "ro"
-                        }
-                    ]
-                }
-            },
-            "3": {
-                "RX": {
-                    "qubit_3/drive": [
-                        {
-                            "duration": 40,
-                            "amplitude": 0.454,
-                            "envelope": { "kind": "gaussian", "rel_sigma": 2.0 },
-                            "type": "qd"
-                        }
-                    ]
-                },
-                "MZ": {
-                    "qubit_3/probe": [
-                        {
-                            "duration": 2000,
-                            "amplitude": 0.25,
-                            "envelope": { "kind": "rectangular" },
-                            "type": "ro"
-                        }
-                    ]
-                }
-            },
-            "4": {
-                "RX": {
-                    "qubit_4/drive": [
-                        {
-                            "duration": 40,
-                            "amplitude": 0.6,
-                            "envelope": { "kind": "gaussian", "rel_sigma": 2.0 },
-                            "type": "qd"
-                        }
-                    ]
-                },
-                "MZ": {
-                    "qubit_4/probe": [
-                        {
-                            "duration": 2000,
-                            "amplitude": 0.31,
-                            "envelope": { "kind": "rectangular" },
-                            "type": "ro"
-                        }
-                    ]
-                }
+      "0": {
+        "RX": {
+          "qubit_0/drive": [
+            {
+              "duration": 40.0,
+              "amplitude": 0.5,
+              "envelope": { "kind": "gaussian", "rel_sigma": 2.0 }
             }
+          ]
+        },
+        "MZ": {
+          "qubit_0/probe": [
+            {
+              "duration": 2000.0,
+              "amplitude": 0.1,
+              "envelope": { "kind": "rectangular" }
+            }
+          ]
+        }
+      },
+      "1": {
+        "RX": {
+          "qubit_1/drive": [
+            {
+              "duration": 40.0,
+              "amplitude": 0.5,
+              "envelope": { "kind": "gaussian", "rel_sigma": 2.0 }
+            }
+          ]
+        },
+        "MZ": {
+          "qubit_1/probe": [
+            {
+              "duration": 2000.0,
+              "amplitude": 0.2,
+              "envelope": { "kind": "rectangular" }
+            }
+          ]
+        }
+      },
+      "2": {
+        "RX": {
+          "qubit_2/drive": [
+            {
+              "duration": 40.0,
+              "amplitude": 0.54,
+              "envelope": { "kind": "gaussian", "rel_sigma": 2.0 }
+            }
+          ]
+        },
+        "MZ": {
+          "qubit_2/probe": [
+            {
+              "duration": 2000.0,
+              "amplitude": 0.02,
+              "envelope": { "kind": "rectangular" }
+            }
+          ]
+        }
+      },
+      "3": {
+        "RX": {
+          "qubit_3/drive": [
+            {
+              "duration": 40.0,
+              "amplitude": 0.454,
+              "envelope": { "kind": "gaussian", "rel_sigma": 2.0 }
+            }
+          ]
+        },
+        "MZ": {
+          "qubit_3/probe": [
+            {
+              "duration": 2000.0,
+              "amplitude": 0.25,
+              "envelope": { "kind": "rectangular" }
+            }
+          ]
+        }
+      },
+      "4": {
+        "RX": {
+          "qubit_4/drive": [
+            {
+              "duration": 40.0,
+              "amplitude": 0.6,
+              "envelope": { "kind": "gaussian", "rel_sigma": 2.0 }
+            }
+          ]
+        },
+        "MZ": {
+          "qubit_4/probe": [
+            {
+              "duration": 2000.0,
+              "amplitude": 0.31,
+              "envelope": { "kind": "rectangular" }
+            }
+          ]
+        }
+      }
     },
     "two_qubit": {
       "0-2": {
         "CZ": {
           "qubit_2/flux": [
             {
-              "duration": 80,
+              "duration": 80.0,
               "amplitude": 0.057,
               "envelope": {
                 "kind": "gaussian_square",
                 "rel_sigma": 5,
                 "width": 0.75
-              },
-              "type": "qf"
+              }
             }
           ],
           "qubit_0/drive": [
             {
-              "type": "vz",
               "phase": 0.0
             }
           ],
           "qubit_2/drive": [
             {
-              "type": "vz",
               "phase": 0.0
             }
           ],
           "coupler_0/flux": [
             {
-              "duration": 30,
+              "duration": 30.0,
               "amplitude": 0.05,
               "envelope": {
                 "kind": "gaussian_square",
                 "rel_sigma": 5,
                 "width": 0.75
-              },
-              "type": "cf"
+              }
             }
           ]
         }
@@ -298,38 +284,34 @@
         "CZ": {
           "qubit_2/flux": [
             {
-              "duration": 30,
+              "duration": 30.0,
               "amplitude": 0.05,
               "envelope": {
                 "kind": "gaussian_square",
                 "rel_sigma": 5,
                 "width": 0.75
-              },
-              "type": "qf"
+              }
             }
           ],
           "qubit_1/drive": [
             {
-              "type": "vz",
               "phase": 0.0
             }
           ],
           "qubit_2/drive": [
             {
-              "type": "vz",
               "phase": 0.0
             }
           ],
           "coupler_1/flux": [
             {
-              "duration": 30,
+              "duration": 30.0,
               "amplitude": 0.05,
               "envelope": {
                 "kind": "gaussian_square",
                 "rel_sigma": 5,
                 "width": 0.75
-              },
-              "type": "cf"
+              }
             }
           ]
         }
@@ -338,38 +320,34 @@
         "CZ": {
           "qubit_2/flux": [
             {
-              "duration": 30,
+              "duration": 30.0,
               "amplitude": 0.05,
               "envelope": {
                 "kind": "gaussian_square",
                 "rel_sigma": 5,
                 "width": 0.75
-              },
-              "type": "qf"
+              }
             }
           ],
           "qubit_2/drive": [
             {
-              "type": "vz",
               "phase": 0.0
             }
           ],
           "qubit_3/drive": [
             {
-              "type": "vz",
               "phase": 0.0
             }
           ],
           "coupler_3/flux": [
             {
-              "duration": 30,
+              "duration": 30.0,
               "amplitude": 0.05,
               "envelope": {
                 "kind": "gaussian_square",
                 "rel_sigma": 5,
                 "width": 0.75
-              },
-              "type": "cf"
+              }
             }
           ]
         }
@@ -378,45 +356,41 @@
         "CZ": {
           "qubit_2/flux": [
             {
-              "duration": 30,
+              "duration": 30.0,
               "amplitude": 0.05,
               "envelope": {
                 "kind": "gaussian_square",
                 "rel_sigma": 5,
                 "width": 0.75
-              },
-              "type": "qf"
+              }
             }
           ],
           "qubit_2/drive": [
             {
-              "type": "vz",
               "phase": 0.0
             }
           ],
           "qubit_4/drive": [
             {
-            "type": "vz",
               "phase": 0.0
             }
           ],
           "coupler_4/flux": [
             {
-              "duration": 30,
+              "duration": 30.0,
               "amplitude": 0.05,
               "envelope": {
                 "kind": "gaussian_square",
                 "rel_sigma": 5,
                 "width": 0.75
-              },
-              "type": "cf"
+              }
             }
           ]
         }
       }
     }
   },
-    "characterization": {
+  "characterization": {
     "single_qubit": {
       "0": {
         "bare_resonator_frequency": 0,

--- a/tests/pulses/test_envelope.py
+++ b/tests/pulses/test_envelope.py
@@ -8,7 +8,6 @@ from qibolab.pulses import (
     GaussianSquare,
     Iir,
     Pulse,
-    PulseType,
     Rectangular,
     Snz,
 )
@@ -30,7 +29,6 @@ def test_sampling_rate(shape):
         frequency=int(100e6),
         envelope=shape,
         relative_phase=0,
-        type=PulseType.DRIVE,
     )
     assert len(pulse.i(sampling_rate=1)) == 40
     assert len(pulse.i(sampling_rate=100)) == 4000
@@ -43,7 +41,6 @@ def test_drag_shape():
         frequency=int(4e9),
         envelope=Drag(rel_sigma=0.5, beta=1),
         relative_phase=0,
-        type=PulseType.DRIVE,
     )
     # envelope i & envelope q should cross nearly at 0 and at 2
     waveform = pulse.i(sampling_rate=10)

--- a/tests/pulses/test_plot.py
+++ b/tests/pulses/test_plot.py
@@ -11,7 +11,6 @@ from qibolab.pulses import (
     Iir,
     Pulse,
     PulseSequence,
-    PulseType,
     Rectangular,
     Snz,
     plot,
@@ -29,7 +28,6 @@ def test_plot_functions():
         frequency=0,
         envelope=Rectangular(),
         relative_phase=0,
-        type=PulseType.FLUX,
     )
     p1 = Pulse(
         duration=40,
@@ -37,7 +35,6 @@ def test_plot_functions():
         frequency=50e6,
         envelope=Gaussian(rel_sigma=0.2),
         relative_phase=0,
-        type=PulseType.DRIVE,
     )
     p2 = Pulse(
         duration=40,
@@ -45,7 +42,6 @@ def test_plot_functions():
         frequency=50e6,
         envelope=Drag(rel_sigma=0.2, beta=2),
         relative_phase=0,
-        type=PulseType.DRIVE,
     )
     p3 = Pulse.flux(
         duration=40,
@@ -59,7 +55,6 @@ def test_plot_functions():
         frequency=400e6,
         envelope=ECap(alpha=2),
         relative_phase=0,
-        type=PulseType.DRIVE,
     )
     p6 = Pulse(
         duration=40,
@@ -67,7 +62,6 @@ def test_plot_functions():
         frequency=50e6,
         envelope=GaussianSquare(rel_sigma=0.2, width=0.9),
         relative_phase=0,
-        type=PulseType.DRIVE,
     )
     ps = PulseSequence()
     ps.update(

--- a/tests/pulses/test_pulse.py
+++ b/tests/pulses/test_pulse.py
@@ -12,7 +12,6 @@ from qibolab.pulses import (
     GaussianSquare,
     Iir,
     Pulse,
-    PulseType,
     Rectangular,
     Snz,
 )
@@ -25,7 +24,6 @@ def test_init():
         amplitude=0.9,
         relative_phase=0.0,
         envelope=Rectangular(),
-        type=PulseType.READOUT,
     )
     assert p0.relative_phase == 0.0
 
@@ -34,9 +32,8 @@ def test_init():
         amplitude=0.9,
         relative_phase=0.0,
         envelope=Rectangular(),
-        type=PulseType.READOUT,
     )
-    assert p1.type is PulseType.READOUT
+    assert p1.amplitude == 0.9
 
     # initialisation with non float (int) relative_phase
     p2 = Pulse(
@@ -44,7 +41,6 @@ def test_init():
         amplitude=0.9,
         relative_phase=1.0,
         envelope=Rectangular(),
-        type=PulseType.READOUT,
     )
     assert isinstance(p2.relative_phase, float) and p2.relative_phase == 1.0
 
@@ -54,28 +50,24 @@ def test_init():
         amplitude=0.9,
         envelope=Rectangular(),
         relative_phase=0,
-        type=PulseType.READOUT,
     )
     p7 = Pulse(
         duration=40,
         amplitude=0.9,
         envelope=Rectangular(),
         relative_phase=0,
-        type=PulseType.FLUX,
     )
     p8 = Pulse(
         duration=40,
         amplitude=0.9,
         envelope=Gaussian(rel_sigma=0.2),
         relative_phase=0,
-        type=PulseType.DRIVE,
     )
     p9 = Pulse(
         duration=40,
         amplitude=0.9,
         envelope=Drag(rel_sigma=0.2, beta=2),
         relative_phase=0,
-        type=PulseType.DRIVE,
     )
     p10 = Pulse.flux(
         duration=40,
@@ -94,14 +86,12 @@ def test_init():
         amplitude=0.9,
         envelope=ECap(alpha=2),
         relative_phase=0,
-        type=PulseType.DRIVE,
     )
     p14 = Pulse(
         duration=40,
         amplitude=0.9,
         envelope=GaussianSquare(rel_sigma=0.2, width=0.9),
         relative_phase=0,
-        type=PulseType.READOUT,
     )
 
     # initialisation with float duration
@@ -110,7 +100,6 @@ def test_init():
         amplitude=0.9,
         relative_phase=1,
         envelope=Rectangular(),
-        type=PulseType.READOUT,
     )
     assert isinstance(p12.duration, float)
     assert p12.duration == 34.33
@@ -128,7 +117,6 @@ def test_attributes():
     assert isinstance(p.amplitude, float) and p.amplitude == 0.9
     assert isinstance(p.relative_phase, float) and p.relative_phase == 0.0
     assert isinstance(p.envelope, BaseEnvelope)
-    assert isinstance(p.type, PulseType)
 
 
 def test_pulse():
@@ -152,7 +140,6 @@ def test_readout_pulse():
         duration=duration,
         relative_phase=0,
         envelope=Rectangular(),
-        type=PulseType.READOUT,
     )
 
     assert pulse.duration == duration

--- a/tests/pulses/test_sequence.py
+++ b/tests/pulses/test_sequence.py
@@ -65,15 +65,15 @@ def test_ro_pulses():
             envelope=Drag(rel_sigma=0.2, beta=2),
         )
     )
-    sequence["ch3/readout"].append(Delay(duration=4))
+    sequence["ch3/probe"].append(Delay(duration=4))
     ro_pulse = Pulse(
         amplitude=0.9,
         duration=2000,
         relative_phase=0,
         envelope=Rectangular(),
     )
-    sequence["ch3/readout"].append(ro_pulse)
-    assert set(sequence.keys()) == {"ch1", "ch2/flux", "ch3/readout"}
+    sequence["ch3/probe"].append(ro_pulse)
+    assert set(sequence.keys()) == {"ch1", "ch2/flux", "ch3/probe"}
     assert sum(len(pulses) for pulses in sequence.values()) == 5
     assert len(sequence.probe_pulses) == 1
     assert sequence.probe_pulses[0] == ro_pulse
@@ -81,8 +81,8 @@ def test_ro_pulses():
 
 def test_durations():
     sequence = PulseSequence()
-    sequence["ch1/readout"].append(Delay(duration=20))
-    sequence["ch1/readout"].append(
+    sequence["ch1/probe"].append(Delay(duration=20))
+    sequence["ch1/probe"].append(
         Pulse(
             duration=1000,
             amplitude=0.9,
@@ -96,11 +96,11 @@ def test_durations():
             envelope=Drag(rel_sigma=0.2, beta=1),
         )
     )
-    assert sequence.channel_duration("ch1/drive") == 20 + 1000
-    assert sequence.channel_duration("ch2/readout") == 40
+    assert sequence.channel_duration("ch1/probe") == 20 + 1000
+    assert sequence.channel_duration("ch2/drive") == 40
     assert sequence.duration == 20 + 1000
 
-    sequence["ch2/readout"].append(
+    sequence["ch2/drive"].append(
         Pulse(
             duration=1200,
             amplitude=0.9,

--- a/tests/pulses/test_sequence.py
+++ b/tests/pulses/test_sequence.py
@@ -1,14 +1,6 @@
 from collections import defaultdict
 
-from qibolab.pulses import (
-    Delay,
-    Drag,
-    Gaussian,
-    Pulse,
-    PulseSequence,
-    PulseType,
-    Rectangular,
-)
+from qibolab.pulses import Delay, Drag, Gaussian, Pulse, PulseSequence, Rectangular
 
 
 def test_init():
@@ -64,26 +56,24 @@ def test_ro_pulses():
             envelope=Gaussian(rel_sigma=0.2),
         )
     )
-    sequence["ch2"].append(Delay(duration=4))
-    sequence["ch2"].append(
+    sequence["ch2/flux"].append(Delay(duration=4))
+    sequence["ch2/flux"].append(
         Pulse(
             amplitude=0.3,
             duration=60,
             relative_phase=0,
             envelope=Drag(rel_sigma=0.2, beta=2),
-            type=PulseType.FLUX,
         )
     )
-    sequence["ch3"].append(Delay(duration=4))
+    sequence["ch3/readout"].append(Delay(duration=4))
     ro_pulse = Pulse(
         amplitude=0.9,
         duration=2000,
         relative_phase=0,
         envelope=Rectangular(),
-        type=PulseType.READOUT,
     )
-    sequence["ch3"].append(ro_pulse)
-    assert set(sequence.keys()) == {"ch1", "ch2", "ch3"}
+    sequence["ch3/readout"].append(ro_pulse)
+    assert set(sequence.keys()) == {"ch1", "ch2/flux", "ch3/readout"}
     assert sum(len(pulses) for pulses in sequence.values()) == 5
     assert len(sequence.probe_pulses) == 1
     assert sequence.probe_pulses[0] == ro_pulse
@@ -91,33 +81,30 @@ def test_ro_pulses():
 
 def test_durations():
     sequence = PulseSequence()
-    sequence["ch1"].append(Delay(duration=20))
-    sequence["ch1"].append(
+    sequence["ch1/readout"].append(Delay(duration=20))
+    sequence["ch1/readout"].append(
         Pulse(
             duration=1000,
             amplitude=0.9,
             envelope=Rectangular(),
-            type=PulseType.READOUT,
         )
     )
-    sequence["ch2"].append(
+    sequence["ch2/drive"].append(
         Pulse(
             duration=40,
             amplitude=0.9,
             envelope=Drag(rel_sigma=0.2, beta=1),
-            type=PulseType.DRIVE,
         )
     )
-    assert sequence.channel_duration("ch1") == 20 + 1000
-    assert sequence.channel_duration("ch2") == 40
+    assert sequence.channel_duration("ch1/drive") == 20 + 1000
+    assert sequence.channel_duration("ch2/readout") == 40
     assert sequence.duration == 20 + 1000
 
-    sequence["ch2"].append(
+    sequence["ch2/readout"].append(
         Pulse(
             duration=1200,
             amplitude=0.9,
             envelope=Rectangular(),
-            type=PulseType.READOUT,
         )
     )
     assert sequence.duration == 40 + 1200

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -2,14 +2,7 @@ import numpy as np
 import pytest
 
 from qibolab import AcquisitionType, AveragingMode, ExecutionParameters, create_platform
-from qibolab.pulses import (
-    Delay,
-    Gaussian,
-    GaussianSquare,
-    Pulse,
-    PulseSequence,
-    PulseType,
-)
+from qibolab.pulses import Delay, Gaussian, GaussianSquare, Pulse, PulseSequence
 from qibolab.sweeper import ChannelParameter, Parameter, Sweeper
 
 SWEPT_POINTS = 5
@@ -52,7 +45,6 @@ def test_dummy_execute_coupler_pulse():
         duration=30,
         amplitude=0.05,
         envelope=GaussianSquare(rel_sigma=5, width=0.75),
-        type=PulseType.COUPLERFLUX,
     )
     sequence[channel.name].append(pulse)
 
@@ -154,7 +146,6 @@ def test_dummy_single_sweep_coupler(
         duration=40,
         amplitude=0.5,
         envelope=GaussianSquare(rel_sigma=0.2, width=0.75),
-        type=PulseType.COUPLERFLUX,
     )
     sequence.extend(probe_seq)
     sequence[platform.get_coupler(0).flux.name].append(coupler_pulse)
@@ -266,9 +257,7 @@ def test_dummy_single_sweep(name, fast_reset, parameter, average, acquisition, n
 def test_dummy_double_sweep(name, parameter1, parameter2, average, acquisition, nshots):
     platform = create_platform(name)
     sequence = PulseSequence()
-    pulse = Pulse(
-        duration=40, amplitude=0.1, envelope=Gaussian(rel_sigma=5), type=PulseType.DRIVE
-    )
+    pulse = Pulse(duration=40, amplitude=0.1, envelope=Gaussian(rel_sigma=5))
     probe_seq = platform.qubits[0].native_gates.MZ.create_sequence()
     probe_pulse = next(iter(probe_seq.values()))[0]
     sequence[platform.get_qubit(0).drive.name].append(pulse)

--- a/tests/test_instruments_qblox_controller.py
+++ b/tests/test_instruments_qblox_controller.py
@@ -5,7 +5,7 @@ import pytest
 
 from qibolab import AveragingMode, ExecutionParameters
 from qibolab.instruments.qblox.controller import MAX_NUM_BINS, QbloxController
-from qibolab.pulses import Gaussian, Pulse, PulseSequence, PulseType, Rectangular
+from qibolab.pulses import Gaussian, Pulse, PulseSequence, Rectangular
 from qibolab.sweeper import Parameter, Sweeper
 
 from .qblox_fixtures import connected_controller, controller

--- a/tests/test_instruments_qm.py
+++ b/tests/test_instruments_qm.py
@@ -6,7 +6,7 @@ from qm import qua
 
 from qibolab import AcquisitionType, ExecutionParameters, create_platform
 from qibolab.instruments.qm import QmController
-from qibolab.pulses import Pulse, PulseSequence, PulseType, Rectangular
+from qibolab.pulses import Pulse, PulseSequence, Rectangular
 from qibolab.qubits import Qubit
 from qibolab.sweeper import Parameter, Sweeper
 

--- a/tests/test_instruments_rfsoc.py
+++ b/tests/test_instruments_rfsoc.py
@@ -14,7 +14,7 @@ from qibolab.instruments.rfsoc.convert import (
     convert_units_sweeper,
     replace_pulse_shape,
 )
-from qibolab.pulses import Drag, Gaussian, Pulse, PulseSequence, PulseType, Rectangular
+from qibolab.pulses import Drag, Gaussian, Pulse, PulseSequence, Rectangular
 from qibolab.qubits import Qubit
 from qibolab.sweeper import Parameter, Sweeper, SweeperType
 

--- a/tests/test_instruments_zhinst.py
+++ b/tests/test_instruments_zhinst.py
@@ -13,7 +13,6 @@ from qibolab.pulses import (
     Iir,
     Pulse,
     PulseSequence,
-    PulseType,
     Rectangular,
     Snz,
 )

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -23,7 +23,7 @@ from qibolab.kernels import Kernels
 from qibolab.platform import Platform, unroll_sequences
 from qibolab.platform.load import PLATFORMS
 from qibolab.platform.platform import update_configs
-from qibolab.pulses import Delay, Gaussian, Pulse, PulseSequence, PulseType, Rectangular
+from qibolab.pulses import Delay, Gaussian, Pulse, PulseSequence, Rectangular
 from qibolab.qubits import Qubit, QubitPair
 from qibolab.serialize import (
     PLATFORM,
@@ -255,7 +255,6 @@ def test_platform_execute_one_drive_pulse(qpu_platform):
             duration=200,
             amplitude=0.07,
             envelope=Gaussian(5),
-            type=PulseType.DRIVE,
         )
     )
     result = platform.execute_pulse_sequence(
@@ -277,7 +276,6 @@ def test_platform_execute_one_coupler_pulse(qpu_platform):
             duration=200,
             amplitude=0.31,
             envelope=Rectangular(),
-            type=PulseType.COUPLERFLUX,
         )
     )
     result = platform.execute_pulse_sequence(
@@ -297,7 +295,6 @@ def test_platform_execute_one_flux_pulse(qpu_platform):
             duration=200,
             amplitude=0.28,
             envelope=Rectangular(),
-            type=PulseType.FLUX,
         )
     )
     result = platform.execute_pulse_sequence(
@@ -311,9 +308,7 @@ def test_platform_execute_one_long_drive_pulse(qpu_platform):
     # Long duration
     platform = qpu_platform
     qubit = next(iter(platform.qubits.values()))
-    pulse = Pulse(
-        duration=8192 + 200, amplitude=0.12, envelope=Gaussian(5), type=PulseType.DRIVE
-    )
+    pulse = Pulse(duration=8192 + 200, amplitude=0.12, envelope=Gaussian(5))
     sequence = PulseSequence()
     sequence[qubit.drive.name].append(pulse)
     options = ExecutionParameters(nshots=nshots)
@@ -333,7 +328,6 @@ def test_platform_execute_one_extralong_drive_pulse(qpu_platform):
         duration=2 * 8192 + 200,
         amplitude=0.12,
         envelope=Gaussian(5),
-        type=PulseType.DRIVE,
     )
     sequence = PulseSequence()
     sequence[qubit.drive.name].append(pulse)
@@ -398,9 +392,7 @@ def test_platform_execute_multiple_overlaping_drive_pulses_one_readout(
     platform = qpu_platform
     qubit_id, qubit = next(iter(platform.qubits.items()))
     sequence = PulseSequence()
-    pulse = Pulse(
-        duration=200, amplitude=0.08, envelope=Gaussian(7), type=PulseType.DRIVE
-    )
+    pulse = Pulse(duration=200, amplitude=0.08, envelope=Gaussian(7))
     sequence[qubit.drive.name].append(pulse)
     sequence[qubit.drive12.name].append(pulse.copy())
     sequence[qubit.probe.name].append(Delay(duration=800))

--- a/tests/test_unrolling.py
+++ b/tests/test_unrolling.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from qibolab.pulses import Drag, Pulse, PulseSequence, PulseType, Rectangular
+from qibolab.pulses import Drag, Pulse, PulseSequence, Rectangular
 from qibolab.unrolling import Bounds, batch
 
 
@@ -13,7 +13,6 @@ def test_bounds_update():
             duration=40,
             amplitude=0.9,
             envelope=Drag(rel_sigma=0.2, beta=1),
-            type=PulseType.DRIVE,
         )
     )
     ps["ch2"].append(
@@ -21,7 +20,6 @@ def test_bounds_update():
             duration=40,
             amplitude=0.9,
             envelope=Drag(rel_sigma=0.2, beta=1),
-            type=PulseType.DRIVE,
         )
     )
     ps["ch1"].append(
@@ -29,7 +27,6 @@ def test_bounds_update():
             duration=40,
             amplitude=0.9,
             envelope=Drag(rel_sigma=0.2, beta=1),
-            type=PulseType.DRIVE,
         )
     )
 
@@ -38,7 +35,6 @@ def test_bounds_update():
             duration=1000,
             amplitude=0.9,
             envelope=Rectangular(),
-            type=PulseType.READOUT,
         )
     )
     ps["ch2"].append(
@@ -46,7 +42,6 @@ def test_bounds_update():
             duration=1000,
             amplitude=0.9,
             envelope=Rectangular(),
-            type=PulseType.READOUT,
         )
     )
     ps["ch1"].append(
@@ -54,7 +49,6 @@ def test_bounds_update():
             duration=1000,
             amplitude=0.9,
             envelope=Rectangular(),
-            type=PulseType.READOUT,
         )
     )
 
@@ -99,7 +93,6 @@ def test_batch(bounds):
             duration=40,
             amplitude=0.9,
             envelope=Drag(rel_sigma=0.2, beta=1),
-            type=PulseType.DRIVE,
         )
     )
     ps["ch2"].append(
@@ -107,7 +100,6 @@ def test_batch(bounds):
             duration=40,
             amplitude=0.9,
             envelope=Drag(rel_sigma=0.2, beta=1),
-            type=PulseType.DRIVE,
         )
     )
     ps["ch1"].append(
@@ -115,7 +107,6 @@ def test_batch(bounds):
             duration=40,
             amplitude=0.9,
             envelope=Drag(rel_sigma=0.2, beta=1),
-            type=PulseType.DRIVE,
         )
     )
 
@@ -124,7 +115,6 @@ def test_batch(bounds):
             duration=1000,
             amplitude=0.9,
             envelope=Rectangular(),
-            type=PulseType.READOUT,
         )
     )
     ps["ch2"].append(
@@ -132,7 +122,6 @@ def test_batch(bounds):
             duration=1000,
             amplitude=0.9,
             envelope=Rectangular(),
-            type=PulseType.READOUT,
         )
     )
     ps["ch1"].append(
@@ -140,7 +129,6 @@ def test_batch(bounds):
             duration=1000,
             amplitude=0.9,
             envelope=Rectangular(),
-            type=PulseType.READOUT,
         )
     )
 

--- a/tests/test_unrolling.py
+++ b/tests/test_unrolling.py
@@ -8,21 +8,21 @@ from qibolab.unrolling import Bounds, batch
 
 def test_bounds_update():
     ps = PulseSequence()
-    ps["ch3"].append(
+    ps["ch3/drive"].append(
         Pulse(
             duration=40,
             amplitude=0.9,
             envelope=Drag(rel_sigma=0.2, beta=1),
         )
     )
-    ps["ch2"].append(
+    ps["ch2/drive"].append(
         Pulse(
             duration=40,
             amplitude=0.9,
             envelope=Drag(rel_sigma=0.2, beta=1),
         )
     )
-    ps["ch1"].append(
+    ps["ch1/drive"].append(
         Pulse(
             duration=40,
             amplitude=0.9,
@@ -30,21 +30,21 @@ def test_bounds_update():
         )
     )
 
-    ps["ch3"].append(
+    ps["ch3/probe"].append(
         Pulse(
             duration=1000,
             amplitude=0.9,
             envelope=Rectangular(),
         )
     )
-    ps["ch2"].append(
+    ps["ch2/probe"].append(
         Pulse(
             duration=1000,
             amplitude=0.9,
             envelope=Rectangular(),
         )
     )
-    ps["ch1"].append(
+    ps["ch1/probe"].append(
         Pulse(
             duration=1000,
             amplitude=0.9,
@@ -88,21 +88,21 @@ def test_bounds_comparison():
 )
 def test_batch(bounds):
     ps = PulseSequence()
-    ps["ch3"].append(
+    ps["ch3/drive"].append(
         Pulse(
             duration=40,
             amplitude=0.9,
             envelope=Drag(rel_sigma=0.2, beta=1),
         )
     )
-    ps["ch2"].append(
+    ps["ch2/drive"].append(
         Pulse(
             duration=40,
             amplitude=0.9,
             envelope=Drag(rel_sigma=0.2, beta=1),
         )
     )
-    ps["ch1"].append(
+    ps["ch1/drive"].append(
         Pulse(
             duration=40,
             amplitude=0.9,
@@ -110,21 +110,21 @@ def test_batch(bounds):
         )
     )
 
-    ps["ch3"].append(
+    ps["ch3/probe"].append(
         Pulse(
             duration=1000,
             amplitude=0.9,
             envelope=Rectangular(),
         )
     )
-    ps["ch2"].append(
+    ps["ch2/probe"].append(
         Pulse(
             duration=1000,
             amplitude=0.9,
             envelope=Rectangular(),
         )
     )
-    ps["ch1"].append(
+    ps["ch1/probe"].append(
         Pulse(
             duration=1000,
             amplitude=0.9,


### PR DESCRIPTION
The current layout is a bit suboptimal, because I'm relying on the convention of the probe channel containing `"probe"` in its name in the sequence, and no one else doing it. But channel names in sequences are arbitrary.

Maybe we should stop using strings, and use a `tuple[QubitId, ChannelType]`.

(yes, it seems like we're removing something from one side, `PulseType`, to reintroduce from another, `ChannelType` - but we already have channel types, they are the `Qubit` attributes, which should somehow match the arbitrary strings in the `PulseSequence`, but they are not really forced to...)