### PR TITLE
Set default threshold to 0

### DIFF
--- a/src/qibolab/qubits.py
+++ b/src/qibolab/qubits.py
@@ -86,7 +86,7 @@ class Qubit:
     mean_exc_states: List[float] = field(default_factory=lambda: [0, 0])
 
     # parameters for single shot classification
-    threshold: Optional[float] = None
+    threshold: float = 0.0
     iq_angle: float = 0.0
     kernel: Optional[np.ndarray] = field(default=None, repr=False)
     # required for mixers (not sure if it should be here)

--- a/tests/test_instruments_rfsoc.py
+++ b/tests/test_instruments_rfsoc.py
@@ -525,8 +525,8 @@ def test_classify_shots(dummy_qrc):
     target_shots = np.array([1, 1, 0, 0, 0, 0, 0])
 
     assert (target_shots == shots).all()
-    with pytest.raises(ValueError):
-        instrument.classify_shots(i_val, q_val, qubit1)
+    shots = instrument.classify_shots(i_val, q_val, qubit1)
+    assert shots.shape == (7,)
 
 
 def test_merge_sweep_results(dummy_qrc):


### PR DESCRIPTION
Following what was discussed earlier, to avoid errors when attempting discrimination on a platform for which the classification parameters have not been calibrated. Now instead of errors, it will just return random shots.