### PR TITLE
collection of small fixes, features, and random pieces of code

### DIFF
--- a/src/qibolab/instruments/qblox/cluster_qcm_bb.py
+++ b/src/qibolab/instruments/qblox/cluster_qcm_bb.py
@@ -271,6 +271,7 @@ class QcmBb(ClusterModule):
         # create sequencer wrapper
         sequencer = Sequencer(next_sequencer_number)
         sequencer.qubit = qubit.name if qubit else None
+        sequencer.coupler = coupler.name if coupler else None
         return sequencer
 
     def get_if(self, pulse):
@@ -519,7 +520,14 @@ class QcmBb(ClusterModule):
                             )
 
                     else:  # qubit_sweeper_parameters
-                        if sequencer.qubit in [qubit.name for qubit in sweeper.qubits]:
+
+                        if (
+                            sweeper.qubits
+                            and sequencer.qubit in [q.name for q in sweeper.qubits]
+                        ) or (
+                            sweeper.couplers
+                            and sequencer.coupler in [c.name for c in sweeper.couplers]
+                        ):
                             # plays an active role
                             if sweeper.parameter == Parameter.bias:
                                 reference_value = self._ports[port].offset

--- a/src/qibolab/instruments/qblox/cluster_qcm_bb.py
+++ b/src/qibolab/instruments/qblox/cluster_qcm_bb.py
@@ -520,13 +520,12 @@ class QcmBb(ClusterModule):
                             )
 
                     else:  # qubit_sweeper_parameters
-
                         if (
                             sweeper.qubits
-                            and sequencer.qubit in [q.name for q in sweeper.qubits]
+                            and sequencer.qubit in [_.name for _ in sweeper.qubits]
                         ) or (
                             sweeper.couplers
-                            and sequencer.coupler in [c.name for c in sweeper.couplers]
+                            and sequencer.coupler in [_.name for _ in sweeper.couplers]
                         ):
                             # plays an active role
                             if sweeper.parameter == Parameter.bias:
@@ -650,7 +649,10 @@ class QcmBb(ClusterModule):
                         and pulses[n].sweeper.type == QbloxSweeperType.duration
                     ):
                         RI = pulses[n].sweeper.register
-                        if pulses[n].type == PulseType.FLUX:
+                        if (
+                            pulses[n].type == PulseType.FLUX
+                            or pulses[n].type == PulseType.COUPLERFLUX
+                        ):
                             RQ = pulses[n].sweeper.register
                         else:
                             RQ = pulses[n].sweeper.aux_register

--- a/src/qibolab/instruments/qblox/cluster_qcm_rf.py
+++ b/src/qibolab/instruments/qblox/cluster_qcm_rf.py
@@ -615,10 +615,7 @@ class QcmRf(ClusterModule):
                         and pulses[n].sweeper.type == QbloxSweeperType.duration
                     ):
                         RI = pulses[n].sweeper.register
-                        if (
-                            pulses[n].type == PulseType.FLUX
-                            or pulses[n].type == PulseType.COUPLERFLUX
-                        ):
+                        if pulses[n].type in (PulseType.FLUX, PulseType.COUPLERFLUX):
                             RQ = pulses[n].sweeper.register
                         else:
                             RQ = pulses[n].sweeper.aux_register

--- a/src/qibolab/instruments/qblox/cluster_qcm_rf.py
+++ b/src/qibolab/instruments/qblox/cluster_qcm_rf.py
@@ -197,6 +197,10 @@ class QcmRf(ClusterModule):
                         self._ports[port].lo_frequency = self.settings[port][
                             "lo_frequency"
                         ]
+                    if "mixer_calibration" in self.settings[port]:
+                        self._ports[port].mixer_calibration = self.settings[port][
+                            "mixer_calibration"
+                        ]
                     self._ports[port].attenuation = self.settings[port]["attenuation"]
                     self._ports[port].hardware_mod_en = True
                     self._ports[port].nco_freq = 0

--- a/src/qibolab/instruments/qblox/cluster_qcm_rf.py
+++ b/src/qibolab/instruments/qblox/cluster_qcm_rf.py
@@ -611,7 +611,10 @@ class QcmRf(ClusterModule):
                         and pulses[n].sweeper.type == QbloxSweeperType.duration
                     ):
                         RI = pulses[n].sweeper.register
-                        if pulses[n].type == PulseType.FLUX:
+                        if (
+                            pulses[n].type == PulseType.FLUX
+                            or pulses[n].type == PulseType.COUPLERFLUX
+                        ):
                             RQ = pulses[n].sweeper.register
                         else:
                             RQ = pulses[n].sweeper.aux_register

--- a/src/qibolab/instruments/qblox/cluster_qcm_rf.py
+++ b/src/qibolab/instruments/qblox/cluster_qcm_rf.py
@@ -289,6 +289,7 @@ class QcmRf(ClusterModule):
     def process_pulse_sequence(
         self,
         qubits: dict,
+        couplers: dict,
         instrument_pulses: PulseSequence,
         navgs: int,
         nshots: int,

--- a/src/qibolab/instruments/qblox/cluster_qrm_rf.py
+++ b/src/qibolab/instruments/qblox/cluster_qrm_rf.py
@@ -337,6 +337,7 @@ class QrmRf(ClusterModule):
     def process_pulse_sequence(
         self,
         qubits: dict,
+        couplers: dict,
         instrument_pulses: PulseSequence,
         navgs: int,
         nshots: int,

--- a/src/qibolab/instruments/qblox/cluster_qrm_rf.py
+++ b/src/qibolab/instruments/qblox/cluster_qrm_rf.py
@@ -741,7 +741,10 @@ class QrmRf(ClusterModule):
                             and pulses[n].sweeper.type == QbloxSweeperType.duration
                         ):
                             RI = pulses[n].sweeper.register
-                            if pulses[n].type == PulseType.FLUX:
+                            if (
+                                pulses[n].type == PulseType.FLUX
+                                or pulses[n].type == PulseType.COUPLERFLUX
+                            ):
                                 RQ = pulses[n].sweeper.register
                             else:
                                 RQ = pulses[n].sweeper.aux_register
@@ -788,7 +791,10 @@ class QrmRf(ClusterModule):
                             and pulses[n].sweeper.type == QbloxSweeperType.duration
                         ):
                             RI = pulses[n].sweeper.register
