### PR TITLE
Add baking in QM driver

### DIFF
--- a/src/qibolab/instruments/qm/config/config.py
+++ b/src/qibolab/instruments/qm/config/config.py
@@ -109,9 +109,11 @@ class QmConfig:
             else:
                 qmpulse = QmAcquisition.from_pulse(pulse, element)
         waveforms = waveforms_from_pulse(pulse)
-        modes = ["I"] if dc else ["I", "Q"]
-        for mode in modes:
-            self.waveforms[getattr(qmpulse.waveforms, mode)] = waveforms[mode]
+        if dc:
+            self.waveforms[qmpulse.waveforms["single"]] = waveforms["I"]
+        else:
+            for mode in ["I", "Q"]:
+                self.waveforms[getattr(qmpulse.waveforms, mode)] = waveforms[mode]
         return qmpulse
 
     def register_iq_pulse(self, element: str, pulse: Pulse):

--- a/src/qibolab/instruments/qm/config/pulses.py
+++ b/src/qibolab/instruments/qm/config/pulses.py
@@ -71,9 +71,10 @@ Waveform = Union[ConstantWaveform, ArbitraryWaveform]
 
 def waveforms_from_pulse(pulse: Pulse) -> Waveform:
     """Register QM waveforms for a given pulse."""
+    needs_baking = pulse.duration < 16 or pulse.duration % 4 != 0
     wvtype = (
         ConstantWaveform
-        if isinstance(pulse.envelope, Rectangular)
+        if isinstance(pulse.envelope, Rectangular) and not needs_baking
         else ArbitraryWaveform
     )
     return wvtype.from_pulse(pulse)

--- a/src/qibolab/instruments/qm/controller.py
+++ b/src/qibolab/instruments/qm/controller.py
@@ -297,11 +297,7 @@ class QmController(Controller):
             acquisitions (dict): Map from measurement instructions to acquisition objects.
         """
         for channel_id, pulse in sequence:
-            if (
-                hasattr(pulse, "duration")
-                and isinstance(pulse.duration, float)
-                and not pulse.duration.is_integer()
-            ):
+            if hasattr(pulse, "duration") and not pulse.duration.is_integer():
                 raise ValueError(
                     f"Quantum Machines cannot play pulse with duration {pulse.duration}. "
                     "Only integer duration in ns is supported."

--- a/src/qibolab/instruments/qm/controller.py
+++ b/src/qibolab/instruments/qm/controller.py
@@ -297,7 +297,11 @@ class QmController(Controller):
             acquisitions (dict): Map from measurement instructions to acquisition objects.
         """
         for channel_id, pulse in sequence:
