### PR TITLE
Unrolling and parallel sweeps for QM

### DIFF
--- a/src/qibolab/instruments/qm/controller.py
+++ b/src/qibolab/instruments/qm/controller.py
@@ -18,7 +18,7 @@ from qibolab.instruments.abstract import Controller
 from qibolab.pulses.pulse import Acquisition, Align, Delay, Pulse, _Readout
 from qibolab.sequence import PulseSequence
 from qibolab.sweeper import ParallelSweepers, Parameter, Sweeper
-from qibolab.unrolling import Bounds
+from qibolab.unrolling import Bounds, unroll_sequences
 
 from .components import QmChannel
 from .config import SAMPLING_RATE, QmConfig, operation
@@ -388,9 +388,14 @@ class QmController(Controller):
         options: ExecutionParameters,
         sweepers: list[ParallelSweepers],
     ):
-        if len(sequences) > 1:
-            raise NotImplementedError
-        elif len(sequences) == 0 or len(sequences[0]) == 0:
+        if len(sequences) == 0:
+            return {}
+        elif len(sequences) == 1:
+            sequence = sequences[0]
+        else:
+            sequence, _ = unroll_sequences(sequences, options.relaxation_time)
+
+        if len(sequence) == 0:
             return {}
 
         # register DC elements so that all qubits are
@@ -399,7 +404,6 @@ class QmController(Controller):
             if isinstance(channel.logical_channel, DcChannel):
                 self.configure_channel(channel, configs)
 
-        sequence = sequences[0]
         self.configure_channels(configs, sequence.channels)
         self.register_pulses(configs, sequence)
         acquisitions = self.register_acquisitions(configs, sequence, options)

--- a/src/qibolab/instruments/qm/controller.py
+++ b/src/qibolab/instruments/qm/controller.py
@@ -415,16 +415,19 @@ class QmController(Controller):
 
         experiment = program(configs, args, options, sweepers)
 
+        if self.script_file_name is not None:
+            script_config = (
+                {"version": 1} if self.manager is None else asdict(self.config)
+            )
+            script = generate_qua_script(experiment, script_config)
+            with open(self.script_file_name, "w") as file:
+                file.write(script)
+
         if self.manager is None:
             warnings.warn(
                 "Not connected to Quantum Machines. Returning program and config."
             )
             return {"program": experiment, "config": asdict(self.config)}
-
-        if self.script_file_name is not None:
-            script = generate_qua_script(experiment, asdict(self.config))
-            with open(self.script_file_name, "w") as file:
-                file.write(script)
 
         if self.simulation_duration is not None:
             result = self.simulate_program(experiment)

--- a/src/qibolab/instruments/qm/program/instructions.py
+++ b/src/qibolab/instruments/qm/program/instructions.py
@@ -8,7 +8,7 @@ from qibolab.components import Config
 from qibolab.execution_parameters import AcquisitionType, ExecutionParameters
 from qibolab.identifier import ChannelType
 from qibolab.pulses import Align, Delay, Pulse, VirtualZ
-from qibolab.sweeper import ParallelSweepers
+from qibolab.sweeper import ParallelSweepers, Sweeper
 
 from ..config import operation
 from .acquisition import Acquisition
