### PR TITLE
QM duration sweeper using multiple waveforms

### DIFF
--- a/src/qibolab/instruments/qm/controller.py
+++ b/src/qibolab/instruments/qm/controller.py
@@ -327,7 +327,7 @@ class QmController(Controller):
             channel = self.channels[channel_name].logical_channel
             for value in sweeper.values:
                 sweep_pulse = pulse.model_copy(updates={"duration": value})
-                sweep_op = self.register_pulse(channel, new_pulse)
+                sweep_op = self.register_pulse(channel, sweep_pulse)
                 args.parameters[op].pulses.append((value, sweep_op))
 
     def register_pulses(

--- a/src/qibolab/instruments/qm/controller.py
+++ b/src/qibolab/instruments/qm/controller.py
@@ -326,7 +326,7 @@ class QmController(Controller):
             channel_name = args.sequence.pulse_channel(pulse.id)
             channel = self.channels[channel_name].logical_channel
             for value in sweeper.values:
-                sweep_pulse = pulse.model_copy(updates={"duration": value})
+                sweep_pulse = pulse.model_copy(update={"duration": value})
                 sweep_op = self.register_pulse(channel, sweep_pulse)
                 args.parameters[op].pulses.append((value, sweep_op))
 

--- a/src/qibolab/instruments/qm/controller.py
+++ b/src/qibolab/instruments/qm/controller.py
@@ -15,7 +15,7 @@ from qibolab.components import AcquireChannel, Channel, Config, DcChannel, IqCha
 from qibolab.execution_parameters import ExecutionParameters
 from qibolab.identifier import ChannelId
 from qibolab.instruments.abstract import Controller
-from qibolab.pulses.pulse import Acquisition, Delay, Pulse, VirtualZ, _Readout
+from qibolab.pulses.pulse import Acquisition, Align, Delay, Pulse, _Readout
 from qibolab.sequence import PulseSequence
 from qibolab.sweeper import ParallelSweepers, Parameter, Sweeper
 from qibolab.unrolling import Bounds
@@ -322,7 +322,7 @@ class QmController(Controller):
             acquisitions (dict): Map from measurement instructions to acquisition objects.
         """
         for channel_id, pulse in sequence:
-            if not isinstance(pulse, (Acquisition, Delay, VirtualZ)):
+            if isinstance(pulse, Pulse):
                 channel = self.channels[str(channel_id)].logical_channel
                 self.register_pulse(channel, pulse)
 
@@ -332,7 +332,7 @@ class QmController(Controller):
         """Register pulse with many different durations, in order to sweep
         duration."""
         for pulse in sweeper.pulses:
-            if isinstance(pulse, Delay):
+            if isinstance(pulse, (Align, Delay)):
                 continue
 
             op = operation(pulse)

--- a/src/qibolab/instruments/qm/controller.py
+++ b/src/qibolab/instruments/qm/controller.py
@@ -17,12 +17,12 @@ from qibolab.identifier import ChannelId
 from qibolab.instruments.abstract import Controller
 from qibolab.pulses.pulse import Acquisition, Delay, VirtualZ, _Readout
 from qibolab.sequence import PulseSequence
-from qibolab.sweeper import ParallelSweepers, Parameter
+from qibolab.sweeper import ParallelSweepers, Parameter, Sweeper
 from qibolab.unrolling import Bounds
 
 from .components import QmChannel
 from .config import SAMPLING_RATE, QmConfig, operation
-from .program import create_acquisition, program
+from .program import ExecutionArguments, create_acquisition, program
 
 OCTAVE_ADDRESS_OFFSET = 11000
 """Offset to be added to Octave addresses, because they must be 11xxx, where
@@ -110,6 +110,11 @@ def fetch_results(result, acquisitions):
     return {
         key: value[0] if len(value) == 1 else value for key, value in results.items()
     }
+
+
+def find_duration_sweepers(sweepers: list[ParallelSweepers]) -> list[Sweeper]:
+    """Find duration sweepers in order to register multiple pulses."""
+    return [s for ps in sweepers for s in ps if s.parameter is Parameter.duration]
 
 
 @dataclass
@@ -291,31 +296,41 @@ class QmController(Controller):
             channel = self.channels[str(channel_id)]
             self.configure_channel(channel, configs)
 
-    def register_pulses(self, configs: dict[str, Config], sequence: PulseSequence):
-        """Adds all pulses except measurements of a given sequence in the QM
-        ``config``.
+    def register_pulse(self, channel: Channel, pulse: Pulse) -> str:
+        """Add pulse in the QM ``config`` and return corresponding
+        operation."""
+        # if (
+        #    pulse.duration % 4 != 0
+        #    or pulse.duration < 16
+        #    or pulse.id in pulses_to_bake
+        # ):
+        #    qmpulse = BakedPulse(pulse, element)
+        #    qmpulse.bake(self.config, durations=[pulse.duration])
+        # else:
+        if isinstance(channel, DcChannel):
+            return self.config.register_dc_pulse(channel.name, pulse)
+        if channel.acquisition is None:
+            return self.config.register_iq_pulse(channel.name, pulse)
+        return self.config.register_acquisition_pulse(channel.name, pulse)
 
-        Returns:
-            acquisitions (dict): Map from measurement instructions to acquisition objects.
-        """
-        for channel_id, pulse in sequence:
-            if not isinstance(pulse, (Acquisition, Delay, VirtualZ)):
-                name = str(channel_id)
-                channel = self.channels[name].logical_channel
-                # if (
-                #    pulse.duration % 4 != 0
-                #    or pulse.duration < 16
-                #    or pulse.id in pulses_to_bake
-                # ):
-                #    qmpulse = BakedPulse(pulse, element)
-                #    qmpulse.bake(self.config, durations=[pulse.duration])
-                # else:
-                if isinstance(channel, DcChannel):
-                    self.config.register_dc_pulse(name, pulse)
-                elif channel.acquisition is None:
-                    self.config.register_iq_pulse(name, pulse)
+    def register_duration_sweeper_pulses(
+        self, args: ExecutionArguments, sweeper: Sweeper
+    ):
+        """Register pulse with many different durations, in order to sweep
+        duration."""
+        for pulse in sweeper.pulses:
+            if isinstance(pulse, Delay):
+                continue
 
-    def register_acquisitions(
+            op = operation(pulse)
+            channel_name = args.sequence.pulse_channel(pulse.id)
+            channel = self.channels[channel_name].logical_channel
+            for value in sweeper.values:
+                sweep_pulse = pulse.model_copy(updates={"duration": value})
+                sweep_op = self.register_pulse(channel, new_pulse)
+                args.parameters[op].pulses.append((value, sweep_op))
+
+    def register_pulses(
         self,
         configs: dict[str, Config],
         sequence: PulseSequence,
@@ -395,7 +410,13 @@ class QmController(Controller):
         self.configure_channels(configs, sequence.channels)
         self.register_pulses(configs, sequence)
         acquisitions = self.register_acquisitions(configs, sequence, options)
-        experiment = program(configs, sequence, options, acquisitions, sweepers)
+
+        args = ExecutionArguments(sequence, acquisitions, options.relaxation_time)
+
+        for sweeper in find_duration_sweepers(sweepers):
+            self.register_duration_sweeper_pulses(args, sweeper)
+
+        experiment = program(configs, args, options, sweepers)
 
         if self.manager is None:
             warnings.warn(

--- a/src/qibolab/instruments/qm/controller.py
+++ b/src/qibolab/instruments/qm/controller.py
@@ -426,8 +426,6 @@ class QmController(Controller):
 
         if self.script_file_name is not None:
             script = generate_qua_script(experiment, asdict(self.config))
-            for _, pulse in sequence:
-                script = script.replace(operation(pulse), str(pulse))
             with open(self.script_file_name, "w") as file:
                 file.write(script)
 

--- a/src/qibolab/instruments/qm/controller.py
+++ b/src/qibolab/instruments/qm/controller.py
@@ -323,7 +323,7 @@ class QmController(Controller):
                 continue
 
             op = operation(pulse)
-            channel_name = args.sequence.pulse_channel(pulse.id)
+            channel_name = args.sequence.pulse_channels(pulse.id)[0]
             channel = self.channels[channel_name].logical_channel
             for value in sweeper.values:
                 sweep_pulse = pulse.model_copy(update={"duration": value})

--- a/src/qibolab/instruments/qm/program/__init__.py
+++ b/src/qibolab/instruments/qm/program/__init__.py
@@ -1,2 +1,3 @@
 from .acquisition import Acquisitions, create_acquisition
+from .arguments import ExecutionArguments
 from .instructions import program

--- a/src/qibolab/instruments/qm/program/arguments.py
+++ b/src/qibolab/instruments/qm/program/arguments.py
@@ -6,7 +6,7 @@ from qm.qua._dsl import _Variable  # for type declaration only
 
 from qibolab.sequence import PulseSequence
 
-from .acquisition import Acquisition
+from .acquisition import Acquisitions
 
 
 @dataclass
@@ -16,6 +16,7 @@ class Parameters:
     duration: Optional[_Variable] = None
     amplitude: Optional[_Variable] = None
     phase: Optional[_Variable] = None
+    pulses: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -27,7 +28,7 @@ class ExecutionArguments:
     """
 
     sequence: PulseSequence
-    acquisitions: dict[tuple[str, str], Acquisition]
+    acquisitions: Acquisitions
     relaxation_time: int = 0
     parameters: dict[str, Parameters] = field(
         default_factory=lambda: defaultdict(Parameters)

--- a/src/qibolab/instruments/qm/program/arguments.py
+++ b/src/qibolab/instruments/qm/program/arguments.py
@@ -16,7 +16,7 @@ class Parameters:
     duration: Optional[_Variable] = None
     amplitude: Optional[_Variable] = None
     phase: Optional[_Variable] = None
-    pulses: list[str] = field(default_factory=list)
+    pulses: list[tuple[float, str]] = field(default_factory=list)
 
 
 @dataclass

--- a/src/qibolab/instruments/qm/program/instructions.py
+++ b/src/qibolab/instruments/qm/program/instructions.py
@@ -18,17 +18,17 @@ from .sweepers import INT_TYPE, NORMALIZERS, SWEEPER_METHODS
 def _delay(pulse: Delay, element: str, parameters: Parameters):
     # TODO: How to play delays on multiple elements?
     if parameters.duration is None:
-        duration = int(pulse.duration) // 4 + 1
+        duration = int(pulse.duration) // 4
     else:
         duration = parameters.duration
-    qua.wait(duration, element)
+    qua.wait(duration + 1, element)
 
 
 def _play_multiple_waveforms(element: str, parameters: Parameters):
     """Sweeping pulse duration using distinctly uploaded waveforms."""
-    with qua.switch_(parameters.duration):
+    with qua.switch_(parameters.duration, unsafe=True):
         for value, sweep_op in parameters.pulses:
-            with qua.case_(value):
+            with qua.case_(value // 4):
                 qua.play(sweep_op, element)
 
 

--- a/src/qibolab/instruments/qm/program/instructions.py
+++ b/src/qibolab/instruments/qm/program/instructions.py
@@ -65,7 +65,7 @@ def play(args: ExecutionArguments):
     # keep track of ``Align`` command that were already played
     # because the same ``Align`` will appear on multiple channels
     # in the sequence
-    played_aligns = set()
+    processed_aligns = set()
 
     for channel_id, pulse in args.sequence:
         element = str(channel_id)
@@ -78,10 +78,10 @@ def play(args: ExecutionArguments):
             _play(op, element, params, acquisition)
         elif isinstance(pulse, VirtualZ):
             qua.frame_rotation_2pi(normalize_phase(pulse.phase), element)
-        elif isinstance(pulse, Align) and pulse.id not in played_aligns:
+        elif isinstance(pulse, Align) and pulse.id not in processed_aligns:
             elements = args.sequence.pulse_channels(pulse.id)
             qua.align(*elements)
-            played_aligns.add(pulse.id)
+            processed_aligns.add(pulse.id)
 
     if args.relaxation_time > 0:
         qua.wait(args.relaxation_time // 4)

--- a/src/qibolab/instruments/qm/program/instructions.py
+++ b/src/qibolab/instruments/qm/program/instructions.py
@@ -79,8 +79,8 @@ def play(args: ExecutionArguments):
         elif isinstance(pulse, VirtualZ):
             qua.frame_rotation_2pi(normalize_phase(pulse.phase), element)
         elif isinstance(pulse, Align) and pulse.id not in processed_aligns:
-            elements = args.sequence.pulse_channels(pulse.id)
-            qua.align(*elements)
+            channel_ids = args.sequence.pulse_channels(pulse.id)
+            qua.align(*(str(ch) for ch in channel_ids))
             processed_aligns.add(pulse.id)
 
     if args.relaxation_time > 0:

--- a/src/qibolab/instruments/qm/program/sweepers.py
+++ b/src/qibolab/instruments/qm/program/sweepers.py
@@ -150,12 +150,17 @@ def _duration(
         args.parameters[operation(pulse)].duration = variable
 
 
-def normalize_phase(phase):
+def normalize_phase(values):
     """Normalize phase from [0, 2pi] to [0, 1]."""
-    return phase / (2 * np.pi)
+    return values / (2 * np.pi)
 
 
-INT_TYPE = {Parameter.frequency, Parameter.duration}
+def normalize_duration(values):
+    """Convert duration from ns to clock cycles (clock cycle = 4ns)."""
+    return (values // 4).astype(int)
+
+
+INT_TYPE = {Parameter.frequency, Parameter.duration, Parameter.duration_interpolated}
 """Sweeper parameters for which we need ``int`` variable type.
 
 The rest parameters need ``fixed`` type.
@@ -163,7 +168,8 @@ The rest parameters need ``fixed`` type.
 
 NORMALIZERS = {
     Parameter.relative_phase: normalize_phase,
-    Parameter.duration: lambda values: (values // 4).astype(int),
+    Parameter.duration: normalize_duration,
+    Parameter.duration_interpolated: normalize_duration,
 }
 """Functions to normalize sweeper values.
 

--- a/src/qibolab/instruments/qm/program/sweepers.py
+++ b/src/qibolab/instruments/qm/program/sweepers.py
@@ -174,6 +174,7 @@ SWEEPER_METHODS = {
     Parameter.frequency: _frequency,
     Parameter.amplitude: _amplitude,
     Parameter.duration: _duration,
+    Parameter.duration_interpolated: _duration,
     Parameter.relative_phase: _relative_phase,
     Parameter.bias: _bias,
 }

--- a/src/qibolab/instruments/qm/program/sweepers.py
+++ b/src/qibolab/instruments/qm/program/sweepers.py
@@ -150,6 +150,11 @@ def _duration(
         args.parameters[operation(pulse)].duration = variable
 
 
+def normalize_phase(phase):
+    """Normalize phase from [0, 2pi] to [0, 1]."""
+    return phase / (2 * np.pi)
+
+
 INT_TYPE = {Parameter.frequency, Parameter.duration}
 """Sweeper parameters for which we need ``int`` variable type.
 
@@ -157,7 +162,7 @@ The rest parameters need ``fixed`` type.
 """
 
 NORMALIZERS = {
-    Parameter.relative_phase: lambda values: values / (2 * np.pi),
+    Parameter.relative_phase: normalize_phase,
     Parameter.duration: lambda values: (values // 4).astype(int),
 }
 """Functions to normalize sweeper values.

--- a/src/qibolab/pulses/__init__.py
+++ b/src/qibolab/pulses/__init__.py
@@ -1,2 +1,2 @@
 from .envelope import *
-from .pulse import Acquisition, Delay, Pulse, PulseLike, VirtualZ
+from .pulse import Align, Acquisition, Delay, Pulse, PulseLike, VirtualZ

--- a/src/qibolab/pulses/__init__.py
+++ b/src/qibolab/pulses/__init__.py
@@ -1,2 +1,2 @@
 from .envelope import *
-from .pulse import Align, Acquisition, Delay, Pulse, PulseLike, VirtualZ
+from .pulse import Acquisition, Align, Delay, Pulse, PulseLike, VirtualZ

--- a/src/qibolab/pulses/plot.py
+++ b/src/qibolab/pulses/plot.py
@@ -143,6 +143,8 @@ def sequence(ps: PulseSequence, freq: dict[str, float], filename=None):
         import matplotlib.pyplot as plt
         from matplotlib import gridspec
 
+        # compile ``Align`` to delays as it is not supported here
+        ps = ps.align_to_delays()
         num_pulses = len(ps)
         _ = plt.figure(figsize=(14, 2 * num_pulses), dpi=200)
         gs = gridspec.GridSpec(ncols=1, nrows=num_pulses)

--- a/src/qibolab/pulses/pulse.py
+++ b/src/qibolab/pulses/pulse.py
@@ -138,6 +138,10 @@ class _Readout(_PulseLike):
         return self.acquisition.id
 
 
+class Align(_PulseLike):
+    """Brings different channels at the same point in time."""
+
+
 PulseLike = Annotated[
-    Union[Pulse, Delay, VirtualZ, Acquisition, _Readout], Field(discriminator="kind")
+    Union[Align, Pulse, Delay, VirtualZ, Acquisition, _Readout], Field(discriminator="kind")
 ]

--- a/src/qibolab/pulses/pulse.py
+++ b/src/qibolab/pulses/pulse.py
@@ -141,6 +141,8 @@ class _Readout(_PulseLike):
 class Align(_PulseLike):
     """Brings different channels at the same point in time."""
 
+    kind: Literal["align"] = "align"
+
 
 PulseLike = Annotated[
     Union[Align, Pulse, Delay, VirtualZ, Acquisition, _Readout],

--- a/src/qibolab/pulses/pulse.py
+++ b/src/qibolab/pulses/pulse.py
@@ -143,5 +143,6 @@ class Align(_PulseLike):
 
 
 PulseLike = Annotated[
-    Union[Align, Pulse, Delay, VirtualZ, Acquisition, _Readout], Field(discriminator="kind")
+    Union[Align, Pulse, Delay, VirtualZ, Acquisition, _Readout],
+    Field(discriminator="kind"),
 ]

--- a/src/qibolab/sequence.py
+++ b/src/qibolab/sequence.py
@@ -82,11 +82,11 @@ class PulseSequence(UserList[_Element]):
 
     def channel_duration(self, channel: ChannelId) -> float:
         """Duration of the given channel."""
-        sequence = self
-        for _, pulse in self:
-            if isinstance(pulse, Align):
-                sequence = self.align_to_delays()
-                break
+        sequence = (
+            self.align_to_delays()
+            if any(isinstance(pulse, Align) for _, pulse in self)
+            else self
+        )
         return sum(pulse.duration for pulse in sequence.channel(channel))
 
     def pulse_channels(self, pulse_id: int) -> list[ChannelId]:

--- a/src/qibolab/sequence.py
+++ b/src/qibolab/sequence.py
@@ -71,6 +71,13 @@ class PulseSequence(UserList[_Element]):
         """Duration of the given channel."""
         return sum(pulse.duration for pulse in self.channel(channel))
 
+    def pulse_channel(self, pulse_id: int) -> ChannelId:
+        """Find channel on which a pulse with a given id plays."""
+        for channel, pulse in self:
+            if pulse.id == pulse_id:
+                return channel
+        raise ValueError(f"Pulse with id {pulse_id} does not exist in the sequence.")
+
     def concatenate(self, other: "PulseSequence") -> None:
         """Juxtapose two sequences.
 

--- a/src/qibolab/sequence.py
+++ b/src/qibolab/sequence.py
@@ -84,14 +84,9 @@ class PulseSequence(UserList[_Element]):
         """Duration of the given channel."""
         return sum(pulse.duration for pulse in self.channel(channel))
 
-    def pulse_channels(self, pulse_id: int) -> ChannelId:
+    def pulse_channels(self, pulse_id: int) -> list[ChannelId]:
         """Find channels on which a pulse with a given id plays."""
-        channels = [channel for channel, pulse in self if pulse.id == pulse_id]
-        if len(channels) == 0:
-            raise ValueError(
-                f"Pulse with id {pulse_id} does not exist in the sequence."
-            )
-        return channels
+        return [channel for channel, pulse in self if pulse.id == pulse_id]
 
     def concatenate(self, other: "PulseSequence") -> None:
         """Juxtapose two sequences.

--- a/src/qibolab/sequence.py
+++ b/src/qibolab/sequence.py
@@ -11,7 +11,7 @@ from pydantic_core import core_schema
 from qibolab.pulses.pulse import Pulse, _Readout
 
 from .identifier import ChannelId, ChannelType
-from .pulses import Align, Acquisition, Delay, PulseLike
+from .pulses import Acquisition, Align, Delay, PulseLike
 
 __all__ = ["PulseSequence"]
 

--- a/src/qibolab/sequence.py
+++ b/src/qibolab/sequence.py
@@ -82,7 +82,12 @@ class PulseSequence(UserList[_Element]):
 
     def channel_duration(self, channel: ChannelId) -> float:
         """Duration of the given channel."""
-        return sum(pulse.duration for pulse in self.channel(channel))
+        sequence = self
+        for _, pulse in self:
+            if isinstance(pulse, Align):
+                sequence = self.align_to_delays()
+                break
+        return sum(pulse.duration for pulse in sequence.channel(channel))
 
     def pulse_channels(self, pulse_id: int) -> list[ChannelId]:
         """Find channels on which a pulse with a given id plays."""

--- a/src/qibolab/sweeper.py
+++ b/src/qibolab/sweeper.py
@@ -13,6 +13,7 @@ class Parameter(Enum):
     frequency = auto()
     amplitude = auto()
     duration = auto()
+    duration_interpolated = auto()
     relative_phase = auto()
 
     attenuation = auto()
@@ -24,6 +25,7 @@ class Parameter(Enum):
 FREQUENCY = Parameter.frequency
 AMPLITUDE = Parameter.amplitude
 DURATION = Parameter.duration
+DURATION_INTERPOLATED = Parameter.duration_interpolated
 RELATIVE_PHASE = Parameter.relative_phase
 ATTENUATION = Parameter.attenuation
 GAIN = Parameter.gain

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -226,6 +226,11 @@ def test_align_to_delay():
     for (ch1, p1), (ch2, p2) in zip(sequence[7:], delay_sequence[6:]):
         assert ch1 == ch2
         assert p1 is p2
+    # assert that pulses after align start simultaneously
+    sequence_without_last = PulseSequence(delay_sequence[:-2])
+    ch1_start = sequence_without_last.channel_duration("ch1")
+    ch2_start = sequence_without_last.channel_duration("ch2")
+    assert ch1_start == ch2_start
 
 
 def test_trim():

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -178,6 +178,56 @@ def test_copy():
     assert "ch3" not in sequence
 
 
+def test_align_to_delay():
+    sequence = PulseSequence(
+        [
+            (
+                "ch1",
+                Pulse(duration=40, amplitude=0.9, envelope=Drag(rel_sigma=0.2, beta=1)),
+            ),
+            (
+                "ch1",
+                Delay(duration=20),
+            ),
+            (
+                "ch1",
+                Pulse(duration=40, amplitude=0.9, envelope=Drag(rel_sigma=0.2, beta=1)),
+            ),
+            (
+                "ch2",
+                Pulse(duration=60, amplitude=0.9, envelope=Drag(rel_sigma=0.2, beta=1)),
+            ),
+            (
+                "ch2",
+                Pulse(duration=80, amplitude=0.9, envelope=Drag(rel_sigma=0.2, beta=1)),
+            ),
+        ]
+    )
+    sequence.align(["ch1", "ch2"])
+    sequence.append(
+        (
+            "ch1",
+            Pulse(duration=20, amplitude=0.1, envelope=Gaussian(rel_sigma=3)),
+        )
+    )
+    sequence.append(
+        (
+            "ch2",
+            Pulse(duration=30, amplitude=0.1, envelope=Gaussian(rel_sigma=3)),
+        )
+    )
+
+    delay_sequence = sequence.align_to_delays()
+    assert len(delay_sequence) == len(sequence) - 1
+    for (ch1, p1), (ch2, p2) in zip(sequence[:5], delay_sequence[:5]):
+        assert ch1 == ch2
+        assert p1 is p2
+    assert delay_sequence[5] == ("ch1", Delay(duration=40))
+    for (ch1, p1), (ch2, p2) in zip(sequence[7:], delay_sequence[6:]):
+        assert ch1 == ch2
+        assert p1 is p2
+
+
 def test_trim():
     p = Pulse(duration=40, amplitude=0.9, envelope=Rectangular())
     d = Delay(duration=10)

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -227,7 +227,7 @@ def test_align_to_delay():
         assert ch1 == ch2
         assert p1 is p2
     # assert that pulses after align start simultaneously
-    sequence_without_last = PulseSequence(delay_sequence[:-2])
+    sequence_without_last = delay_sequence[:-2]
     ch1_start = sequence_without_last.channel_duration("ch1")
     ch2_start = sequence_without_last.channel_duration("ch2")
     assert ch1_start == ch2_start


### PR DESCRIPTION
Follows the plan outlined in https://github.com/qiboteam/qibolab/issues/935#issuecomment-2265612540, which I copy here in order to track progress:

- [x] implement duration sweepers in QM with multiple waveforms
- [x] checking the timing is predictable, and it could sweep a Rabi with just delays `wait()` instructions
- [x] introduce a new `DurationInterpolated` sweeper parameter
- [x] introduce an `Align` pulse, to synchronize multiple channels
    - this will have the specific meaning of a runtime synchronization, possibly introducing delays
- [x] keep `Sequence` as a list, in such a way that is clear for all channels what it comes before and after an `Align` (done in #965)

Example report for the Rabi length routine: http://login.qrccluster.com:9000/3XbCXPG-TAGC5uODkQDGFQ==

There is still an issue at short times (< 30ns) however I believe this is not due to the scheduling, as it appears even when using `qua.align()` and `qua.switch_()` with multiple waveforms. With the 1 clock cycle (=4ns) padding on delays, there is no overlap between the drive and readout pulses, as shown in the following simulation.

<details>
<summary>Simulation plot</summary>

![Screenshot 2024-08-13 205027](https://github.com/user-attachments/assets/4ac02a86-c452-4814-ac6d-75e5b18e1112)

</details>