### PR TITLE
Extend `Config` beyond channels

### DIFF
--- a/doc/source/getting-started/experiment.rst
+++ b/doc/source/getting-started/experiment.rst
@@ -205,7 +205,7 @@ We leave to the dedicated tutorial a full explanation of the experiment, but her
     from qibolab import create_platform
     from qibolab.sequence import PulseSequence
     from qibolab.result import magnitude
-    from qibolab.sweeper import Sweeper, SweeperType, Parameter
+    from qibolab.sweeper import Sweeper, Parameter
     from qibolab.execution_parameters import (
         ExecutionParameters,
         AveragingMode,
@@ -221,11 +221,11 @@ We leave to the dedicated tutorial a full explanation of the experiment, but her
     sequence = natives.MZ.create_sequence()
 
     # define a sweeper for a frequency scan
+    f0 = platform.config(str(qubit.probe.name)).frequency  # center frequency
     sweeper = Sweeper(
         parameter=Parameter.frequency,
-        values=np.arange(-2e8, +2e8, 1e6),
+        values=f0 + np.arange(-2e8, +2e8, 1e6),
         channels=[qubit.probe.name],
-        type=SweeperType.OFFSET,
     )
 
     # perform the experiment using specific options
@@ -241,9 +241,7 @@ We leave to the dedicated tutorial a full explanation of the experiment, but her
 
     # plot the results
     amplitudes = magnitude(results[acq.id][0])
-    frequencies = (
-        np.arange(-2e8, +2e8, 1e6) + platform.config(str(qubit.probe.name)).frequency
-    )
+    frequencies = sweeper.values
 
     plt.title("Resonator Spectroscopy")
     plt.xlabel("Frequencies [Hz]")

--- a/doc/source/tutorials/calibration.rst
+++ b/doc/source/tutorials/calibration.rst
@@ -32,7 +32,7 @@ around the pre-defined frequency.
     from qibolab import create_platform
     from qibolab.sequence import PulseSequence
     from qibolab.result import magnitude
-    from qibolab.sweeper import Sweeper, SweeperType, Parameter
+    from qibolab.sweeper import Sweeper, Parameter
     from qibolab.execution_parameters import (
         ExecutionParameters,
         AveragingMode,
@@ -47,11 +47,11 @@ around the pre-defined frequency.
     sequence = natives.MZ.create_sequence()
 
     # allocate frequency sweeper
+    f0 = platform.config(str(qubit.probe.name)).frequency
     sweeper = Sweeper(
         parameter=Parameter.frequency,
-        values=np.arange(-2e8, +2e8, 1e6),
+        values=f0 + np.arange(-2e8, +2e8, 1e6),
         channels=[qubit.probe.name],
-        type=SweeperType.OFFSET,
     )
 
 We then define the execution parameters and launch the experiment.
@@ -75,9 +75,7 @@ In few seconds, the experiment will be finished and we can proceed to plot it.
 
     acq = sequence.acquisitions[0][1]
     amplitudes = magnitude(results[acq.id][0])
-    frequencies = (
-        np.arange(-2e8, +2e8, 1e6) + platform.config(str(qubit.probe.name)).frequency
-    )
+    frequencies = sweeper.values
 
     plt.title("Resonator Spectroscopy")
     plt.xlabel("Frequencies [Hz]")
@@ -116,7 +114,7 @@ complex pulse sequence. Therefore with start with that:
     from qibolab.pulses import Pulse, Delay, Gaussian
     from qibolab.sequence import PulseSequence
     from qibolab.result import magnitude
-    from qibolab.sweeper import Sweeper, SweeperType, Parameter
+    from qibolab.sweeper import Sweeper, Parameter
     from qibolab.execution_parameters import (
         ExecutionParameters,
         AveragingMode,
@@ -143,11 +141,11 @@ complex pulse sequence. Therefore with start with that:
     sequence.concatenate(natives.MZ.create_sequence())
 
     # allocate frequency sweeper
+    f0 = platform.config(str(qubit.probe.name)).frequency
     sweeper = Sweeper(
         parameter=Parameter.frequency,
-        values=np.arange(-2e8, +2e8, 1e6),
+        values=f0 + np.arange(-2e8, +2e8, 1e6),
         channels=[qubit.drive.name],
-        type=SweeperType.OFFSET,
     )
 
 Note that the drive pulse has been changed to match the characteristics required
@@ -168,9 +166,7 @@ We can now proceed to launch on hardware:
 
     _, acq = next(iter(sequence.acquisitions))
     amplitudes = magnitude(results[acq.id][0])
-    frequencies = (
-        np.arange(-2e8, +2e8, 1e6) + platform.config(str(qubit.drive.name)).frequency
-    )
+    frequencies = sweeper.values
 
     plt.title("Resonator Spectroscopy")
     plt.xlabel("Frequencies [Hz]")
@@ -223,7 +219,7 @@ and its impact on qubit states in the IQ plane.
     from qibolab.pulses import Delay
     from qibolab.sequence import PulseSequence
     from qibolab.result import unpack
-    from qibolab.sweeper import Sweeper, SweeperType, Parameter
+    from qibolab.sweeper import Sweeper, Parameter
     from qibolab.execution_parameters import (
         ExecutionParameters,
         AveragingMode,

--- a/src/qibolab/components/configs.py
+++ b/src/qibolab/components/configs.py
@@ -120,19 +120,6 @@ class AcquisitionConfig(Config):
         )
 
 
-class BoundsConfig(Config):
-    """Instument memory limitations proxies."""
-
-    kind: Literal["bounds"] = "bounds"
-
-    waveforms: int
-    """Waveforms estimated size."""
-    readout: int
-    """Number of readouts."""
-    instructions: int
-    """Instructions estimated size."""
-
-
 ChannelConfig = Union[
-    DcConfig, IqMixerConfig, OscillatorConfig, IqConfig, AcquisitionConfig, BoundsConfig
+    DcConfig, IqMixerConfig, OscillatorConfig, IqConfig, AcquisitionConfig
 ]

--- a/src/qibolab/components/configs.py
+++ b/src/qibolab/components/configs.py
@@ -20,10 +20,15 @@ __all__ = [
     "IqMixerConfig",
     "OscillatorConfig",
     "Config",
+    "ChannelConfig",
 ]
 
 
-class DcConfig(Model):
+class Config(Model):
+    """Configuration values depot."""
+
+
+class DcConfig(Config):
     """Configuration for a channel that can be used to send DC pulses (i.e.
     just envelopes without modulation)."""
 
@@ -33,7 +38,7 @@ class DcConfig(Model):
     """DC offset/bias of the channel."""
 
 
-class OscillatorConfig(Model):
+class OscillatorConfig(Config):
     """Configuration for an oscillator."""
 
     kind: Literal["oscillator"] = "oscillator"
@@ -42,7 +47,7 @@ class OscillatorConfig(Model):
     power: float
 
 
-class IqMixerConfig(Model):
+class IqMixerConfig(Config):
     """Configuration for IQ mixer.
 
     Mixers usually have various imperfections, and one needs to
@@ -64,7 +69,7 @@ class IqMixerConfig(Model):
     imbalance."""
 
 
-class IqConfig(Model):
+class IqConfig(Config):
     """Configuration for an IQ channel."""
 
     kind: Literal["iq"] = "iq"
@@ -73,7 +78,7 @@ class IqConfig(Model):
     """The carrier frequency of the channel."""
 
 
-class AcquisitionConfig(Model):
+class AcquisitionConfig(Config):
     """Configuration for acquisition channel.
 
     Currently, in qibolab, acquisition channels are FIXME:
@@ -115,7 +120,7 @@ class AcquisitionConfig(Model):
         )
 
 
-class BoundsConfig(Model):
+class BoundsConfig(Config):
     """Instument memory limitations proxies."""
 
     kind: Literal["bounds"] = "bounds"
@@ -128,14 +133,6 @@ class BoundsConfig(Model):
     """Instructions estimated size."""
 
 
-Config = Annotated[
-    Union[
-        DcConfig,
-        IqMixerConfig,
-        OscillatorConfig,
-        IqConfig,
-        AcquisitionConfig,
-        BoundsConfig,
-    ],
-    Field(discriminator="kind"),
+ChannelConfig = Union[
+    DcConfig, IqMixerConfig, OscillatorConfig, IqConfig, AcquisitionConfig, BoundsConfig
 ]

--- a/src/qibolab/identifier.py
+++ b/src/qibolab/identifier.py
@@ -1,12 +1,26 @@
 from enum import Enum
 from typing import Annotated, Optional, Union
 
-from pydantic import Field, TypeAdapter, model_serializer, model_validator
+from pydantic import (
+    BeforeValidator,
+    Field,
+    PlainSerializer,
+    TypeAdapter,
+    model_serializer,
+    model_validator,
+)
 
 from .serialize import Model
 
 QubitId = Annotated[Union[int, str], Field(union_mode="left_to_right")]
 """Type for qubit names."""
+
+QubitPairId = Annotated[
+    tuple[QubitId, QubitId],
+    BeforeValidator(lambda p: tuple(p.split("-")) if isinstance(p, str) else p),
+    PlainSerializer(lambda p: f"{p[0]}-{p[1]}"),
+]
+"""Type for holding ``QubitPair``s in the ``platform.pairs`` dictionary."""
 
 
 # TODO: replace with StrEnum, once py3.10 will be abandoned

--- a/src/qibolab/identifier.py
+++ b/src/qibolab/identifier.py
@@ -42,6 +42,9 @@ class ChannelType(str, Enum):
         return str(self.value)
 
 
+_adapted_qubit = TypeAdapter(QubitId)
+
+
 class ChannelId(Model):
     """Unique identifier for a channel."""
 
@@ -56,7 +59,7 @@ class ChannelId(Model):
         # TODO: replace with pattern matching, once py3.9 will be abandoned
         if len(elements) > 3:
             raise ValueError()
-        q = TypeAdapter(QubitId).validate_python(elements[0])
+        q = _adapted_qubit.validate_python(elements[0])
         ct = ChannelType(elements[1])
         assert len(elements) == 2 or ct is ChannelType.DRIVE_CROSS
         dc = elements[2] if len(elements) == 3 else None

--- a/src/qibolab/instruments/qm/components/configs.py
+++ b/src/qibolab/instruments/qm/components/configs.py
@@ -4,7 +4,7 @@ from pydantic import Field
 
 from qibolab.components import AcquisitionConfig, DcConfig
 
-__all__ = ["OpxOutputConfig", "QmAcquisitionConfig", "QmConfig"]
+__all__ = ["OpxOutputConfig", "QmAcquisitionConfig", "QmConfigs"]
 
 
 class OpxOutputConfig(DcConfig):
@@ -41,4 +41,4 @@ class QmAcquisitionConfig(AcquisitionConfig):
     """Constant voltage to be applied on the input."""
 
 
-QmConfig = Union[OpxOutputConfig, QmAcquisitionConfig]
+QmConfigs = Union[OpxOutputConfig, QmAcquisitionConfig]

--- a/src/qibolab/instruments/qm/components/configs.py
+++ b/src/qibolab/instruments/qm/components/configs.py
@@ -1,13 +1,10 @@
-from typing import Literal
+from typing import Literal, Union
 
 from pydantic import Field
 
 from qibolab.components import AcquisitionConfig, DcConfig
 
-__all__ = [
-    "OpxOutputConfig",
-    "QmAcquisitionConfig",
-]
+__all__ = ["OpxOutputConfig", "QmAcquisitionConfig", "QmConfig"]
 
 
 class OpxOutputConfig(DcConfig):
@@ -20,7 +17,7 @@ class OpxOutputConfig(DcConfig):
 
     Possible values are -0.5V to 0.5V.
     """
-    filter: dict[str, float] = Field(default_factory=dict)
+    filter: dict[str, list[float]] = Field(default_factory=dict)
     """FIR and IIR filters to be applied for correcting signal distortions.
 
     See
@@ -42,3 +39,6 @@ class QmAcquisitionConfig(AcquisitionConfig):
     """
     offset: float = 0.0
     """Constant voltage to be applied on the input."""
+
+
+QmConfig = Union[OpxOutputConfig, QmAcquisitionConfig]

--- a/src/qibolab/parameters.py
+++ b/src/qibolab/parameters.py
@@ -5,6 +5,7 @@ example.
 """
 
 from collections.abc import Callable, Iterable
+from types import UnionType
 from typing import Annotated, Any, Type, Union
 
 from pydantic import BeforeValidator, Field, PlainSerializer, TypeAdapter
@@ -104,7 +105,8 @@ ComponentId = str
 This is assumed to always be in its serialized form.
 """
 
-_BUILTIN_CONFIGS = [ChannelConfig, Bounds]
+_ChannelConfigT = Union[UnionType, type[Config]]
+_BUILTIN_CONFIGS: tuple[_ChannelConfigT, ...] = (ChannelConfig, Bounds)
 
 
 class ConfigKinds:
@@ -120,7 +122,7 @@ class ConfigKinds:
         loading operations.
     """
 
-    _registered: list[Type[Config]] = _BUILTIN_CONFIGS
+    _registered: list[_ChannelConfigT] = list(_BUILTIN_CONFIGS)
 
     @classmethod
     def extend(cls, kinds: Iterable[Type[Config]]):
@@ -133,10 +135,10 @@ class ConfigKinds:
     @classmethod
     def reset(cls):
         """Reset known configuration kinds to built-ins."""
-        cls._registered = _BUILTIN_CONFIGS
+        cls._registered = list(_BUILTIN_CONFIGS)
 
     @classmethod
-    def registered(cls) -> list[Type[Config]]:
+    def registered(cls) -> list[_ChannelConfigT]:
         """Retrieve registered configuration kinds."""
         return cls._registered.copy()
 

--- a/src/qibolab/parameters.py
+++ b/src/qibolab/parameters.py
@@ -5,7 +5,6 @@ example.
 """
 
 from collections.abc import Callable, Iterable
-from types import UnionType
 from typing import Annotated, Any, Union
 
 from pydantic import BeforeValidator, Field, PlainSerializer, TypeAdapter
@@ -105,7 +104,9 @@ ComponentId = str
 This is assumed to always be in its serialized form.
 """
 
-_ChannelConfigT = Union[UnionType, type[Config]]
+# TODO: replace _UnionType with UnionType, once py3.9 will be abandoned
+_UnionType = Any
+_ChannelConfigT = Union[_UnionType, type[Config]]
 _BUILTIN_CONFIGS: tuple[_ChannelConfigT, ...] = (ChannelConfig, Bounds)
 
 

--- a/src/qibolab/parameters.py
+++ b/src/qibolab/parameters.py
@@ -5,12 +5,12 @@ example.
 """
 
 from collections.abc import Callable
-from typing import Any
+from typing import Annotated, Any
 
 from pydantic import Field, TypeAdapter
 from pydantic_core import core_schema
 
-from qibolab.components import Config
+from qibolab.components import Config, ChannelConfig
 from qibolab.execution_parameters import ConfigUpdate, ExecutionParameters
 from qibolab.native import SingleQubitNatives, TwoQubitNatives
 from qibolab.qubits import QubitId, QubitPairId
@@ -108,5 +108,8 @@ class Parameters(Model):
     """Serializable parameters."""
 
     settings: Settings = Field(default_factory=Settings)
-    configs: dict[ComponentId, Config] = Field(default_factory=dict)
+    configs: dict[
+        ComponentId,
+        Annotated[ChannelConfig, Field(discriminator="kind")],
+    ] = Field(default_factory=dict)
     native_gates: NativeGates = Field(default_factory=NativeGates)

--- a/src/qibolab/parameters.py
+++ b/src/qibolab/parameters.py
@@ -148,7 +148,9 @@ class ConfigKinds:
         configuration kinds as the appropriate Python objects.
         """
         return TypeAdapter(
-            Annotated[Union[*ConfigKinds._registered], Field(discriminator="kind")]
+            Annotated[
+                Union[tuple(ConfigKinds._registered)], Field(discriminator="kind")
+            ]
         )
 
 

--- a/src/qibolab/parameters.py
+++ b/src/qibolab/parameters.py
@@ -124,20 +124,31 @@ class ConfigKinds:
 
     @classmethod
     def extend(cls, kinds: Iterable[Type[Config]]):
+        """Extend the known configuration kinds.
+
+        Nested unions are supported (i.e. :class:`Union` as elements of ``kinds``).
+        """
         cls._registered.extend(kinds)
 
     @classmethod
     def reset(cls):
+        """Reset known configuration kinds to built-ins."""
         cls._registered = _BUILTIN_CONFIGS
 
     @classmethod
     def registered(cls) -> list[Type[Config]]:
+        """Retrieve registered configuration kinds."""
         return cls._registered.copy()
 
     @classmethod
-    def adapted(cls):
+    def adapted(cls) -> TypeAdapter:
+        """Construct tailored pydantic type adapter.
+
+        The adapter will be able to directly load all the registered
+        configuration kinds as the appropriate Python objects.
+        """
         return TypeAdapter(
-            Annotated[Union[*ConfigKinds.registered()], Field(discriminator="kind")]
+            Annotated[Union[*ConfigKinds._registered], Field(discriminator="kind")]
         )
 
 

--- a/src/qibolab/parameters.py
+++ b/src/qibolab/parameters.py
@@ -5,16 +5,17 @@ example.
 """
 
 from collections.abc import Callable
-from typing import Annotated, Any
+from typing import Annotated, Any, Union
 
 from pydantic import Field, TypeAdapter
 from pydantic_core import core_schema
 
-from qibolab.components import Config, ChannelConfig
+from qibolab.components import ChannelConfig, Config
 from qibolab.execution_parameters import ConfigUpdate, ExecutionParameters
+from qibolab.identifier import QubitId, QubitPairId
 from qibolab.native import SingleQubitNatives, TwoQubitNatives
-from qibolab.qubits import QubitId, QubitPairId
 from qibolab.serialize import Model, replace
+from qibolab.unrolling import Bounds
 
 
 def update_configs(configs: dict[str, Config], updates: list[ConfigUpdate]):
@@ -110,6 +111,6 @@ class Parameters(Model):
     settings: Settings = Field(default_factory=Settings)
     configs: dict[
         ComponentId,
-        Annotated[ChannelConfig, Field(discriminator="kind")],
+        Annotated[Union[ChannelConfig, Bounds], Field(discriminator="kind")],
     ] = Field(default_factory=dict)
     native_gates: NativeGates = Field(default_factory=NativeGates)

--- a/src/qibolab/parameters.py
+++ b/src/qibolab/parameters.py
@@ -6,7 +6,7 @@ example.
 
 from collections.abc import Callable, Iterable
 from types import UnionType
-from typing import Annotated, Any, Type, Union
+from typing import Annotated, Any, Union
 
 from pydantic import BeforeValidator, Field, PlainSerializer, TypeAdapter
 from pydantic_core import core_schema
@@ -125,7 +125,7 @@ class ConfigKinds:
     _registered: list[_ChannelConfigT] = list(_BUILTIN_CONFIGS)
 
     @classmethod
-    def extend(cls, kinds: Iterable[Type[Config]]):
+    def extend(cls, kinds: Iterable[type[Config]]):
         """Extend the known configuration kinds.
 
         Nested unions are supported (i.e. :class:`Union` as elements of ``kinds``).

--- a/src/qibolab/platform/platform.py
+++ b/src/qibolab/platform/platform.py
@@ -12,10 +12,10 @@ from qibo.config import log, raise_error
 
 from qibolab.components import Config
 from qibolab.execution_parameters import ExecutionParameters
-from qibolab.identifier import ChannelId
+from qibolab.identifier import ChannelId, QubitId, QubitPairId
 from qibolab.instruments.abstract import Controller, Instrument, InstrumentId
 from qibolab.parameters import NativeGates, Parameters, Settings, update_configs
-from qibolab.qubits import Qubit, QubitId, QubitPairId
+from qibolab.qubits import Qubit
 from qibolab.sequence import PulseSequence
 from qibolab.sweeper import ParallelSweepers
 from qibolab.unrolling import Bounds, batch

--- a/src/qibolab/platform/platform.py
+++ b/src/qibolab/platform/platform.py
@@ -260,7 +260,8 @@ class Platform:
 
         results = defaultdict(list)
         # pylint: disable=unsubscriptable-object
-        bounds = Bounds.from_config(self.parameters.configs[self._controller.bounds])
+        bounds = self.parameters.configs[self._controller.bounds]
+        assert isinstance(bounds, Bounds)
         for b in batch(sequences, bounds):
             result = self._execute(b, options, configs, sweepers)
             for serial, data in result.items():

--- a/src/qibolab/platform/platform.py
+++ b/src/qibolab/platform/platform.py
@@ -1,6 +1,5 @@
 """A platform for executing quantum algorithms."""
 
-import json
 from collections import defaultdict
 from collections.abc import Iterable
 from dataclasses import dataclass, field
@@ -288,9 +287,7 @@ class Platform:
 
         return cls(
             name=name,
-            parameters=Parameters.model_validate(
-                json.loads((path / PARAMETERS).read_text())
-            ),
+            parameters=Parameters.model_validate_json((path / PARAMETERS).read_text()),
             instruments=instruments,
             qubits=qubits,
             couplers=couplers,
@@ -298,9 +295,7 @@ class Platform:
 
     def dump(self, path: Path):
         """Dump platform."""
-        (path / PARAMETERS).write_text(
-            json.dumps(self.parameters.model_dump(), sort_keys=False, indent=4)
-        )
+        (path / PARAMETERS).write_text(self.parameters.model_dump_json(indent=4))
 
     def get_qubit(self, qubit: QubitId) -> Qubit:
         """Return the name of the physical qubit corresponding to a logical

--- a/src/qibolab/qubits.py
+++ b/src/qibolab/qubits.py
@@ -1,7 +1,7 @@
 from collections.abc import Iterable
-from typing import Annotated, Optional
+from typing import Optional
 
-from pydantic import BeforeValidator, ConfigDict, PlainSerializer
+from pydantic import ConfigDict
 
 from .components import AcquireChannel, DcChannel, IqChannel
 from .components.channels import Channel
@@ -58,11 +58,3 @@ class Qubit(Model):
                 _if = native.frequency - _lo
                 freqs[name] = _lo, _if
         return freqs
-
-
-QubitPairId = Annotated[
-    tuple[QubitId, QubitId],
-    BeforeValidator(lambda p: tuple(p.split("-")) if isinstance(p, str) else p),
-    PlainSerializer(lambda p: f"{p[0]}-{p[1]}"),
-]
-"""Type for holding ``QubitPair``s in the ``platform.pairs`` dictionary."""

--- a/src/qibolab/sequence.py
+++ b/src/qibolab/sequence.py
@@ -17,6 +17,8 @@ __all__ = ["PulseSequence"]
 
 _Element = tuple[ChannelId, PulseLike]
 
+_adapted_sequence = TypeAdapter(list[_Element])
+
 
 def _synchronize(sequence: "PulseSequence", channels: Iterable[ChannelId]) -> None:
     """Helper for ``concatenate`` and ``align_to_delays``.
@@ -60,7 +62,7 @@ class PulseSequence(UserList[_Element]):
 
     @staticmethod
     def _serialize(value):
-        return TypeAdapter(list[_Element]).dump_python(list(value))
+        return _adapted_sequence.dump_python(list(value))
 
     @classmethod
     def load(cls, value: list[tuple[str, PulseLike]]):

--- a/src/qibolab/serialize.py
+++ b/src/qibolab/serialize.py
@@ -58,7 +58,7 @@ def eq(obj1: BaseModel, obj2: BaseModel) -> bool:
 class Model(BaseModel):
     """Global qibolab model, holding common configurations."""
 
-    model_config = ConfigDict(arbitrary_types_allowed=True, extra="allow", frozen=True)
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid", frozen=True)
 
 
 M = TypeVar("M", bound=BaseModel)

--- a/src/qibolab/sweeper.py
+++ b/src/qibolab/sweeper.py
@@ -1,7 +1,5 @@
-import operator
 from dataclasses import dataclass
 from enum import Enum, auto
-from functools import partial
 from typing import Optional
 
 import numpy.typing as npt
@@ -30,14 +28,6 @@ RELATIVE_PHASE = Parameter.relative_phase
 ATTENUATION = Parameter.attenuation
 GAIN = Parameter.gain
 BIAS = Parameter.bias
-
-
-class SweeperType(Enum):
-    """Type of the Sweeper."""
-
-    ABSOLUTE = partial(lambda x, y=None: x)
-    FACTOR = operator.mul
-    OFFSET = operator.add
 
 
 ChannelParameter = {
@@ -90,7 +80,6 @@ class Sweeper:
     values: npt.NDArray
     pulses: Optional[list] = None
     channels: Optional[list] = None
-    type: Optional[SweeperType] = SweeperType.ABSOLUTE
 
     def __post_init__(self):
         if self.pulses is not None and self.channels is not None:
@@ -109,10 +98,6 @@ class Sweeper:
             raise ValueError(
                 "Cannot create a sweeper without specifying pulses or channels."
             )
-
-    def get_values(self, base_value):
-        """Convert sweeper values depending on the sweeper type."""
-        return self.type.value(self.values, base_value)
 
 
 ParallelSweepers = list[Sweeper]

--- a/src/qibolab/unrolling.py
+++ b/src/qibolab/unrolling.py
@@ -5,10 +5,11 @@ May be reused by different instruments.
 
 from collections import defaultdict
 from functools import total_ordering
-from typing import Annotated
+from typing import Annotated, Iterable, Literal
 
-from qibolab.components.configs import BoundsConfig
-from qibolab.serialize import Model
+from pydantic.fields import FieldInfo
+
+from qibolab.components.configs import Config
 
 from .pulses import Delay, Pulse
 from .pulses.envelope import Rectangular
@@ -40,8 +41,10 @@ def _instructions(sequence: PulseSequence):
 
 
 @total_ordering
-class Bounds(Model):
+class Bounds(Config):
     """Instument memory limitations proxies."""
+
+    kind: Literal["bounds"] = "bounds"
 
     waveforms: Annotated[int, {"count": _waveform}]
     """Waveforms estimated size."""
@@ -49,12 +52,6 @@ class Bounds(Model):
     """Number of readouts."""
     instructions: Annotated[int, {"count": _instructions}]
     """Instructions estimated size."""
-
-    @classmethod
-    def from_config(cls, config: BoundsConfig):
-        d = config.model_dump()
-        del d["kind"]
-        return cls(**d)
 
     @classmethod
     def update(cls, sequence: PulseSequence):

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -37,9 +37,9 @@ class DummyConfig1(Config):
 
 
 class TestConfigKinds:
+    # TODO: add @staticmethod and drop unused `self`, once py3.9 will be abandoned
     @pytest.fixture(autouse=True)
-    @staticmethod
-    def clean_kinds():
+    def clean_kinds(self):
         ConfigKinds.reset()
 
     def test_manipulation(self):

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -1,0 +1,23 @@
+import pytest
+
+from qibolab.native import FixedSequenceFactory, TwoQubitNatives
+from qibolab.parameters import TwoQubitContainer
+
+
+def test_two_qubit_container():
+    """The container guarantees access to symmetric interactions.
+
+    Swapped indexing is working (only with getitem, not other dict
+    methods) if all the registered natives are symmetric.
+    """
+    symmetric = TwoQubitContainer({(0, 1): TwoQubitNatives(CZ=FixedSequenceFactory())})
+    assert symmetric[1, 0].CZ is not None
+
+    asymmetric = TwoQubitContainer(
+        {(0, 1): TwoQubitNatives(CNOT=FixedSequenceFactory())}
+    )
+    with pytest.raises(KeyError):
+        asymmetric[(1, 0)]
+
+    empty = TwoQubitContainer({(0, 1): TwoQubitNatives()})
+    assert empty[(1, 0)] is not None

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 import pytest
 
 from qibolab.components.configs import Config
@@ -25,11 +27,13 @@ def test_two_qubit_container():
 
 
 class DummyConfig(Config):
+    kind: Literal["dummy"] = "dummy"
     ciao: str
 
 
 class DummyConfig1(Config):
-    come: str
+    kind: Literal["dummy1"] = "dummy1"
+    come: int
 
 
 class TestConfigKinds:
@@ -48,3 +52,19 @@ class TestConfigKinds:
         ConfigKinds.extend([DummyConfig, DummyConfig1])
         assert DummyConfig in ConfigKinds.registered()
         assert DummyConfig1 in ConfigKinds.registered()
+
+    def test_adapted(self):
+        ConfigKinds.extend([DummyConfig, DummyConfig1])
+        adapted = ConfigKinds.adapted()
+
+        dummy = DummyConfig(ciao="come")
+        dump = adapted.dump_python(dummy)
+        assert dump["ciao"] == "come"
+        reloaded = adapted.validate_python(dump)
+        assert reloaded == dummy
+
+        dummy1 = DummyConfig1(come=42)
+        dump1 = adapted.dump_python(dummy1)
+        assert dump1["come"] == 42
+        reloaded1 = adapted.validate_python(dump1)
+        assert reloaded1 == dummy1

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -4,7 +4,7 @@ import pytest
 
 from qibolab.components.configs import Config
 from qibolab.native import FixedSequenceFactory, TwoQubitNatives
-from qibolab.parameters import ConfigKinds, TwoQubitContainer
+from qibolab.parameters import ConfigKinds, Parameters, TwoQubitContainer
 
 
 def test_two_qubit_container():
@@ -68,3 +68,14 @@ class TestConfigKinds:
         assert dump1["come"] == 42
         reloaded1 = adapted.validate_python(dump1)
         assert reloaded1 == dummy1
+
+    def test_within_parameters(self):
+        ConfigKinds.extend([DummyConfig, DummyConfig1])
+        pars = Parameters(configs={"come": DummyConfig1(come=42)})
+
+        dump = pars.model_dump()
+        assert dump["configs"]["come"]["come"] == 42
+        assert "dummy1" in pars.model_dump_json()
+
+        reloaded = Parameters.model_validate(dump)
+        assert reloaded == pars

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -1,7 +1,8 @@
 import pytest
 
+from qibolab.components.configs import Config
 from qibolab.native import FixedSequenceFactory, TwoQubitNatives
-from qibolab.parameters import TwoQubitContainer
+from qibolab.parameters import ConfigKinds, TwoQubitContainer
 
 
 def test_two_qubit_container():
@@ -21,3 +22,29 @@ def test_two_qubit_container():
 
     empty = TwoQubitContainer({(0, 1): TwoQubitNatives()})
     assert empty[(1, 0)] is not None
+
+
+class DummyConfig(Config):
+    ciao: str
+
+
+class DummyConfig1(Config):
+    come: str
+
+
+class TestConfigKinds:
+    @pytest.fixture(autouse=True)
+    @staticmethod
+    def clean_kinds():
+        ConfigKinds.reset()
+
+    def test_manipulation(self):
+        ConfigKinds.extend([DummyConfig])
+        assert DummyConfig in ConfigKinds.registered()
+
+        ConfigKinds.reset()
+        assert DummyConfig not in ConfigKinds.registered()
+
+        ConfigKinds.extend([DummyConfig, DummyConfig1])
+        assert DummyConfig in ConfigKinds.registered()
+        assert DummyConfig1 in ConfigKinds.registered()


### PR DESCRIPTION
Closes #990 

- [x] restore `extra` to `"forbid"`
    https://github.com/qiboteam/qibolab/blob/b0ba6e47afbea8dfe0f181001d4518d015f1c708/src/qibolab/serialize.py#L61
- ~~allow original QM objects, partially reverting https://github.com/qiboteam/qibolab/pull/989/files~~
  - postponed to #1001 
- [x] test additions