### PR TITLE
QM driver patches for new serialization

### DIFF
--- a/src/qibolab/instruments/qm/components/configs.py
+++ b/src/qibolab/instruments/qm/components/configs.py
@@ -1,4 +1,6 @@
-from dataclasses import dataclass, field
+from typing import Literal
+
+from pydantic import Field
 
 from qibolab.components import AcquisitionConfig, DcConfig
 
@@ -8,16 +10,17 @@ __all__ = [
 ]
 
 
-@dataclass(frozen=True)
 class OpxOutputConfig(DcConfig):
     """DC channel config using QM OPX+."""
+
+    kind: Literal["opx-output"] = "opx-output"
 
     offset: float = 0.0
     """DC offset to be applied in V.
 
     Possible values are -0.5V to 0.5V.
     """
-    filter: dict[str, float] = field(default_factory=dict)
+    filter: dict[str, float] = Field(default_factory=dict)
     """FIR and IIR filters to be applied for correcting signal distortions.
 
     See
@@ -27,9 +30,10 @@ class OpxOutputConfig(DcConfig):
     """
 
 
-@dataclass(frozen=True)
 class QmAcquisitionConfig(AcquisitionConfig):
     """Acquisition config for QM OPX+."""
+
+    kind: Literal["qm-acquisition"] = "qm-acquisition"
 
     gain: int = 0
     """Input gain in dB.

--- a/src/qibolab/instruments/qm/config/config.py
+++ b/src/qibolab/instruments/qm/config/config.py
@@ -50,7 +50,7 @@ class QmConfig:
 
     def configure_dc_line(self, channel: QmChannel, config: OpxOutputConfig):
         controller = self.controllers[channel.device]
-        controller.analog_outputs[channel.port] = config
+        controller.analog_outputs[channel.port] = AnalogOutput.from_config(config)
         self.elements[channel.logical_channel.name] = DcElement.from_channel(channel)
 
     def configure_iq_line(

--- a/src/qibolab/instruments/qm/config/devices.py
+++ b/src/qibolab/instruments/qm/config/devices.py
@@ -5,6 +5,7 @@ from qibolab.components.configs import OscillatorConfig
 from ..components import OpxOutputConfig, QmAcquisitionConfig
 
 __all__ = [
+    "AnalogOutput",
     "OctaveOutput",
     "OctaveInput",
     "Controller",
@@ -29,6 +30,19 @@ class PortDict(dict):
 
     def __setitem__(self, key, value):
         super().__setitem__(str(key), value)
+
+
+@dataclass(frozen=True)
+class AnalogOutput:
+    offset: float = 0.0
+    filter: dict[str, float] = field(default_factory=dict)
+
+    @classmethod
+    def from_config(cls, config: OpxOutputConfig):
+        return cls(
+            offset=config.offset,
+            filter=config.filter,
+        )
 
 
 @dataclass(frozen=True)
@@ -69,7 +83,7 @@ class OctaveInput:
 
 @dataclass
 class Controller:
-    analog_outputs: PortDict[str, dict[str, OpxOutputConfig]] = field(
+    analog_outputs: PortDict[str, dict[str, AnalogOutput]] = field(
         default_factory=PortDict
     )
     digital_outputs: PortDict[str, dict[str, dict]] = field(default_factory=PortDict)
@@ -79,8 +93,8 @@ class Controller:
 
     def add_octave_output(self, port: int):
         # TODO: Add offset here?
-        self.analog_outputs[2 * port - 1] = OpxOutputConfig()
-        self.analog_outputs[2 * port] = OpxOutputConfig()
+        self.analog_outputs[2 * port - 1] = AnalogOutput()
+        self.analog_outputs[2 * port] = AnalogOutput()
 
         self.digital_outputs[2 * port - 1] = {}
 

--- a/src/qibolab/instruments/qm/controller.py
+++ b/src/qibolab/instruments/qm/controller.py
@@ -215,6 +215,12 @@ class QmController(Controller):
             shutil.rmtree(self._calibration_path)
             self._calibration_path = None
 
+    def setup(self, *args, **kwargs):
+        """Complying with abstract instrument interface.
+
+        Not needed for this instrument.
+        """
+
     def connect(self):
         """Connect to the Quantum Machines manager."""
         host, port = self.address.split(":")

--- a/src/qibolab/serialize.py
+++ b/src/qibolab/serialize.py
@@ -58,7 +58,7 @@ def eq(obj1: BaseModel, obj2: BaseModel) -> bool:
 class Model(BaseModel):
     """Global qibolab model, holding common configurations."""
 
-    model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid", frozen=True)
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="allow", frozen=True)
 
 
 M = TypeVar("M", bound=BaseModel)


### PR DESCRIPTION
These updates in the QM driver were required to be compatible with the new serialization. This is based on #983 and the single shot routine has been tested to work on the platform in https://github.com/qiboteam/qibolab_platforms_qrc/pull/153.

The main issue was that `asdict` from `dataclasses` does not seem to work as expected for pydantic `Model` objects, so I had to do a small patch. This may be fixed if we replace all the objects used for QM config to pydantic, but I don't plan to do this for 0.2 as it is fully internal.