-                            if pulses[n].type == PulseType.FLUX:
+                            if (
+                                pulses[n].type == PulseType.FLUX
+                                or pulses[n].type == PulseType.COUPLERFLUX
+                            ):
                                 RQ = pulses[n].sweeper.register
                             else:
                                 RQ = pulses[n].sweeper.aux_register

--- a/src/qibolab/instruments/qblox/cluster_qrm_rf.py
+++ b/src/qibolab/instruments/qblox/cluster_qrm_rf.py
@@ -745,9 +745,9 @@ class QrmRf(ClusterModule):
                             and pulses[n].sweeper.type == QbloxSweeperType.duration
                         ):
                             RI = pulses[n].sweeper.register
-                            if (
-                                pulses[n].type == PulseType.FLUX
-                                or pulses[n].type == PulseType.COUPLERFLUX
+                            if pulses[n].type in (
+                                PulseType.FLUX,
+                                PulseType.COUPLERFLUX,
                             ):
                                 RQ = pulses[n].sweeper.register
                             else:
@@ -795,9 +795,9 @@ class QrmRf(ClusterModule):
                             and pulses[n].sweeper.type == QbloxSweeperType.duration
                         ):
                             RI = pulses[n].sweeper.register
-                            if (
-                                pulses[n].type == PulseType.FLUX
-                                or pulses[n].type == PulseType.COUPLERFLUX
+                            if pulses[n].type in (
+                                PulseType.FLUX,
+                                PulseType.COUPLERFLUX,
                             ):
                                 RQ = pulses[n].sweeper.register
                             else:

--- a/src/qibolab/instruments/qblox/cluster_qrm_rf.py
+++ b/src/qibolab/instruments/qblox/cluster_qrm_rf.py
@@ -213,6 +213,10 @@ class QrmRf(ClusterModule):
                         self._ports["o1"].lo_frequency = self.settings["o1"][
                             "lo_frequency"
                         ]
+                    if "mixer_calibration" in self.settings["o1"]:
+                        self._ports["o1"].mixer_calibration = self.settings["o1"][
+                            "mixer_calibration"
+                        ]
                     self._ports["o1"].hardware_mod_en = True
                     self._ports["o1"].nco_freq = 0
                     self._ports["o1"].nco_phase_offs = 0

--- a/src/qibolab/instruments/qblox/controller.py
+++ b/src/qibolab/instruments/qblox/controller.py
@@ -120,6 +120,7 @@ class QbloxController(Controller):
     def _execute_pulse_sequence(
         self,
         qubits: dict,
+        couplers: dict,
         sequence: PulseSequence,
         options: ExecutionParameters,
         sweepers: list() = [],  # list(Sweeper) = []
@@ -178,6 +179,7 @@ class QbloxController(Controller):
             #  ask each module to generate waveforms & program and upload them to the device
             module.process_pulse_sequence(
                 qubits,
+                couplers,
                 module_pulses[name],
                 navgs,
                 nshots,
@@ -228,7 +230,7 @@ class QbloxController(Controller):
         return data
 
     def play(self, qubits, couplers, sequence, options):
-        return self._execute_pulse_sequence(qubits, sequence, options)
+        return self._execute_pulse_sequence(qubits, couplers, sequence, options)
 
     def sweep(
         self,
@@ -292,6 +294,7 @@ class QbloxController(Controller):
         # execute the each sweeper recursively
         self._sweep_recursion(
             qubits,
+            couplers,
             sequence_copy,
             options,
             *tuple(sweepers_copy),
@@ -308,6 +311,7 @@ class QbloxController(Controller):
     def _sweep_recursion(
         self,
         qubits,
+        couplers,
         sequence,
         options: ExecutionParameters,
         *sweepers,
@@ -386,6 +390,7 @@ class QbloxController(Controller):
                 if len(sweepers) > 1:
                     self._sweep_recursion(
                         qubits,
+                        couplers,
                         sequence,
                         options,
                         *sweepers[1:],
@@ -393,7 +398,10 @@ class QbloxController(Controller):
                     )
                 else:
                     result = self._execute_pulse_sequence(
-                        qubits=qubits, sequence=sequence, options=options
+                        qubits=qubits,
+                        couplers=couplers,
+                        sequence=sequence,
+                        options=options,
                     )
                     for pulse in sequence.ro_pulses:
                         if results[pulse.id]:
@@ -440,6 +448,7 @@ class QbloxController(Controller):
                         )
                         self._sweep_recursion(
                             qubits,
+                            couplers,
                             sequence,
                             options,
                             *((split_sweeper,) + sweepers[1:]),
@@ -486,7 +495,7 @@ class QbloxController(Controller):
                     #                 qubits[pulse.qubit].drive.gain = 1
 
                     result = self._execute_pulse_sequence(
-                        qubits, sequence, options, sweepers
+                        qubits, couplers, sequence, options, sweepers
                     )
                     self._add_to_results(sequence, results, result)
                 else:
@@ -509,6 +518,7 @@ class QbloxController(Controller):
 
                         res = self._execute_pulse_sequence(
                             qubits,
+                            couplers,
                             sequence,
                             replace(options, nshots=_nshots),
                             sweepers,

--- a/src/qibolab/instruments/qblox/port.py
+++ b/src/qibolab/instruments/qblox/port.py
@@ -248,19 +248,12 @@ class QbloxOutputPort(Port):
         self._settings.i_offset, self._settings.q_offset = value
 
         if self.module.device:
-            self.module._set_device_parameter(
-                self.module.device,
-                f"out{self.port_number}_offset_path0",
-                value=self._settings.i_offset,
-            )
-            self.module._set_device_parameter(
-                self.module.device,
-                f"out{self.port_number}_offset_path1",
-                value=self._settings.q_offset,
-            )
-        else:
-            pass
-            # TODO: This case regards a connection error of the module
+            self.module.device.set(
+                f"out{self.port_number}_offset_path0", self._settings.i_offset
+            ),
+            self.module.device.set(
+                f"out{self.port_number}_offset_path1", self._settings.q_offset
+            ),
 
 
 class QbloxInputPort:

--- a/src/qibolab/instruments/qblox/port.py
+++ b/src/qibolab/instruments/qblox/port.py
@@ -38,7 +38,7 @@ class QbloxOutputPort(Port):
     def __init__(self, module, port_number: int, port_name: str = None):
         self.name = port_name
         self.module = module
-        self.sequencer_number: int = port_number
+        self.sequencer_number: int = module.DEFAULT_SEQUENCERS[port_name]
         self.port_number: int = port_number
         self._settings = QbloxOutputPort_Settings()
 

--- a/src/qibolab/instruments/qblox/sequencer.py
+++ b/src/qibolab/instruments/qblox/sequencer.py
@@ -127,7 +127,7 @@ class WaveformsBuffer:
         # there may be other waveforms stored already, set first index as the next available
         first_idx = len(self.unique_waveforms)
 
-        if pulse.type == PulseType.FLUX:
+        if pulses[n].type == PulseType.FLUX or pulses[n].type == PulseType.COUPLERFLUX:
             # for flux pulses, store i waveforms
             idx_range = np.arange(first_idx, first_idx + len(values), 1)
 

--- a/src/qibolab/instruments/qblox/sequencer.py
+++ b/src/qibolab/instruments/qblox/sequencer.py
@@ -1,3 +1,5 @@
+from typing import Optional, Union
+
 import numpy as np
 from qblox_instruments.qcodes_drivers.sequencer import Sequencer as QbloxSequencer
 
@@ -120,15 +122,15 @@ class WaveformsBuffer:
         Raises:
             NotEnoughMemory: If the memory needed to store the waveforms in more than the memory avalible.
         """
-        # In order to generate waveforms for each duration value, the pulse will need to be modified.
         values = np.round(values).astype(int)
+        # In order to generate waveforms for each duration value, the pulse will need to be modified.
         # To avoid any conflicts, make a copy of the pulse first.
         pulse_copy = pulse.copy()
 
         # there may be other waveforms stored already, set first index as the next available
         first_idx = len(self.unique_waveforms)
 
-        if pulse.type == PulseType.FLUX or pulse.type == PulseType.COUPLERFLUX:
+        if pulse.type in (PulseType.FLUX, PulseType.COUPLERFLUX):
             # for flux pulses, store i waveforms
             idx_range = np.arange(first_idx, first_idx + len(values), 1)
 
@@ -232,5 +234,5 @@ class Sequencer:
         self.acquisitions: dict = {}
         self.weights: dict = {}
         self.program: Program = Program()
-        self.qubit = None  # self.qubit: int | str = None
-        self.coupler = None  # self.coupler: int | str = None
+        self.qubit: Optional[Union[int, str]] = None
+        self.coupler: Optional[Union[int, str]] = None

--- a/src/qibolab/instruments/qblox/sequencer.py
+++ b/src/qibolab/instruments/qblox/sequencer.py
@@ -121,6 +121,7 @@ class WaveformsBuffer:
             NotEnoughMemory: If the memory needed to store the waveforms in more than the memory avalible.
         """
         # In order to generate waveforms for each duration value, the pulse will need to be modified.
+        values = np.round(values).astype(int)
         # To avoid any conflicts, make a copy of the pulse first.
         pulse_copy = pulse.copy()
 

--- a/src/qibolab/instruments/qblox/sequencer.py
+++ b/src/qibolab/instruments/qblox/sequencer.py
@@ -232,3 +232,4 @@ class Sequencer:
         self.weights: dict = {}
         self.program: Program = Program()
         self.qubit = None  # self.qubit: int | str = None
+        self.coupler = None  # self.coupler: int | str = None

--- a/src/qibolab/instruments/qblox/sequencer.py
+++ b/src/qibolab/instruments/qblox/sequencer.py
@@ -127,7 +127,7 @@ class WaveformsBuffer:
         # there may be other waveforms stored already, set first index as the next available
         first_idx = len(self.unique_waveforms)
 
-        if pulses[n].type == PulseType.FLUX or pulses[n].type == PulseType.COUPLERFLUX:
+        if pulse.type == PulseType.FLUX or pulse.type == PulseType.COUPLERFLUX:
             # for flux pulses, store i waveforms
             idx_range = np.arange(first_idx, first_idx + len(values), 1)
 

--- a/src/qibolab/platform/platform.py
+++ b/src/qibolab/platform/platform.py
@@ -385,13 +385,15 @@ class Platform:
         qubit = self.get_qubit(qubit)
         return self.create_MZ_pulse(qubit, start)
 
-    def create_qubit_flux_pulse(self, qubit, start, duration, amplitude=1):
+    def create_qubit_flux_pulse(self, qubit, start, duration, amplitude=1, shape=None):
         qubit = self.get_qubit(qubit)
+        if shape is None:
+            shape = "Rectangular()"
         pulse = FluxPulse(
             start=start,
             duration=duration,
             amplitude=amplitude,
-            shape="Rectangular",
+            shape=shape,
             channel=self.qubits[qubit].flux.name,
             qubit=qubit,
         )

--- a/src/qibolab/platform/platform.py
+++ b/src/qibolab/platform/platform.py
@@ -400,8 +400,10 @@ class Platform:
         pulse.duration = duration
         return pulse
 
-    def create_coupler_pulse(self, coupler, start, duration=None, amplitude=None):
+    def create_coupler_pulse(self, coupler, start, duration=None, amplitude=None, shape=None):
         coupler = self.get_coupler(coupler)
+        if shape is None:
+            shape = "Rectangular()"
         pulse = self.couplers[coupler].native_pulse.CP.pulse(start)
         if duration is not None:
             pulse.duration = duration

--- a/src/qibolab/platform/platform.py
+++ b/src/qibolab/platform/platform.py
@@ -10,7 +10,14 @@ from qibo.config import log, raise_error
 from qibolab.couplers import Coupler
 from qibolab.execution_parameters import ExecutionParameters
 from qibolab.instruments.abstract import Controller, Instrument, InstrumentId
-from qibolab.pulses import Drag, FluxPulse, PulseSequence, ReadoutPulse
+from qibolab.pulses import (
+    CouplerFluxPulse,
+    Drag,
+    FluxPulse,
+    PulseSequence,
+    ReadoutPulse,
+    Rectangular,
+)
 from qibolab.qubits import Qubit, QubitId, QubitPair, QubitPairId
 from qibolab.sweeper import Sweeper
 from qibolab.unrolling import batch
@@ -388,7 +395,7 @@ class Platform:
     def create_qubit_flux_pulse(self, qubit, start, duration, amplitude=1, shape=None):
         qubit = self.get_qubit(qubit)
         if shape is None:
-            shape = "Rectangular()"
+            shape = Rectangular()
         pulse = FluxPulse(
             start=start,
             duration=duration,
@@ -400,15 +407,30 @@ class Platform:
         pulse.duration = duration
         return pulse
 
-    def create_coupler_pulse(self, coupler, start, duration=None, amplitude=None, shape=None):
+    def create_coupler_pulse(
+        self, coupler, start, duration=None, amplitude=None, shape=None
+    ):
         coupler = self.get_coupler(coupler)
+        native_pulse = self.couplers[coupler].native_pulse.CP.pulse(start)
+
+        if duration is None:
+            duration = native_pulse.duration
+        if amplitude is None:
+            amplitude = native_pulse.amplitude
+
         if shape is None:
-            shape = "Rectangular()"
-        pulse = self.couplers[coupler].native_pulse.CP.pulse(start)
-        if duration is not None:
+            pulse = native_pulse
             pulse.duration = duration
-        if amplitude is not None:
             pulse.amplitude = amplitude
+        else:
+            pulse = CouplerFluxPulse(
+                start=start,
+                duration=duration,
+                amplitude=amplitude,
+                shape=shape,
+                channel=self.qubits[coupler].flux.name,
+                qubit=coupler,
+            )
         return pulse
 
     # TODO Remove RX90_drag_pulse and RX_drag_pulse, replace them with create_qubit_drive_pulse

--- a/src/qibolab/pulses.py
+++ b/src/qibolab/pulses.py
@@ -943,15 +943,6 @@ class Pulse:
                 self.channel,
                 self.qubit,
             )
-        elif type(self) == CouplerFluxPulse:
-            return CouplerFluxPulse(
-                self.start,
-                self.duration,
-                self.amplitude,
-                self._shape,
-                self.channel,
-                self.qubit,
-            )
         else:
             # return eval(self.serial)
             return Pulse(

--- a/src/qibolab/pulses.py
+++ b/src/qibolab/pulses.py
@@ -748,12 +748,12 @@ class Custom(PulseShape):
 
         if self.pulse:
             num_samples = int(np.rint(self.pulse.duration * sampling_rate))
-            if len(self.envelope_i) != num_samples:
+            if len(self.envelope_i) < num_samples:
                 raise ValueError(
-                    "Length of envelope_i must be equal to pulse duration in samples"
+                    "Length of envelope_i must not be shorter than pulse duration in samples"
                 )
 
-            waveform = Waveform(self.envelope_i * self.pulse.amplitude)
+            waveform = Waveform(self.envelope_i[:num_samples] * self.pulse.amplitude)
             waveform.serial = f"Envelope_Waveform_I(num_samples = {num_samples}, amplitude = {format(self.pulse.amplitude, '.6f').rstrip('0').rstrip('.')}, shape = {repr(self)})"
             return waveform
         raise ShapeInitError
@@ -763,12 +763,12 @@ class Custom(PulseShape):
 
         if self.pulse:
             num_samples = int(np.rint(self.pulse.duration * sampling_rate))
-            if len(self.envelope_q) != num_samples:
+            if len(self.envelope_q) < num_samples:
                 raise ValueError(
-                    "Length of envelope_q must be equal to pulse duration in samples"
+                    "Length of envelope_q must not be shorter than pulse duration in samples"
                 )
 
-            waveform = Waveform(self.envelope_q * self.pulse.amplitude)
+            waveform = Waveform(self.envelope_q[:num_samples] * self.pulse.amplitude)
             waveform.serial = f"Envelope_Waveform_Q(num_samples = {num_samples}, amplitude = {format(self.pulse.amplitude, '.6f').rstrip('0').rstrip('.')}, shape = {repr(self)})"
             return waveform
         raise ShapeInitError

--- a/src/qibolab/pulses.py
+++ b/src/qibolab/pulses.py
@@ -929,6 +929,15 @@ class Pulse:
                 self.channel,
                 self.qubit,
             )
+        elif type(self) == CouplerFluxPulse:
+            return CouplerFluxPulse(
+                self.start,
+                self.duration,
+                self.amplitude,
+                self._shape,
+                self.channel,
+                self.qubit,
+            )
         else:
             # return eval(self.serial)
             return Pulse(
@@ -1221,6 +1230,7 @@ class PulseConstructor(Enum):
     READOUT = ReadoutPulse
     DRIVE = DrivePulse
     FLUX = FluxPulse
+    COUPLERFLUX = CouplerFluxPulse
 
 
 class PulseSequence:

--- a/src/qibolab/pulses.py
+++ b/src/qibolab/pulses.py
@@ -705,11 +705,13 @@ class Custom(PulseShape):
     """Arbitrary shape."""
 
     def __init__(self, envelope_i, envelope_q=None):
+        from ast import literal_eval
+
         self.name = "Custom"
         self.pulse: Pulse = None
-        self.envelope_i: np.ndarray = np.array(envelope_i)
+        self.envelope_i: np.ndarray = np.array(literal_eval(envelope_i))
         if envelope_q is not None:
-            self.envelope_q: np.ndarray = np.array(envelope_q)
+            self.envelope_q: np.ndarray = np.array(literal_eval(envelope_q))
         else:
             self.envelope_q = self.envelope_i
 
@@ -717,11 +719,13 @@ class Custom(PulseShape):
         """The envelope waveform of the i component of the pulse."""
 
         if self.pulse:
-            if self.pulse.duration != len(self.envelope_i):
+            if self.pulse.duration > len(self.envelope_i):
                 raise ValueError("Length of envelope_i must be equal to pulse duration")
             num_samples = int(np.rint(self.pulse.duration * sampling_rate))
 
-            waveform = Waveform(self.envelope_i * self.pulse.amplitude)
+            waveform = Waveform(
+                np.clip(self.envelope_i[:num_samples] * self.pulse.amplitude, -1, 1)
+            )
             waveform.serial = f"Envelope_Waveform_I(num_samples = {num_samples}, amplitude = {format(self.pulse.amplitude, '.6f').rstrip('0').rstrip('.')}, shape = {repr(self)})"
             return waveform
         raise ShapeInitError
@@ -730,11 +734,13 @@ class Custom(PulseShape):
         """The envelope waveform of the q component of the pulse."""
 
         if self.pulse:
-            if self.pulse.duration != len(self.envelope_q):
+            if self.pulse.duration > len(self.envelope_q):
                 raise ValueError("Length of envelope_q must be equal to pulse duration")
             num_samples = int(np.rint(self.pulse.duration * sampling_rate))
 
-            waveform = Waveform(self.envelope_q * self.pulse.amplitude)
+            waveform = Waveform(
+                np.clip(self.envelope_q[:num_samples] * self.pulse.amplitude, -1, 1)
+            )
             waveform.serial = f"Envelope_Waveform_Q(num_samples = {num_samples}, amplitude = {format(self.pulse.amplitude, '.6f').rstrip('0').rstrip('.')}, shape = {repr(self)})"
             return waveform
         raise ShapeInitError

--- a/src/qibolab/pulses.py
+++ b/src/qibolab/pulses.py
@@ -1587,30 +1587,39 @@ class PulseSequence:
         """Separates a sequence of overlapping pulses into a list of non-
         overlapping sequences."""
 
-        # This routine separates the pulses of a sequence into non-overlapping sets
-        # but it does not check if the frequencies of the pulses within a set have the same frequency
+        # This routine separates the pulses of a sequence into sets of different frequecy, non-overlapping
+        # pulses
 
-        separated_pulses = []
-        for new_pulse in self.pulses:
-            stored = False
-            for ps in separated_pulses:
-                overlaps = False
-                for existing_pulse in ps:
-                    if (
-                        new_pulse.start < existing_pulse.finish
-                        and new_pulse.finish > existing_pulse.start
-                    ):
-                        overlaps = True
+        freqs = set()
+        for pulse in self.pulses:
+            freqs |= {pulse.frequency}
+        PS_freq = {}
+        separated_pulses = {}
+        for freq in freqs:
+            PS_freq[freq] = PulseSequence()
+            separated_pulses[freq] = []
+            for pulse in self.pulses:
+                if pulse.frequency == freq:
+                    PS_freq[freq].add(pulse)
+
+            for new_pulse in PS_freq[freq]:
+                stored = False
+                for ps in separated_pulses[freq]:
+                    overlaps = False
+                    for existing_pulse in ps:
+                        if (
+                            new_pulse.start < existing_pulse.finish
+                            and new_pulse.finish > existing_pulse.start
+                        ):
+                            overlaps = True
+                            break
+                    if not overlaps:
+                        ps.add(new_pulse)
+                        stored = True
                         break
-                if not overlaps:
-                    ps.add(new_pulse)
-                    stored = True
-                    break
-            if not stored:
-                separated_pulses.append(PulseSequence(new_pulse))
-        return separated_pulses
-
-    # TODO: Implement separate_different_frequency_pulses()
+                if not stored:
+                    separated_pulses[freq].append(PulseSequence(new_pulse))
+        return [ps for freq in freqs for ps in separated_pulses[freq]]
 
     @property
     def pulses_overlap(self) -> bool:

--- a/src/qibolab/pulses.py
+++ b/src/qibolab/pulses.py
@@ -705,28 +705,14 @@ class Custom(PulseShape):
     """Arbitrary shape."""
 
     def __init__(self, envelope_i, envelope_q=None):
-        from ast import literal_eval
 
         self.name = "Custom"
         self.pulse: Pulse = None
-        if isinstance(envelope_i, str):
-            self.envelope_i: np.ndarray = np.array(literal_eval(envelope_i))
-            if envelope_q is not None:
-                self.envelope_q: np.ndarray = np.array(literal_eval(envelope_q))
-            else:
-                self.envelope_q = self.envelope_i
-        elif isinstance(envelope_i, list):
-            self.envelope_i: np.ndarray = np.array(envelope_i)
-            if envelope_q is not None:
-                self.envelope_q: np.ndarray = np.array(envelope_q)
-            else:
-                self.envelope_q = self.envelope_i
-        elif isinstance(envelope_i, np.ndarray):
-            self.envelope_i: np.ndarray = envelope_i
-            if envelope_q is not None:
-                self.envelope_q: np.ndarray = envelope_q
-            else:
-                self.envelope_q = self.envelope_i
+        self.envelope_i: np.ndarray = np.array(envelope_i)
+        if envelope_q is not None:
+            self.envelope_q: np.ndarray = np.array(envelope_q)
+        else:
+            self.envelope_q = self.envelope_i
 
     def envelope_waveform_i(self, sampling_rate=SAMPLING_RATE) -> Waveform:
         """The envelope waveform of the i component of the pulse."""

--- a/src/qibolab/pulses.py
+++ b/src/qibolab/pulses.py
@@ -709,11 +709,24 @@ class Custom(PulseShape):
 
         self.name = "Custom"
         self.pulse: Pulse = None
-        self.envelope_i: np.ndarray = np.array(literal_eval(envelope_i))
-        if envelope_q is not None:
-            self.envelope_q: np.ndarray = np.array(literal_eval(envelope_q))
-        else:
-            self.envelope_q = self.envelope_i
+        if isinstance(envelope_i, str):
+            self.envelope_i: np.ndarray = np.array(literal_eval(envelope_i))
+            if envelope_q is not None:
+                self.envelope_q: np.ndarray = np.array(literal_eval(envelope_q))
+            else:
+                self.envelope_q = self.envelope_i
+        elif isinstance(envelope_i, list):
+            self.envelope_i: np.ndarray = np.array(envelope_i)
+            if envelope_q is not None:
+                self.envelope_q: np.ndarray = np.array(envelope_q)
+            else:
+                self.envelope_q = self.envelope_i
+        elif isinstance(envelope_i, np.ndarray):
+            self.envelope_i: np.ndarray = envelope_i
+            if envelope_q is not None:
+                self.envelope_q: np.ndarray = envelope_q
+            else:
+                self.envelope_q = self.envelope_i
 
     def envelope_waveform_i(self, sampling_rate=SAMPLING_RATE) -> Waveform:
         """The envelope waveform of the i component of the pulse."""

--- a/src/qibolab/pulses.py
+++ b/src/qibolab/pulses.py
@@ -938,6 +938,15 @@ class Pulse:
                 self.channel,
                 self.qubit,
             )
+        elif type(self) == CouplerFluxPulse:
+            return CouplerFluxPulse(
+                self.start,
+                self.duration,
+                self.amplitude,
+                self._shape,
+                self.channel,
+                self.qubit,
+            )
         else:
             # return eval(self.serial)
             return Pulse(

--- a/src/qibolab/pulses.py
+++ b/src/qibolab/pulses.py
@@ -732,13 +732,13 @@ class Custom(PulseShape):
         """The envelope waveform of the i component of the pulse."""
 
         if self.pulse:
-            if self.pulse.duration > len(self.envelope_i):
-                raise ValueError("Length of envelope_i must be equal to pulse duration")
             num_samples = int(np.rint(self.pulse.duration * sampling_rate))
+            if len(self.envelope_i) != num_samples:
+                raise ValueError(
+                    "Length of envelope_i must be equal to pulse duration in samples"
+                )
 
-            waveform = Waveform(
-                np.clip(self.envelope_i[:num_samples] * self.pulse.amplitude, -1, 1)
-            )
+            waveform = Waveform(self.envelope_i * self.pulse.amplitude)
             waveform.serial = f"Envelope_Waveform_I(num_samples = {num_samples}, amplitude = {format(self.pulse.amplitude, '.6f').rstrip('0').rstrip('.')}, shape = {repr(self)})"
             return waveform
         raise ShapeInitError
@@ -747,13 +747,13 @@ class Custom(PulseShape):
         """The envelope waveform of the q component of the pulse."""
 
         if self.pulse:
-            if self.pulse.duration > len(self.envelope_q):
-                raise ValueError("Length of envelope_q must be equal to pulse duration")
             num_samples = int(np.rint(self.pulse.duration * sampling_rate))
+            if len(self.envelope_q) != num_samples:
+                raise ValueError(
+                    "Length of envelope_q must be equal to pulse duration in samples"
+                )
 
-            waveform = Waveform(
-                np.clip(self.envelope_q[:num_samples] * self.pulse.amplitude, -1, 1)
-            )
+            waveform = Waveform(self.envelope_q * self.pulse.amplitude)
             waveform.serial = f"Envelope_Waveform_Q(num_samples = {num_samples}, amplitude = {format(self.pulse.amplitude, '.6f').rstrip('0').rstrip('.')}, shape = {repr(self)})"
             return waveform
         raise ShapeInitError

--- a/src/qibolab/pulses.py
+++ b/src/qibolab/pulses.py
@@ -939,7 +939,7 @@ class Pulse:
                 self.start,
                 self.duration,
                 self.amplitude,
-                self._shape,
+                self.shape,
                 self.channel,
                 self.qubit,
             )

--- a/src/qibolab/result.py
+++ b/src/qibolab/result.py
@@ -38,7 +38,7 @@ class IntegratedResults:
     @cached_property
     def phase(self):
         """Signal phase in radians."""
-        return np.unwrap(np.arctan2(self.voltage_i, self.voltage_q))
+        return np.unwrap(np.arctan2(self.voltage_q, self.voltage_i))
 
     @cached_property
     def phase_std(self):
@@ -95,7 +95,7 @@ class AveragedIntegratedResults(IntegratedResults):
     @cached_property
     def phase(self):
         """Phase not unwrapped because it is a single value."""
-        return np.arctan2(self.voltage_i, self.voltage_q)
+        return np.arctan2(self.voltage_q, self.voltage_i)
 
 
 class RawWaveformResults(IntegratedResults):

--- a/tests/dummy_qrc/qblox/parameters.json
+++ b/tests/dummy_qrc/qblox/parameters.json
@@ -11,24 +11,30 @@
         3,
         4
     ],
-    "topology": [
-        [
+    "couplers": [
+        0,
+        1,
+        3,
+        4
+    ],
+    "topology": {
+        "0": [
             0,
             2
         ],
-        [
+        "1": [
             1,
             2
         ],
-        [
+        "3": [
             2,
             3
         ],
-        [
+        "4": [
             2,
             4
         ]
-    ],
+    },
     "instruments": {
         "qblox_controller": {
             "bounds": {
@@ -76,7 +82,8 @@
             "o1": {
                 "attenuation": 36,
                 "lo_frequency": 7300000000,
-                "gain": 0.6
+                "gain": 0.6,
+                "mixer_calibration": [-3.2, 1.4]
             },
             "i1": {
                 "acquisition_hold_off": 500,
@@ -87,7 +94,8 @@
             "o1": {
                 "attenuation": 36,
                 "lo_frequency": 7850000000,
-                "gain": 0.6
+                "gain": 0.6,
+                "mixer_calibration": [0.3, -3.8]
             },
             "i1": {
                 "acquisition_hold_off": 500,
@@ -240,6 +248,48 @@
                     "type": "ro",
                     "relative_start": 0,
                     "phase": 0
+                }
+            }
+        },
+        "coupler": {
+            "0": {
+                "CP": {
+                    "type": "coupler",
+                    "duration": 0,
+                    "amplitude": 0,
+                    "shape": "Rectangular()",
+                    "coupler": 0,
+                    "relative_start": 0
+                }
+            },
+            "1": {
+                "CP": {
+                    "type": "coupler",
+                    "duration": 0,
+                    "amplitude": 0,
+                    "shape": "Rectangular()",
+                    "coupler": 1,
+                    "relative_start": 0
+                }
+            },
+            "3": {
+                "CP": {
+                    "type": "coupler",
+                    "duration": 0,
+                    "amplitude": 0,
+                    "shape": "Rectangular()",
+                    "coupler": 3,
+                    "relative_start": 0
+                }
+            },
+            "4": {
+                "CP": {
+                    "type": "coupler",
+                    "duration": 0,
+                    "amplitude": 0,
+                    "shape": "Rectangular()",
+                    "coupler": 4,
+                    "relative_start": 0
                 }
             }
         },
@@ -401,22 +451,18 @@
                 "threshold": 0.002323
             }
         },
-        "two_qubit":{
-            "0-2": {
-                "gate_fidelity": [0.0, 0.0],
-                "cz_fidelity": [0.0, 0.0]
+        "coupler": {
+            "0": {
+                "sweetspot": 0.1
             },
-            "1-2": {
-                "gate_fidelity": [0.0, 0.0],
-                "cz_fidelity": [0.0, 0.0]
+            "1": {
+                "sweetspot": 0.2
             },
-            "2-3": {
-                "gate_fidelity": [0.0, 0.0],
-                "cz_fidelity": [0.0, 0.0]
+            "3": {
+                "sweetspot": -0.3
             },
-            "2-4": {
-                "gate_fidelity": [0.0, 0.0],
-                "cz_fidelity": [0.0, 0.0]
+            "4": {
+                "sweetspot": 0.0
             }
         }
     }

--- a/tests/dummy_qrc/qblox/platform.py
+++ b/tests/dummy_qrc/qblox/platform.py
@@ -30,6 +30,7 @@ def create():
     modules = {
         "qcm_bb0": QcmBb("qcm_bb0", f"{ADDRESS}:2"),
         "qcm_bb1": QcmBb("qcm_bb1", f"{ADDRESS}:4"),
+        "qcm_bb2": QcmBb("qcm_bb2", f"{ADDRESS}:3"),
         "qcm_rf0": QcmRf("qcm_rf0", f"{ADDRESS}:6"),
         "qcm_rf1": QcmRf("qcm_rf1", f"{ADDRESS}:8"),
         "qcm_rf2": QcmRf("qcm_rf2", f"{ADDRESS}:10"),
@@ -61,12 +62,17 @@ def create():
     channels |= Channel(name="L3-12", port=modules["qcm_rf1"].ports("o1"))
     channels |= Channel(name="L3-13", port=modules["qcm_rf1"].ports("o2"))
     channels |= Channel(name="L3-14", port=modules["qcm_rf2"].ports("o1"))
-    # Flux
+    # Qubit flux
     channels |= Channel(name="L4-5", port=modules["qcm_bb0"].ports("o1"))
     channels |= Channel(name="L4-1", port=modules["qcm_bb0"].ports("o2"))
     channels |= Channel(name="L4-2", port=modules["qcm_bb0"].ports("o3"))
     channels |= Channel(name="L4-3", port=modules["qcm_bb0"].ports("o4"))
     channels |= Channel(name="L4-4", port=modules["qcm_bb1"].ports("o1"))
+    # Coupler flux
+    channels |= Channel(name="L4-12", port=modules["qcm_bb1"].ports("o2"))
+    channels |= Channel(name="L4-13", port=modules["qcm_bb1"].ports("o3"))
+    channels |= Channel(name="L4-14", port=modules["qcm_bb1"].ports("o4"))
+    channels |= Channel(name="L4-5", port=modules["qcm_bb2"].ports("o1"))
     # TWPA
     channels |= Channel(name="L3-28", port=None)
     channels["L3-28"].local_oscillator = twpa_pump
@@ -98,8 +104,20 @@ def create():
     for q in range(5):
         qubits[q].flux.max_bias = 2.5
 
+    for i, coupler in enumerate(couplers):
+        couplers[coupler].flux = (
+            channels[f"L4-{11 + i}"] if i > 0 else channels[f"L4-5"]
+        )
+        couplers[coupler].flux.max_bias = 2.5
+
     settings = load_settings(runcard)
 
     return Platform(
-        str(FOLDER), qubits, pairs, instruments, settings, resonator_type="2D"
+        str(FOLDER),
+        qubits,
+        pairs,
+        instruments,
+        settings,
+        resonator_type="2D",
+        couplers=couplers,
     )

--- a/tests/test_instruments_qblox_controller.py
+++ b/tests/test_instruments_qblox_controller.py
@@ -61,6 +61,25 @@ def test_sweep_too_many_sweep_points(platform, controller):
         controller.sweep({0: qubit}, {}, PulseSequence(pulse), params, sweep)
 
 
+def test_sweep_coupler(platform, controller):
+    """Test that coupler related sweep is accepted."""
+    ro_pulse = platform.create_MZ_pulse(qubit=0, start=0)
+    sequence = PulseSequence(ro_pulse)
+
+    sweeper = Sweeper(Parameter.bias, np.random.rand(4), couplers=[0])
+    params = ExecutionParameters(
+        nshots=10, relaxation_time=1000, averaging_mode=AveragingMode.CYCLIC
+    )
+    mock_data = np.array([1, 2, 3, 4])
+    controller._execute_pulse_sequence = Mock(
+        return_value={ro_pulse.serial: IntegratedResults(mock_data)}
+    )
+    res = controller.sweep(
+        platform.qubits, platform.couplers, sequence, params, sweeper
+    )
+    assert np.array_equal(res[ro_pulse.serial].voltage, mock_data)
+
+
 @pytest.mark.qpu
 def connect(connected_controller: QbloxController):
     connected_controller.connect()

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -71,7 +71,7 @@ def test_integrated_result_properties(result):
         np.sqrt(results.voltage_i**2 + results.voltage_q**2), results.magnitude
     )
     np.testing.assert_equal(
-        np.unwrap(np.arctan2(results.voltage_i, results.voltage_q)), results.phase
+        np.unwrap(np.arctan2(results.voltage_q, results.voltage_i)), results.phase
     )
 
 
@@ -119,7 +119,7 @@ def test_serialize(average, result):
             "MSR[V]": np.sqrt(avg.voltage_i**2 + avg.voltage_q**2),
             "i[V]": avg.voltage_i,
             "q[V]": avg.voltage_q,
-            "phase[rad]": np.unwrap(np.arctan2(avg.voltage_i, avg.voltage_q)),
+            "phase[rad]": np.unwrap(np.arctan2(avg.voltage_q, avg.voltage_i)),
         }
         assert avg.serialize.keys() == target_dict.keys()
         for key in output:
@@ -155,7 +155,7 @@ def test_serialize_averaged_iq_results(result):
         "MSR[V]": np.sqrt(results.voltage_i**2 + results.voltage_q**2),
         "i[V]": results.voltage_i,
         "q[V]": results.voltage_q,
-        "phase[rad]": np.unwrap(np.arctan2(results.voltage_i, results.voltage_q)),
+        "phase[rad]": np.unwrap(np.arctan2(results.voltage_q, results.voltage_i)),
     }
     assert output.keys() == target_dict.keys()
     for key in output:


### PR DESCRIPTION
This PR brings the following:

- some cherry picked commits from branch **alvaro/latest_20231215** that collectively
  1. introduce support for couplers in the qblox driver.
  2. expose `offset_i` and `offset_q` mixer calibration parameters for qblox RF modules.
- cleanup of the said commits to 
  1. align the code with main (the commits were based on older version of qibolab)
  2. make the code more pythonic and more readable
  3. remove things that were done from a perspective of a user that uses qblox alone (i.e. from a perspective where qibolab==qblox driver), but should not be part of things qibolab does.
- fix "deserialization" of `Custom` pulse shape:
  - as a side effect fixes deserialization of IIR, and SNR as well.

This is intended to cover the discussions in https://github.com/qiboteam/qibolab/issues/919 and https://github.com/qiboteam/qibolab/issues/921