### PR TITLE
Lift sequence

### DIFF
--- a/doc/source/getting-started/experiment.rst
+++ b/doc/source/getting-started/experiment.rst
@@ -203,7 +203,7 @@ We leave to the dedicated tutorial a full explanation of the experiment, but her
     import matplotlib.pyplot as plt
 
     from qibolab import create_platform
-    from qibolab.pulses import PulseSequence
+    from qibolab.sequence import PulseSequence
     from qibolab.result import magnitude
     from qibolab.sweeper import Sweeper, SweeperType, Parameter
     from qibolab.execution_parameters import (

--- a/doc/source/main-documentation/qibolab.rst
+++ b/doc/source/main-documentation/qibolab.rst
@@ -63,7 +63,8 @@ Now we can create a simple sequence (again, without explicitly giving any qubit 
 
 .. testcode::  python
 
-   from qibolab.pulses import PulseSequence, Delay
+   from qibolab.pulses import Delay
+   from qibolab.sequence import PulseSequence
    import numpy as np
 
    ps = PulseSequence()
@@ -276,7 +277,7 @@ To organize pulses into sequences, Qibolab provides the :class:`qibolab.pulses.P
 
 .. testcode:: python
 
-    from qibolab.pulses import PulseSequence
+    from qibolab.sequence import PulseSequence
 
 
     pulse1 = Pulse(
@@ -460,7 +461,8 @@ For example:
 
 .. testcode:: python
 
-    from qibolab.pulses import PulseSequence, Delay
+    from qibolab.pulses import Delay
+    from qibolab.sequence import PulseSequence
 
     qubit = platform.qubits[0]
     natives = platform.natives.single_qubit[0]

--- a/doc/source/tutorials/calibration.rst
+++ b/doc/source/tutorials/calibration.rst
@@ -30,7 +30,7 @@ around the pre-defined frequency.
 
     import numpy as np
     from qibolab import create_platform
-    from qibolab.pulses import PulseSequence
+    from qibolab.sequence import PulseSequence
     from qibolab.result import magnitude
     from qibolab.sweeper import Sweeper, SweeperType, Parameter
     from qibolab.execution_parameters import (
@@ -111,7 +111,8 @@ complex pulse sequence. Therefore with start with that:
     import numpy as np
     import matplotlib.pyplot as plt
     from qibolab import create_platform
-    from qibolab.pulses import Pulse, PulseSequence, Delay, Gaussian
+    from qibolab.pulses import Pulse, Delay, Gaussian
+    from qibolab.sequence import PulseSequence
     from qibolab.result import magnitude
     from qibolab.sweeper import Sweeper, SweeperType, Parameter
     from qibolab.execution_parameters import (
@@ -215,7 +216,8 @@ and its impact on qubit states in the IQ plane.
     import numpy as np
     import matplotlib.pyplot as plt
     from qibolab import create_platform
-    from qibolab.pulses import PulseSequence, Delay
+    from qibolab.pulses import Delay
+    from qibolab.sequence import PulseSequence
     from qibolab.result import unpack
     from qibolab.sweeper import Sweeper, SweeperType, Parameter
     from qibolab.execution_parameters import (

--- a/doc/source/tutorials/compiler.rst
+++ b/doc/source/tutorials/compiler.rst
@@ -71,7 +71,7 @@ The following example shows how to modify the compiler in order to execute a cir
     from qibo import gates
     from qibo.models import Circuit
     from qibolab.backends import QibolabBackend
-    from qibolab.pulses import PulseSequence
+    from qibolab.sequence import PulseSequence
 
     # define the circuit
     circuit = Circuit(1)

--- a/doc/source/tutorials/lab.rst
+++ b/doc/source/tutorials/lab.rst
@@ -106,7 +106,8 @@ the native gates, but separately from the single-qubit ones.
     from qibolab.components import IqChannel, AcquireChannel, DcChannel, IqConfig
     from qibolab.qubits import Qubit
     from qibolab.parameters import Parameters, TwoQubitContainer
-    from qibolab.pulses import Gaussian, Pulse, PulseSequence, Rectangular
+    from qibolab.pulses import Gaussian, Pulse, Rectangular
+    from qibolab.sequence import PulseSequence
     from qibolab.native import (
         RxyFactory,
         FixedSequenceFactory,
@@ -207,7 +208,8 @@ will take them into account when calling :class:`qibolab.native.TwoQubitNatives`
 
     from qibolab.components import DcChannel
     from qibolab.qubits import Qubit
-    from qibolab.pulses import Pulse, PulseSequence
+    from qibolab.pulses import Pulse
+    from qibolab.sequence import PulseSequence
     from qibolab.native import (
         FixedSequenceFactory,
         SingleQubitNatives,

--- a/doc/source/tutorials/pulses.rst
+++ b/doc/source/tutorials/pulses.rst
@@ -8,7 +8,8 @@ pulses (:class:`qibolab.pulses.Pulse`) through the
 
 .. testcode::  python
 
-    from qibolab.pulses import Pulse, PulseSequence, Rectangular, Gaussian, Delay
+    from qibolab.pulses import Pulse, Rectangular, Gaussian, Delay
+    from qibolab.sequence import PulseSequence
 
     # Define PulseSequence
     sequence = PulseSequence(

--- a/examples/minimum_working_example.py
+++ b/examples/minimum_working_example.py
@@ -1,6 +1,7 @@
 from qibolab import create_platform
 from qibolab.paths import qibolab_folder
-from qibolab.pulses import Pulse, PulseSequence, ReadoutPulse
+from qibolab.pulses import Pulse, ReadoutPulse
+from qibolab.sequence import PulseSequence
 
 # Define PulseSequence
 sequence = PulseSequence()

--- a/extras/test819.py
+++ b/extras/test819.py
@@ -9,7 +9,7 @@ from qibolab.execution_parameters import (
 )
 from qibolab.instruments.qblox.controller import QbloxController
 from qibolab.platform import NS_TO_SEC
-from qibolab.pulses import PulseSequence
+from qibolab.sequence import PulseSequence
 from qibolab.sweeper import Parameter, Sweeper, SweeperType
 
 GlobalBackend.set_backend("qibolab", "spinq10q")

--- a/src/qibolab/backends.py
+++ b/src/qibolab/backends.py
@@ -9,7 +9,7 @@ from qibo.result import MeasurementOutcomes
 
 from qibolab.compilers import Compiler
 from qibolab.execution_parameters import ExecutionParameters
-from qibolab.platform import Platform, create_platform
+from qibolab.platform import Platform, create_platform, probe_pulses
 from qibolab.platform.load import available_platforms
 from qibolab.version import __version__ as qibolab_version
 
@@ -69,7 +69,10 @@ class QibolabBackend(NumpyBackend):
                 containing the readout measurement shots. This is created in ``execute_circuit``.
         """
         for gate, sequence in measurement_map.items():
-            _samples = (readout[pulse.id] for pulse in sequence.probe_pulses)
+            _samples = (
+                readout[pulse.id]
+                for pulse in probe_pulses(sequence, self.platform.configs)
+            )
             samples = list(filter(lambda x: x is not None, _samples))
             gate.result.backend = self
             gate.result.register_samples(np.array(samples).T)

--- a/src/qibolab/backends.py
+++ b/src/qibolab/backends.py
@@ -9,7 +9,7 @@ from qibo.result import MeasurementOutcomes
 
 from qibolab.compilers import Compiler
 from qibolab.execution_parameters import ExecutionParameters
-from qibolab.platform import Platform, create_platform, probe_pulses
+from qibolab.platform import Platform, create_platform
 from qibolab.platform.load import available_platforms
 from qibolab.version import __version__ as qibolab_version
 
@@ -69,10 +69,7 @@ class QibolabBackend(NumpyBackend):
                 containing the readout measurement shots. This is created in ``execute_circuit``.
         """
         for gate, sequence in measurement_map.items():
-            _samples = (
-                readout[pulse.id]
-                for pulse in probe_pulses(sequence, self.platform.configs)
-            )
+            _samples = (readout[pulse.id] for pulse in sequence.probe_pulses)
             samples = list(filter(lambda x: x is not None, _samples))
             gate.result.backend = self
             gate.result.register_samples(np.array(samples).T)

--- a/src/qibolab/compilers/compiler.py
+++ b/src/qibolab/compilers/compiler.py
@@ -16,8 +16,9 @@ from qibolab.compilers.default import (
     z_rule,
 )
 from qibolab.platform import Platform
-from qibolab.pulses import Delay, PulseSequence
+from qibolab.pulses import Delay
 from qibolab.qubits import QubitId
+from qibolab.sequence import PulseSequence
 
 Rule = Callable[..., PulseSequence]
 """Compiler rule."""

--- a/src/qibolab/compilers/default.py
+++ b/src/qibolab/compilers/default.py
@@ -9,8 +9,9 @@ import numpy as np
 from qibo.gates import Align, Gate
 
 from qibolab.native import SingleQubitNatives, TwoQubitNatives
-from qibolab.pulses import Delay, PulseSequence, VirtualZ
+from qibolab.pulses import Delay, VirtualZ
 from qibolab.qubits import Qubit
+from qibolab.sequence import PulseSequence
 
 
 def z_rule(gate: Gate, qubit: Qubit) -> PulseSequence:

--- a/src/qibolab/instruments/abstract.py
+++ b/src/qibolab/instruments/abstract.py
@@ -6,7 +6,7 @@ import numpy.typing as npt
 
 from qibolab.components import Config
 from qibolab.execution_parameters import ExecutionParameters
-from qibolab.pulses.sequence import PulseSequence
+from qibolab.sequence import PulseSequence
 from qibolab.sweeper import ParallelSweepers
 
 InstrumentId = str

--- a/src/qibolab/instruments/dummy.py
+++ b/src/qibolab/instruments/dummy.py
@@ -4,6 +4,7 @@ import numpy as np
 from qibo.config import log
 
 from qibolab import AcquisitionType, AveragingMode, ExecutionParameters
+from qibolab.platform import probe_pulses
 from qibolab.pulses import PulseSequence
 from qibolab.pulses.pulse import Pulse
 from qibolab.sweeper import ParallelSweepers
@@ -101,4 +102,6 @@ class DummyInstrument(Controller):
                 self.values(options, options.results_shape(sweepers, samples))
             )
 
-        return {ro.id: values(ro) for seq in sequences for ro in seq.probe_pulses}
+        return {
+            ro.id: values(ro) for seq in sequences for ro in probe_pulses(seq, configs)
+        }

--- a/src/qibolab/instruments/dummy.py
+++ b/src/qibolab/instruments/dummy.py
@@ -4,8 +4,8 @@ import numpy as np
 from qibo.config import log
 
 from qibolab import AcquisitionType, AveragingMode, ExecutionParameters
-from qibolab.pulses import PulseSequence
-from qibolab.pulses.pulse import Pulse
+from qibolab.pulses import Pulse
+from qibolab.sequence import PulseSequence
 from qibolab.sweeper import ParallelSweepers
 from qibolab.unrolling import Bounds
 

--- a/src/qibolab/instruments/dummy.py
+++ b/src/qibolab/instruments/dummy.py
@@ -4,7 +4,6 @@ import numpy as np
 from qibo.config import log
 
 from qibolab import AcquisitionType, AveragingMode, ExecutionParameters
-from qibolab.platform import probe_pulses
 from qibolab.pulses import PulseSequence
 from qibolab.pulses.pulse import Pulse
 from qibolab.sweeper import ParallelSweepers
@@ -102,6 +101,4 @@ class DummyInstrument(Controller):
                 self.values(options, options.results_shape(sweepers, samples))
             )
 
-        return {
-            ro.id: values(ro) for seq in sequences for ro in probe_pulses(seq, configs)
-        }
+        return {ro.id: values(ro) for seq in sequences for ro in seq.probe_pulses}

--- a/src/qibolab/instruments/emulator/pulse_simulator.py
+++ b/src/qibolab/instruments/emulator/pulse_simulator.py
@@ -12,9 +12,9 @@ from qibolab import AcquisitionType, AveragingMode, ExecutionParameters
 from qibolab.instruments.abstract import Controller
 from qibolab.instruments.emulator.engines.qutip_engine import QutipSimulator
 from qibolab.instruments.emulator.models import general_no_coupler_model
-from qibolab.pulses import PulseSequence
 from qibolab.qubits import Qubit, QubitId
 from qibolab.result import average, collect
+from qibolab.sequence import PulseSequence
 from qibolab.sweeper import Parameter, Sweeper, SweeperType
 
 AVAILABLE_SWEEP_PARAMETERS = {

--- a/src/qibolab/instruments/icarusqfpga.py
+++ b/src/qibolab/instruments/icarusqfpga.py
@@ -13,9 +13,10 @@ from qibolab.execution_parameters import (
     ExecutionParameters,
 )
 from qibolab.instruments.abstract import Controller
-from qibolab.pulses import Pulse, PulseSequence
+from qibolab.pulses import Pulse
 from qibolab.qubits import Qubit, QubitId
 from qibolab.result import average, average_iq, collect
+from qibolab.sequence import PulseSequence
 from qibolab.sweeper import Parameter, Sweeper, SweeperType
 
 DAC_SAMPLNG_RATE_MHZ = 5898.24

--- a/src/qibolab/instruments/qblox/cluster_qcm_bb.py
+++ b/src/qibolab/instruments/qblox/cluster_qcm_bb.py
@@ -18,7 +18,8 @@ from qibolab.instruments.qblox.q1asm import (
 )
 from qibolab.instruments.qblox.sequencer import Sequencer, WaveformsBuffer
 from qibolab.instruments.qblox.sweeper import QbloxSweeper, QbloxSweeperType
-from qibolab.pulses import Pulse, PulseSequence
+from qibolab.pulses import Pulse
+from qibolab.sequence import PulseSequence
 from qibolab.sweeper import Parameter, Sweeper, SweeperType
 
 

--- a/src/qibolab/instruments/qblox/cluster_qcm_rf.py
+++ b/src/qibolab/instruments/qblox/cluster_qcm_rf.py
@@ -18,7 +18,8 @@ from qibolab.instruments.qblox.q1asm import (
 )
 from qibolab.instruments.qblox.sequencer import Sequencer, WaveformsBuffer
 from qibolab.instruments.qblox.sweeper import QbloxSweeper, QbloxSweeperType
-from qibolab.pulses import Pulse, PulseSequence
+from qibolab.pulses import Pulse
+from qibolab.sequence import PulseSequence
 from qibolab.sweeper import Parameter, Sweeper, SweeperType
 
 

--- a/src/qibolab/instruments/qblox/cluster_qrm_rf.py
+++ b/src/qibolab/instruments/qblox/cluster_qrm_rf.py
@@ -10,7 +10,8 @@ from qblox_instruments.qcodes_drivers.cluster import Cluster
 from qblox_instruments.qcodes_drivers.module import Module
 from qibo.config import log
 
-from qibolab.pulses import Pulse, PulseSequence
+from qibolab.pulses import Pulse
+from qibolab.sequence import PulseSequence
 from qibolab.sweeper import Parameter, Sweeper, SweeperType
 
 from .acquisition import AveragedAcquisition, DemodulatedAcquisition

--- a/src/qibolab/instruments/qblox/controller.py
+++ b/src/qibolab/instruments/qblox/controller.py
@@ -11,7 +11,7 @@ from qibolab.instruments.qblox.cluster_qcm_bb import QcmBb
 from qibolab.instruments.qblox.cluster_qcm_rf import QcmRf
 from qibolab.instruments.qblox.cluster_qrm_rf import QrmRf
 from qibolab.instruments.qblox.sequencer import SAMPLING_RATE
-from qibolab.pulses import PulseSequence
+from qibolab.sequence import PulseSequence
 from qibolab.sweeper import Parameter, Sweeper, SweeperType
 from qibolab.unrolling import Bounds
 

--- a/src/qibolab/instruments/qblox/sequencer.py
+++ b/src/qibolab/instruments/qblox/sequencer.py
@@ -4,8 +4,9 @@ import numpy as np
 from qblox_instruments.qcodes_drivers.sequencer import Sequencer as QbloxSequencer
 
 from qibolab.instruments.qblox.q1asm import Program
-from qibolab.pulses import Pulse, PulseSequence
+from qibolab.pulses import Pulse
 from qibolab.pulses.modulation import modulate
+from qibolab.sequence import PulseSequence
 from qibolab.sweeper import Parameter, Sweeper
 
 SAMPLING_RATE = 1

--- a/src/qibolab/instruments/qm/controller.py
+++ b/src/qibolab/instruments/qm/controller.py
@@ -14,7 +14,8 @@ from qualang_tools.simulator_tools import create_simulator_controller_connection
 from qibolab.components import Channel, ChannelId, Config, DcChannel, IqChannel
 from qibolab.execution_parameters import ExecutionParameters
 from qibolab.instruments.abstract import Controller
-from qibolab.pulses import Delay, Pulse, PulseSequence, VirtualZ
+from qibolab.pulses import Delay, Pulse, VirtualZ
+from qibolab.sequence import PulseSequence
 from qibolab.sweeper import ParallelSweepers, Parameter
 from qibolab.unrolling import Bounds
 

--- a/src/qibolab/instruments/qm/program/arguments.py
+++ b/src/qibolab/instruments/qm/program/arguments.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from qm.qua._dsl import _Variable  # for type declaration only
 
-from qibolab.pulses import PulseSequence
+from qibolab.sequence import PulseSequence
 
 from .acquisition import Acquisition
 

--- a/src/qibolab/instruments/qm/program/instructions.py
+++ b/src/qibolab/instruments/qm/program/instructions.py
@@ -6,7 +6,8 @@ from qualang_tools.loops import from_array
 
 from qibolab.components import Config
 from qibolab.execution_parameters import AcquisitionType, ExecutionParameters
-from qibolab.pulses import Delay, PulseSequence
+from qibolab.pulses import Delay
+from qibolab.sequence import PulseSequence
 from qibolab.sweeper import ParallelSweepers
 
 from ..config import operation

--- a/src/qibolab/instruments/rfsoc/convert.py
+++ b/src/qibolab/instruments/rfsoc/convert.py
@@ -8,8 +8,9 @@ import numpy as np
 import qibosoq.components.base as rfsoc
 import qibosoq.components.pulses as rfsoc_pulses
 
-from qibolab.pulses import Envelope, Pulse, PulseSequence
+from qibolab.pulses import Envelope, Pulse
 from qibolab.qubits import Qubit
+from qibolab.sequence import PulseSequence
 from qibolab.sweeper import BIAS, DURATION, Parameter, Sweeper
 
 HZ_TO_MHZ = 1e-6

--- a/src/qibolab/instruments/rfsoc/driver.py
+++ b/src/qibolab/instruments/rfsoc/driver.py
@@ -11,8 +11,8 @@ from qibosoq import client
 
 from qibolab import AcquisitionType, AveragingMode, ExecutionParameters
 from qibolab.instruments.abstract import Controller
-from qibolab.pulses import PulseSequence
 from qibolab.qubits import Qubit
+from qibolab.sequence import PulseSequence
 from qibolab.sweeper import BIAS, Sweeper
 
 from .convert import convert, convert_units_sweeper

--- a/src/qibolab/instruments/zhinst/executor.py
+++ b/src/qibolab/instruments/zhinst/executor.py
@@ -10,7 +10,8 @@ from laboneq.dsl.device import create_connection
 
 from qibolab import AcquisitionType, AveragingMode, ExecutionParameters
 from qibolab.instruments.abstract import Controller
-from qibolab.pulses import Delay, Pulse, PulseSequence
+from qibolab.pulses import Delay, Pulse
+from qibolab.sequence import PulseSequence
 from qibolab.sweeper import Parameter, Sweeper
 from qibolab.unrolling import Bounds
 

--- a/src/qibolab/native.py
+++ b/src/qibolab/native.py
@@ -3,7 +3,8 @@ from typing import Annotated, Optional
 
 import numpy as np
 
-from .pulses import Drag, Gaussian, Pulse, PulseSequence
+from .pulses import Drag, Gaussian, Pulse
+from .sequence import PulseSequence
 from .serialize import Model, replace
 
 

--- a/src/qibolab/platform/__init__.py
+++ b/src/qibolab/platform/__init__.py
@@ -1,4 +1,4 @@
 from .load import create_platform
-from .platform import Platform, unroll_sequences
+from .platform import Platform, probe_pulses, unroll_sequences
 
-__all__ = ["Platform", "create_platform", "unroll_sequences"]
+__all__ = ["Platform", "create_platform", "probe_pulses", "unroll_sequences"]

--- a/src/qibolab/platform/__init__.py
+++ b/src/qibolab/platform/__init__.py
@@ -1,4 +1,4 @@
 from .load import create_platform
-from .platform import Platform, probe_pulses, unroll_sequences
+from .platform import Platform, unroll_sequences
 
-__all__ = ["Platform", "create_platform", "probe_pulses", "unroll_sequences"]
+__all__ = ["Platform", "create_platform", "unroll_sequences"]

--- a/src/qibolab/platform/platform.py
+++ b/src/qibolab/platform/platform.py
@@ -10,7 +10,7 @@ from typing import Any, Literal, Optional, TypeVar, Union
 
 from qibo.config import log, raise_error
 
-from qibolab.components import Config, AcquireChannel
+from qibolab.components import AcquireChannel, Config
 from qibolab.execution_parameters import ExecutionParameters
 from qibolab.instruments.abstract import Controller, Instrument, InstrumentId
 from qibolab.parameters import NativeGates, Parameters, Settings, update_configs

--- a/src/qibolab/platform/platform.py
+++ b/src/qibolab/platform/platform.py
@@ -14,8 +14,9 @@ from qibolab.components import Config
 from qibolab.execution_parameters import ExecutionParameters
 from qibolab.instruments.abstract import Controller, Instrument, InstrumentId
 from qibolab.parameters import NativeGates, Parameters, Settings, update_configs
-from qibolab.pulses import Delay, PulseSequence
+from qibolab.pulses import Delay
 from qibolab.qubits import Qubit, QubitId, QubitPairId
+from qibolab.sequence import PulseSequence
 from qibolab.sweeper import ParallelSweepers
 from qibolab.unrolling import Bounds, batch
 
@@ -252,7 +253,7 @@ class Platform:
                 import numpy as np
                 from qibolab.dummy import create_dummy
                 from qibolab.sweeper import Sweeper, Parameter
-                from qibolab.pulses import PulseSequence
+                from qibolab.sequence import PulseSequence
                 from qibolab.execution_parameters import ExecutionParameters
 
 

--- a/src/qibolab/platform/platform.py
+++ b/src/qibolab/platform/platform.py
@@ -10,11 +10,11 @@ from typing import Any, Literal, Optional, TypeVar, Union
 
 from qibo.config import log, raise_error
 
-from qibolab.components import AcquireChannel, Config
+from qibolab.components import Config
 from qibolab.execution_parameters import ExecutionParameters
 from qibolab.instruments.abstract import Controller, Instrument, InstrumentId
 from qibolab.parameters import NativeGates, Parameters, Settings, update_configs
-from qibolab.pulses import Delay, Pulse, PulseSequence
+from qibolab.pulses import Delay, PulseSequence
 from qibolab.qubits import Qubit, QubitId, QubitPairId
 from qibolab.sweeper import ParallelSweepers
 from qibolab.unrolling import Bounds, batch
@@ -86,16 +86,6 @@ def estimate_duration(
 def _channels_map(elements: QubitMap):
     """Map channel names to element (qubit or coupler)."""
     return {ch.name: id for id, el in elements.items() for ch in el.channels}
-
-
-def probe_pulses(
-    sequence: PulseSequence, configs: dict[str, Config]
-) -> Iterable[Pulse]:
-    """Filter probe pulses."""
-    for ch, pulse in sequence:
-        if isinstance(configs[ch], AcquireChannel):
-            assert isinstance(pulse, Pulse)
-            yield pulse
 
 
 @dataclass

--- a/src/qibolab/platform/platform.py
+++ b/src/qibolab/platform/platform.py
@@ -10,11 +10,11 @@ from typing import Any, Literal, Optional, TypeVar, Union
 
 from qibo.config import log, raise_error
 
-from qibolab.components import Config
+from qibolab.components import Config, AcquireChannel
 from qibolab.execution_parameters import ExecutionParameters
 from qibolab.instruments.abstract import Controller, Instrument, InstrumentId
 from qibolab.parameters import NativeGates, Parameters, Settings, update_configs
-from qibolab.pulses import Delay, PulseSequence
+from qibolab.pulses import Delay, Pulse, PulseSequence
 from qibolab.qubits import Qubit, QubitId, QubitPairId
 from qibolab.sweeper import ParallelSweepers
 from qibolab.unrolling import Bounds, batch
@@ -86,6 +86,16 @@ def estimate_duration(
 def _channels_map(elements: QubitMap):
     """Map channel names to element (qubit or coupler)."""
     return {ch.name: id for id, el in elements.items() for ch in el.channels}
+
+
+def probe_pulses(
+    sequence: PulseSequence, configs: dict[str, Config]
+) -> Iterable[Pulse]:
+    """Filter probe pulses."""
+    for ch, pulse in sequence:
+        if isinstance(configs[ch], AcquireChannel):
+            assert isinstance(pulse, Pulse)
+            yield pulse
 
 
 @dataclass

--- a/src/qibolab/pulses/__init__.py
+++ b/src/qibolab/pulses/__init__.py
@@ -1,3 +1,2 @@
 from .envelope import *
-from .pulse import Delay, Pulse, VirtualZ
-from .sequence import PulseSequence
+from .pulse import Delay, Pulse, PulseLike, VirtualZ

--- a/src/qibolab/pulses/plot.py
+++ b/src/qibolab/pulses/plot.py
@@ -6,10 +6,11 @@ from typing import Optional
 import matplotlib.pyplot as plt
 import numpy as np
 
+from qibolab.sequence import PulseSequence
+
 from .envelope import Waveform
 from .modulation import modulate
 from .pulse import Delay, Pulse, VirtualZ
-from .sequence import PulseSequence
 
 SAMPLING_RATE = 1
 """Default sampling rate in gigasamples per second (GSps).

--- a/src/qibolab/pulses/sequence.py
+++ b/src/qibolab/pulses/sequence.py
@@ -9,7 +9,7 @@ from pydantic_core import core_schema
 
 from qibolab.components import ChannelId
 
-from .pulse import Delay, Pulse, PulseLike
+from .pulse import Delay, PulseLike
 
 __all__ = ["PulseSequence"]
 
@@ -96,11 +96,3 @@ class PulseSequence(UserList[_Element]):
                 terminated.add(ch)
             new.append((ch, pulse))
         return type(self)(reversed(new))
-
-    @property
-    def probe_pulses(self) -> list[Pulse]:
-        """Return list of the readout pulses in this sequence."""
-        # pulse filter needed to exclude delays
-        return [
-            pulse for (ch, pulse) in self if isinstance(pulse, Pulse) if "probe" in ch
-        ]

--- a/src/qibolab/pulses/sequence.py
+++ b/src/qibolab/pulses/sequence.py
@@ -9,7 +9,7 @@ from pydantic_core import core_schema
 
 from qibolab.components import ChannelId
 
-from .pulse import Delay, PulseLike
+from .pulse import Delay, Pulse, PulseLike
 
 __all__ = ["PulseSequence"]
 
@@ -96,3 +96,11 @@ class PulseSequence(UserList[_Element]):
                 terminated.add(ch)
             new.append((ch, pulse))
         return type(self)(reversed(new))
+
+    @property
+    def probe_pulses(self) -> list[Pulse]:
+        """Return list of the readout pulses in this sequence."""
+        # pulse filter needed to exclude delays
+        return [
+            pulse for (ch, pulse) in self if isinstance(pulse, Pulse) if "probe" in ch
+        ]

--- a/src/qibolab/sequence.py
+++ b/src/qibolab/sequence.py
@@ -9,7 +9,7 @@ from pydantic_core import core_schema
 
 from qibolab.components import ChannelId
 
-from .pulse import Delay, Pulse, PulseLike
+from .pulses import Delay, Pulse, PulseLike
 
 __all__ = ["PulseSequence"]
 

--- a/src/qibolab/sweeper.py
+++ b/src/qibolab/sweeper.py
@@ -60,7 +60,7 @@ class Sweeper:
             import numpy as np
             from qibolab.dummy import create_dummy
             from qibolab.sweeper import Sweeper, Parameter
-            from qibolab.pulses import PulseSequence
+            from qibolab.sequence import PulseSequence
             from qibolab import ExecutionParameters
 
 

--- a/src/qibolab/unrolling.py
+++ b/src/qibolab/unrolling.py
@@ -30,7 +30,8 @@ def _waveform(sequence: PulseSequence):
 
 def _readout(sequence: PulseSequence):
     # TODO: Do we count 1 readout per pulse or 1 readout per multiplexed readout ?
-    return len(sequence.probe_pulses)
+    # FIXME: exploitation of non-standard convention for channel names
+    return sum(1 for ch, p in sequence if "probe" in ch)
 
 
 def _instructions(sequence: PulseSequence):

--- a/src/qibolab/unrolling.py
+++ b/src/qibolab/unrolling.py
@@ -9,8 +9,9 @@ from typing import Annotated
 from qibolab.components.configs import BoundsConfig
 from qibolab.serialize import Model
 
-from .pulses import Pulse, PulseSequence
+from .pulses import Pulse
 from .pulses.envelope import Rectangular
+from .sequence import PulseSequence
 
 
 def _waveform(sequence: PulseSequence):

--- a/src/qibolab/unrolling.py
+++ b/src/qibolab/unrolling.py
@@ -30,8 +30,7 @@ def _waveform(sequence: PulseSequence):
 
 def _readout(sequence: PulseSequence):
     # TODO: Do we count 1 readout per pulse or 1 readout per multiplexed readout ?
-    # FIXME: exploitation of non-standard convention for channel names
-    return sum(1 for ch, p in sequence if "probe" in ch)
+    return len(sequence.probe_pulses)
 
 
 def _instructions(sequence: PulseSequence):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ from qibolab import (
     create_platform,
 )
 from qibolab.platform.load import PLATFORMS
-from qibolab.pulses import PulseSequence
+from qibolab.sequence import PulseSequence
 from qibolab.sweeper import ParallelSweepers, Parameter, Sweeper
 
 ORIGINAL_PLATFORMS = os.environ.get(PLATFORMS, "")

--- a/tests/pulses/test_plot.py
+++ b/tests/pulses/test_plot.py
@@ -10,12 +10,12 @@ from qibolab.pulses import (
     GaussianSquare,
     Iir,
     Pulse,
-    PulseSequence,
     Rectangular,
     Snz,
     plot,
 )
 from qibolab.pulses.modulation import modulate
+from qibolab.sequence import PulseSequence
 
 HERE = pathlib.Path(__file__).parent
 SAMPLING_RATE = 1

--- a/tests/pulses/test_sequence.py
+++ b/tests/pulses/test_sequence.py
@@ -1,5 +1,6 @@
-from qibolab.pulses import Delay, Drag, Gaussian, Pulse, PulseSequence, Rectangular
+from qibolab.pulses import Delay, Drag, Gaussian, Pulse, Rectangular
 from qibolab.pulses.pulse import VirtualZ
+from qibolab.sequence import PulseSequence
 
 
 def test_init():

--- a/tests/test_compilers_default.py
+++ b/tests/test_compilers_default.py
@@ -7,7 +7,8 @@ from qibo.models import Circuit
 from qibolab import create_platform
 from qibolab.compilers import Compiler
 from qibolab.platform import Platform
-from qibolab.pulses import Delay, PulseSequence
+from qibolab.pulses import Delay
+from qibolab.sequence import PulseSequence
 
 
 def generate_circuit_with_gate(nqubits, gate, *params, **kwargs):

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -3,7 +3,8 @@ import pytest
 
 from qibolab import AcquisitionType, AveragingMode, ExecutionParameters, create_platform
 from qibolab.platform.platform import Platform
-from qibolab.pulses import Delay, Gaussian, GaussianSquare, Pulse, PulseSequence
+from qibolab.pulses import Delay, Gaussian, GaussianSquare, Pulse
+from qibolab.sequence import PulseSequence
 from qibolab.sweeper import ChannelParameter, Parameter, Sweeper
 
 SWEPT_POINTS = 5

--- a/tests/test_emulator.py
+++ b/tests/test_emulator.py
@@ -18,7 +18,7 @@ from qibolab.instruments.emulator.models import (
 )
 from qibolab.instruments.emulator.pulse_simulator import AVAILABLE_SWEEP_PARAMETERS
 from qibolab.platform.load import PLATFORMS
-from qibolab.pulses import PulseSequence
+from qibolab.sequence import PulseSequence
 from qibolab.sweeper import ChannelParameter, Parameter, Sweeper
 
 os.environ[PLATFORMS] = str(pathlib.Path(__file__).parent / "emulators/")

--- a/tests/test_instruments_qblox_cluster_qcm_bb.py
+++ b/tests/test_instruments_qblox_cluster_qcm_bb.py
@@ -6,7 +6,7 @@ import pytest
 from qibolab.instruments.abstract import Instrument
 from qibolab.instruments.qblox.cluster_qcm_bb import QcmBb
 from qibolab.instruments.qblox.port import QbloxOutputPort
-from qibolab.pulses import PulseSequence
+from qibolab.sequence import PulseSequence
 from qibolab.sweeper import Parameter, Sweeper, SweeperType
 
 from .qblox_fixtures import connected_controller, controller

--- a/tests/test_instruments_qblox_cluster_qcm_rf.py
+++ b/tests/test_instruments_qblox_cluster_qcm_rf.py
@@ -4,7 +4,7 @@ import pytest
 from qibolab.instruments.abstract import Instrument
 from qibolab.instruments.qblox.cluster_qcm_rf import QcmRf
 from qibolab.instruments.qblox.port import QbloxOutputPort
-from qibolab.pulses import PulseSequence
+from qibolab.sequence import PulseSequence
 from qibolab.sweeper import Parameter, Sweeper, SweeperType
 
 from .qblox_fixtures import connected_controller, controller

--- a/tests/test_instruments_qblox_cluster_qrm_rf.py
+++ b/tests/test_instruments_qblox_cluster_qrm_rf.py
@@ -4,7 +4,7 @@ import pytest
 from qibolab.instruments.abstract import Instrument
 from qibolab.instruments.qblox.cluster_qrm_rf import QrmRf
 from qibolab.instruments.qblox.port import QbloxInputPort, QbloxOutputPort
-from qibolab.pulses import PulseSequence
+from qibolab.sequence import PulseSequence
 from qibolab.sweeper import Parameter, Sweeper, SweeperType
 
 from .qblox_fixtures import connected_controller, controller

--- a/tests/test_instruments_qblox_controller.py
+++ b/tests/test_instruments_qblox_controller.py
@@ -5,7 +5,8 @@ import pytest
 
 from qibolab import AveragingMode, ExecutionParameters
 from qibolab.instruments.qblox.controller import MAX_NUM_BINS, QbloxController
-from qibolab.pulses import Gaussian, Pulse, PulseSequence, Rectangular
+from qibolab.pulses import Gaussian, Pulse, Rectangular
+from qibolab.sequence import PulseSequence
 from qibolab.sweeper import Parameter, Sweeper
 
 from .qblox_fixtures import connected_controller, controller

--- a/tests/test_instruments_qm.py
+++ b/tests/test_instruments_qm.py
@@ -6,8 +6,9 @@ from qm import qua
 
 from qibolab import AcquisitionType, ExecutionParameters, create_platform
 from qibolab.instruments.qm import QmController
-from qibolab.pulses import Pulse, PulseSequence, Rectangular
+from qibolab.pulses import Pulse, Rectangular
 from qibolab.qubits import Qubit
+from qibolab.sequence import PulseSequence
 from qibolab.sweeper import Parameter, Sweeper
 
 from .conftest import set_platform_profile

--- a/tests/test_instruments_qmsim.py
+++ b/tests/test_instruments_qmsim.py
@@ -23,7 +23,8 @@ from qibo.models import Circuit
 
 from qibolab import AcquisitionType, AveragingMode, ExecutionParameters, create_platform
 from qibolab.backends import QibolabBackend
-from qibolab.pulses import Pulse, PulseSequence, Rectangular, Snz
+from qibolab.pulses import Pulse, Rectangular, Snz
+from qibolab.sequence import PulseSequence
 from qibolab.sweeper import Parameter, Sweeper
 
 from .conftest import set_platform_profile

--- a/tests/test_instruments_rfsoc.py
+++ b/tests/test_instruments_rfsoc.py
@@ -14,8 +14,9 @@ from qibolab.instruments.rfsoc.convert import (
     convert_units_sweeper,
     replace_pulse_shape,
 )
-from qibolab.pulses import Drag, Gaussian, Pulse, PulseSequence, Rectangular
+from qibolab.pulses import Drag, Gaussian, Pulse, Rectangular
 from qibolab.qubits import Qubit
+from qibolab.sequence import PulseSequence
 from qibolab.sweeper import Parameter, Sweeper, SweeperType
 
 from .conftest import get_instrument

--- a/tests/test_instruments_zhinst.py
+++ b/tests/test_instruments_zhinst.py
@@ -6,16 +6,8 @@ import pytest
 from qibolab import AcquisitionType, AveragingMode, ExecutionParameters, create_platform
 from qibolab.instruments.zhinst import ProcessedSweeps, Zurich, classify_sweepers
 from qibolab.instruments.zhinst.pulse import select_pulse
-from qibolab.pulses import (
-    Delay,
-    Drag,
-    Gaussian,
-    Iir,
-    Pulse,
-    PulseSequence,
-    Rectangular,
-    Snz,
-)
+from qibolab.pulses import Delay, Drag, Gaussian, Iir, Pulse, Rectangular, Snz
+from qibolab.sequence import PulseSequence
 from qibolab.sweeper import Parameter, Sweeper
 from qibolab.unrolling import batch
 

--- a/tests/test_native.py
+++ b/tests/test_native.py
@@ -11,9 +11,9 @@ from qibolab.pulses import (
     Gaussian,
     GaussianSquare,
     Pulse,
-    PulseSequence,
     Rectangular,
 )
+from qibolab.sequence import PulseSequence
 
 
 def test_fixed_sequence_factory():

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -24,7 +24,8 @@ from qibolab.parameters import NativeGates, Parameters, update_configs
 from qibolab.platform import Platform, unroll_sequences
 from qibolab.platform.load import PLATFORM, PLATFORMS
 from qibolab.platform.platform import PARAMETERS
-from qibolab.pulses import Delay, Gaussian, Pulse, PulseSequence, Rectangular
+from qibolab.pulses import Delay, Gaussian, Pulse, Rectangular
+from qibolab.sequence import PulseSequence
 from qibolab.serialize import replace
 
 from .conftest import find_instrument

--- a/tests/test_unrolling.py
+++ b/tests/test_unrolling.py
@@ -2,7 +2,8 @@
 
 import pytest
 
-from qibolab.pulses import Drag, Pulse, PulseSequence, Rectangular
+from qibolab.pulses import Drag, Pulse, Rectangular
+from qibolab.sequence import PulseSequence
 from qibolab.unrolling import Bounds, batch
 
 


### PR DESCRIPTION
In #970 I'd like to move towards more structured channel IDs.
Thinking about that, I considered that the main *customer* of the channels, other than the platforms (and of course the drivers), is the `PulseSequence` itself, that is now a combination of channels and pulses (as it is clear from `_Element`).

Since channels are an important constituent of the sequence, and they are not constituent of pulses, I decided it was more fair to lift the sequence out of the pulses submodule. Pulses are a thing on its own, the variables we use for our "instructions". A sequence is a program, i.e. a list of instructions.

> *(for the time being, an "instruction" is just the pulse + channel association, but we're about to insert `Align` and `Acquire`, that are not really pulses, as `Delay` and `VirtualZ` are already somewhat different, and then go for further instructions in #917 - they could also go fully outside the `.pulses` subpackage)*

This PR is standalone because, despite there is almost no substantial change, it is generating a huge diff, and I didn't want to mix in anything else.