-            if hasattr(pulse, "duration") and not pulse.duration.is_integer():
+            if (
+                hasattr(pulse, "duration")
+                and isinstance(pulse.duration, float)
+                and not pulse.duration.is_integer()
+            ):
                 raise ValueError(
                     f"Quantum Machines cannot play pulse with duration {pulse.duration}. "
                     "Only integer duration in ns is supported."

--- a/src/qibolab/instruments/qm/controller.py
+++ b/src/qibolab/instruments/qm/controller.py
@@ -297,6 +297,11 @@ class QmController(Controller):
             acquisitions (dict): Map from measurement instructions to acquisition objects.
         """
         for channel_id, pulse in sequence:
+            if hasattr(pulse, "duration") and not pulse.duration.is_integer():
+                raise ValueError(
+                    f"Quantum Machines cannot play pulse with duration {pulse.duration}. "
+                    "Only integer duration in ns is supported."
+                )
             if isinstance(pulse, Pulse):
                 channel = self.channels[str(channel_id)].logical_channel
                 self.register_pulse(channel, pulse)

--- a/src/qibolab/instruments/qm/controller.py
+++ b/src/qibolab/instruments/qm/controller.py
@@ -299,14 +299,6 @@ class QmController(Controller):
     def register_pulse(self, channel: Channel, pulse: Pulse) -> str:
         """Add pulse in the QM ``config`` and return corresponding
         operation."""
-        # if (
-        #    pulse.duration % 4 != 0
-        #    or pulse.duration < 16
-        #    or pulse.id in pulses_to_bake
-        # ):
-        #    qmpulse = BakedPulse(pulse, element)
-        #    qmpulse.bake(self.config, durations=[pulse.duration])
-        # else:
         name = str(channel.name)
         if isinstance(channel, DcChannel):
             return self.config.register_dc_pulse(name, pulse)

--- a/src/qibolab/instruments/qm/controller.py
+++ b/src/qibolab/instruments/qm/controller.py
@@ -71,23 +71,6 @@ def declare_octaves(octaves, host, calibration_path=None):
     return config
 
 
-def find_baking_pulses(sweepers):
-    """Find pulses that require baking because we are sweeping their duration.
-
-    Args:
-        sweepers (list): List of :class:`qibolab.sweeper.Sweeper` objects.
-    """
-    to_bake = set()
-    for sweeper in sweepers:
-        values = sweeper.values
-        step = values[1] - values[0] if len(values) > 0 else values[0]
-        if sweeper.parameter is Parameter.duration and step % 4 != 0:
-            for pulse in sweeper.pulses:
-                to_bake.add(pulse.id)
-
-    return to_bake
-
-
 def fetch_results(result, acquisitions):
     """Fetches results from an executed experiment.
 

--- a/src/qibolab/instruments/qm/program/arguments.py
+++ b/src/qibolab/instruments/qm/program/arguments.py
@@ -17,6 +17,7 @@ class Parameters:
     amplitude: Optional[_Variable] = None
     phase: Optional[_Variable] = None
     pulses: list[tuple[float, str]] = field(default_factory=list)
+    interpolated: bool = False
 
 
 @dataclass

--- a/src/qibolab/instruments/qm/program/instructions.py
+++ b/src/qibolab/instruments/qm/program/instructions.py
@@ -6,6 +6,7 @@ from qualang_tools.loops import from_array
 
 from qibolab.components import Config
 from qibolab.execution_parameters import AcquisitionType, ExecutionParameters
+from qibolab.identifier import ChannelType
 from qibolab.pulses import Align, Delay, Pulse, VirtualZ
 from qibolab.sweeper import ParallelSweepers
 
@@ -70,6 +71,9 @@ def play(args: ExecutionArguments):
     processed_aligns = set()
 
     for channel_id, pulse in args.sequence:
+        if channel_id.channel_type is ChannelType.ACQUISITION:
+            continue
+
         element = str(channel_id)
         op = operation(pulse)
         params = args.parameters[op]

--- a/src/qibolab/instruments/qm/program/instructions.py
+++ b/src/qibolab/instruments/qm/program/instructions.py
@@ -19,6 +19,8 @@ def _delay(pulse: Delay, element: str, parameters: Parameters):
     # TODO: How to play delays on multiple elements?
     if parameters.duration is None:
         duration = int(pulse.duration) // 4
+    elif parameters.interpolated:
+        duration = parameters.duration
     else:
         duration = parameters.duration / 4
     qua.wait(duration + 1, element)

--- a/src/qibolab/instruments/qm/program/instructions.py
+++ b/src/qibolab/instruments/qm/program/instructions.py
@@ -20,7 +20,7 @@ def _delay(pulse: Delay, element: str, parameters: Parameters):
     if parameters.duration is None:
         duration = int(pulse.duration) // 4
     else:
-        duration = parameters.duration
+        duration = parameters.duration / 4
     qua.wait(duration + 1, element)
 
 
@@ -28,7 +28,7 @@ def _play_multiple_waveforms(element: str, parameters: Parameters):
     """Sweeping pulse duration using distinctly uploaded waveforms."""
     with qua.switch_(parameters.duration, unsafe=True):
         for value, sweep_op in parameters.pulses:
-            with qua.case_(value // 4):
+            with qua.case_(value):
                 qua.play(sweep_op, element)
 
 

--- a/src/qibolab/instruments/qm/program/instructions.py
+++ b/src/qibolab/instruments/qm/program/instructions.py
@@ -19,12 +19,17 @@ from .sweepers import INT_TYPE, NORMALIZERS, SWEEPER_METHODS, normalize_phase
 def _delay(pulse: Delay, element: str, parameters: Parameters):
     # TODO: How to play delays on multiple elements?
     if parameters.duration is None:
-        duration = int(pulse.duration) // 4
+        duration = max(int(pulse.duration) // 4 + 1, 4)
+        qua.wait(duration, element)
     elif parameters.interpolated:
-        duration = parameters.duration
+        duration = parameters.duration + 1
+        qua.wait(duration, element)
     else:
         duration = parameters.duration / 4
-    qua.wait(duration + 1, element)
+        with qua.if_(duration < 4):
+            qua.wait(4, element)
+        with qua.else_():
+            qua.wait(duration, element)
 
 
 def _play_multiple_waveforms(element: str, parameters: Parameters):

--- a/src/qibolab/instruments/qm/program/sweepers.py
+++ b/src/qibolab/instruments/qm/program/sweepers.py
@@ -130,6 +130,19 @@ def _duration(
         args.parameters[operation(pulse)].duration = variable
 
 
+def _duration_interpolated(
+    pulses: list[Pulse],
+    values: npt.NDArray,
+    variable: _Variable,
+    configs: dict[str, Config],
+    args: ExecutionArguments,
+):
+    for pulse in pulses:
+        params = args.parameters[operation(pulse)]
+        params.duration = variable
+        params.interpolated = True
+
+
 def normalize_phase(values):
     """Normalize phase from [0, 2pi] to [0, 1]."""
     return values / (2 * np.pi)
@@ -163,7 +176,7 @@ SWEEPER_METHODS = {
     Parameter.frequency: _frequency,
     Parameter.amplitude: _amplitude,
     Parameter.duration: _duration,
-    Parameter.duration_interpolated: _duration,
+    Parameter.duration_interpolated: _duration_interpolated,
     Parameter.relative_phase: _relative_phase,
     Parameter.bias: _bias,
 }

--- a/src/qibolab/instruments/qm/program/sweepers.py
+++ b/src/qibolab/instruments/qm/program/sweepers.py
@@ -150,9 +150,9 @@ def normalize_phase(values):
 
 def normalize_duration(values):
     """Convert duration from ns to clock cycles (clock cycle = 4ns)."""
-    if not all(values % 4 == 0):
+    if any(values < 16) and not all(values % 4 == 0):
         raise ValueError(
-            "Cannot use interpolated duration sweeper for durations that are not multiple of 4ns. Please use normal duration sweeper."
+            "Cannot use interpolated duration sweeper for durations that are not multiple of 4ns or are less than 16ns. Please use normal duration sweeper."
         )
     return (values // 4).astype(int)
 


### PR DESCRIPTION
Essentially support playing and sweeping over durations with 1ns resolution (lifting the 4ns constraint). Also the related discussion in #979 should now be fixed. Here I am doing the "baking" (=padding with zeros) myself, instead of using the QM helpers, because this way it fits better with the rest of the driver.

Here is an example of the Rabi length with 1ns step: http://login.qrccluster.com:9000/EWxzJbXUSwmaT8_ES4pF0g==

This is ready for the most part. I just need to check how it behaves for rectangular pulses, but I need to write a script to do this.