@@ -98,35 +98,17 @@ def play(args: ExecutionArguments):
         qua.wait(args.relaxation_time // 4)
 
 
-def _sweep_recursion(sweepers, configs, args):
-    """Unrolls a list of qibolab sweepers to the corresponding QUA for loops
-    using recursion."""
-    if len(sweepers) > 0:
-        parallel_sweepers = sweepers[0]
-        if len(parallel_sweepers) > 1:
-            raise NotImplementedError
+def _process_sweeper(sweeper: Sweeper):
+    parameter = sweeper.parameter
+    if parameter not in SWEEPER_METHODS:
+        raise NotImplementedError(f"Sweeper for {parameter} is not implemented.")
 
-        sweeper = parallel_sweepers[0]
-        parameter = sweeper.parameter
-        if parameter not in SWEEPER_METHODS:
-            raise NotImplementedError(f"Sweeper for {parameter} is not implemented.")
+    variable = declare(int) if parameter in INT_TYPE else declare(fixed)
+    values = sweeper.values
+    if parameter in NORMALIZERS:
+        values = NORMALIZERS[parameter](sweeper.values)
 
-        variable = declare(int) if parameter in INT_TYPE else declare(fixed)
-        values = sweeper.values
-        if parameter in NORMALIZERS:
-            values = NORMALIZERS[parameter](sweeper.values)
-
-        method = SWEEPER_METHODS[parameter]
-        with for_(*from_array(variable, values)):
-            if sweeper.pulses is not None:
-                method(sweeper.pulses, values, variable, configs, args)
-            else:
-                method(sweeper.channels, values, variable, configs, args)
-
-            _sweep_recursion(sweepers[1:], configs, args)
-
-    else:
-        play(args)
+    return variable, values
 
 
 def sweep(
@@ -134,11 +116,35 @@ def sweep(
     configs: dict[str, Config],
     args: ExecutionArguments,
 ):
-    """Public sweep function that is called by the driver."""
-    # for sweeper in sweepers:
-    #    if sweeper.parameter is Parameter.duration:
-    #        _update_baked_pulses(sweeper, instructions, config)
-    _sweep_recursion(sweepers, configs, args)
+    """Unrolls a list of qibolab sweepers to the corresponding QUA for loops.
+
+    Uses recursion to handle nested sweepers.
+    """
+    if len(sweepers) > 0:
+        parallel_sweepers = sweepers[0]
+
+        variables, all_values = zip(
+            *(_process_sweeper(sweeper) for sweeper in parallel_sweepers)
+        )
+        if len(parallel_sweepers) > 1:
+            loop = qua.for_each_(variables, all_values)
+        else:
+            loop = for_(*from_array(variables[0], all_values[0]))
+
+        with loop:
+            for sweeper, variable, values in zip(
+                parallel_sweepers, variables, all_values
+            ):
+                method = SWEEPER_METHODS[sweeper.parameter]
+                if sweeper.pulses is not None:
+                    method(sweeper.pulses, values, variable, configs, args)
+                else:
+                    method(sweeper.channels, values, variable, configs, args)
+
+            sweep(sweepers[1:], configs, args)
+
+    else:
+        play(args)
 
 
 def program(

--- a/src/qibolab/platform/__init__.py
+++ b/src/qibolab/platform/__init__.py
@@ -1,4 +1,4 @@
 from .load import create_platform
-from .platform import Platform, unroll_sequences
+from .platform import Platform
 
-__all__ = ["Platform", "create_platform", "unroll_sequences"]
+__all__ = ["Platform", "create_platform"]

--- a/src/qibolab/platform/platform.py
+++ b/src/qibolab/platform/platform.py
@@ -15,7 +15,6 @@ from qibolab.execution_parameters import ExecutionParameters
 from qibolab.identifier import ChannelId
 from qibolab.instruments.abstract import Controller, Instrument, InstrumentId
 from qibolab.parameters import NativeGates, Parameters, Settings, update_configs
-from qibolab.pulses import Delay
 from qibolab.qubits import Qubit, QubitId, QubitPairId
 from qibolab.sequence import PulseSequence
 from qibolab.sweeper import ParallelSweepers
@@ -36,36 +35,6 @@ T = TypeVar("T")
 def default(value: Optional[T], default: T) -> T:
     """None replacement shortcut."""
     return value if value is not None else default
-
-
-def unroll_sequences(
-    sequences: list[PulseSequence], relaxation_time: int
-) -> tuple[PulseSequence, dict[int, list[int]]]:
-    """Unrolls a list of pulse sequences to a single sequence.
-
-    The resulting sequence may contain multiple measurements.
-
-    `relaxation_time` is the time in ns to wait for the qubit to relax between playing
-    different sequences.
-
-    It returns both the unrolled pulse sequence, and the map from original readout pulse
-    serials to the unrolled readout pulse serials. Required to construct the results
-    dictionary that is returned after execution.
-    """
-    total_sequence = PulseSequence()
-    readout_map = defaultdict(list)
-    for sequence in sequences:
-        total_sequence.concatenate(sequence)
-        # TODO: Fix unrolling results
-        for _, acq in sequence.acquisitions:
-            readout_map[acq.id].append(acq.id)
-
-        length = sequence.duration + relaxation_time
-        for channel in sequence.channels:
-            delay = length - sequence.channel_duration(channel)
-            total_sequence.append((channel, Delay(duration=delay)))
-
-    return total_sequence, readout_map
 
 
 def estimate_duration(

--- a/src/qibolab/unrolling.py
+++ b/src/qibolab/unrolling.py
@@ -3,13 +3,14 @@
 May be reused by different instruments.
 """
 
+from collections import defaultdict
 from functools import total_ordering
 from typing import Annotated
 
 from qibolab.components.configs import BoundsConfig
 from qibolab.serialize import Model
 
-from .pulses import Pulse
+from .pulses import Delay, Pulse
 from .pulses.envelope import Rectangular
 from .sequence import PulseSequence
 
@@ -95,3 +96,33 @@ def batch(sequences: list[PulseSequence], bounds: Bounds):
             batch.append(sequence)
             counters += update
     yield batch
+
+
+def unroll_sequences(
+    sequences: list[PulseSequence], relaxation_time: int
+) -> tuple[PulseSequence, dict[int, list[int]]]:
+    """Unrolls a list of pulse sequences to a single sequence.
+
+    The resulting sequence may contain multiple measurements.
+
+    `relaxation_time` is the time in ns to wait for the qubit to relax between playing
+    different sequences.
+
+    It returns both the unrolled pulse sequence, and the map from original readout pulse
+    serials to the unrolled readout pulse serials. Required to construct the results
+    dictionary that is returned after execution.
+    """
+    total_sequence = PulseSequence()
+    readout_map = defaultdict(list)
+    for sequence in sequences:
+        total_sequence.concatenate(sequence)
+        # TODO: Fix unrolling results
+        for _, acq in sequence.acquisitions:
+            readout_map[acq.id].append(acq.id)
+
+        length = sequence.duration + relaxation_time
+        for channel in sequence.channels:
+            delay = length - sequence.channel_duration(channel)
+            total_sequence.append((channel, Delay(duration=delay)))
+
+    return total_sequence, readout_map

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -21,7 +21,7 @@ from qibolab.execution_parameters import ExecutionParameters
 from qibolab.instruments.qblox.controller import QbloxController
 from qibolab.native import SingleQubitNatives, TwoQubitNatives
 from qibolab.parameters import NativeGates, Parameters, update_configs
-from qibolab.platform import Platform, unroll_sequences
+from qibolab.platform import Platform
 from qibolab.platform.load import PLATFORM, PLATFORMS
 from qibolab.platform.platform import PARAMETERS
 from qibolab.pulses import Delay, Gaussian, Pulse, Rectangular
@@ -31,19 +31,6 @@ from qibolab.serialize import replace
 from .conftest import find_instrument
 
 nshots = 1024
-
-
-def test_unroll_sequences(platform: Platform):
-    qubit = next(iter(platform.qubits.values()))
-    natives = platform.natives.single_qubit[0]
-    sequence = PulseSequence()
-    sequence.concatenate(natives.RX.create_sequence())
-    sequence.append((qubit.probe.name, Delay(duration=sequence.duration)))
-    sequence.concatenate(natives.MZ.create_sequence())
-    total_sequence, readouts = unroll_sequences(10 * [sequence], relaxation_time=10000)
-    assert len(total_sequence.acquisitions) == 10
-    assert len(readouts) == 1
-    assert all(len(readouts[acq.id]) == 10 for _, acq in sequence.acquisitions)
 
 
 def test_create_platform(platform):


### PR DESCRIPTION
Implements the missing features needed to close #969.

Unrolling was tested with the single shot routine and it's working, except the fact that the result shape remains a bit weird, similarly to 0.1 (see [f4b776978180f3ef71a093d4c3c0f6ce612da358](https://github.com/qiboteam/qibocal/pull/809/commits/f4b776978180f3ef71a093d4c3c0f6ce612da358)). I am not sure if #964 is aiming to improve on this.

Parallel sweeps are implemented but not tested, as they are not used in any existing routine. I only confirmed that they don't break non-parallel sweeps. We need to write a custom script to test them, but I will probably do so after dropping sweeper types (which will force us to use them anyway).