### PR TITLE
Convert all QM sweepers to absolute

### DIFF
--- a/src/qibolab/instruments/qm/controller.py
+++ b/src/qibolab/instruments/qm/controller.py
@@ -340,8 +340,8 @@ class QmController(Controller):
     ):
         """Register pulse with different amplitude.
 
-        Needed when sweeping amplitude and the original amplitude is not
-        sufficient to reach all the sweeper values.
+        Needed when sweeping amplitude because the original amplitude
+        may not sufficient to reach all the sweeper values.
         """
         new_op = None
         amplitude = sweeper_amplitude(sweeper.values)

--- a/src/qibolab/instruments/qm/program/arguments.py
+++ b/src/qibolab/instruments/qm/program/arguments.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from qm.qua._dsl import _Variable  # for type declaration only
 
+from qibolab.pulses import Pulse
 from qibolab.sequence import PulseSequence
 
 from .acquisition import Acquisitions
@@ -14,12 +15,13 @@ class Parameters:
     """Container of swept QUA variables."""
 
     amplitude: Optional[_Variable] = None
-    amplitude_pulse: Optional[str] = None
+    amplitude_pulse: Optional[Pulse] = None
+    amplitude_op: Optional[str] = None
 
     phase: Optional[_Variable] = None
 
     duration: Optional[_Variable] = None
-    pulses: list[tuple[float, str]] = field(default_factory=list)
+    duration_ops: list[tuple[float, str]] = field(default_factory=list)
     interpolated: bool = False
 
 

--- a/src/qibolab/instruments/qm/program/arguments.py
+++ b/src/qibolab/instruments/qm/program/arguments.py
@@ -13,9 +13,12 @@ from .acquisition import Acquisitions
 class Parameters:
     """Container of swept QUA variables."""
 
-    duration: Optional[_Variable] = None
     amplitude: Optional[_Variable] = None
+    amplitude_pulse: Optional[str] = None
+
     phase: Optional[_Variable] = None
+
+    duration: Optional[_Variable] = None
     pulses: list[tuple[float, str]] = field(default_factory=list)
     interpolated: bool = False
 

--- a/src/qibolab/instruments/qm/program/instructions.py
+++ b/src/qibolab/instruments/qm/program/instructions.py
@@ -49,7 +49,7 @@ def _play_single_waveform(
     acquisition: Optional[Acquisition] = None,
 ):
     if parameters.amplitude is not None:
-        op = op * parameters.amplitude
+        op = parameters.amplitude_pulse * parameters.amplitude
     if acquisition is not None:
         acquisition.measure(op)
     else:

--- a/src/qibolab/instruments/qm/program/instructions.py
+++ b/src/qibolab/instruments/qm/program/instructions.py
@@ -35,7 +35,7 @@ def _delay(pulse: Delay, element: str, parameters: Parameters):
 def _play_multiple_waveforms(element: str, parameters: Parameters):
     """Sweeping pulse duration using distinctly uploaded waveforms."""
     with qua.switch_(parameters.duration, unsafe=True):
-        for value, sweep_op in parameters.pulses:
+        for value, sweep_op in parameters.duration_ops:
             if parameters.amplitude is not None:
                 sweep_op = sweep_op * parameters.amplitude
             with qua.case_(value):
@@ -49,7 +49,7 @@ def _play_single_waveform(
     acquisition: Optional[Acquisition] = None,
 ):
     if parameters.amplitude is not None:
-        op = parameters.amplitude_pulse * parameters.amplitude
+        op = parameters.amplitude_op * parameters.amplitude
     if acquisition is not None:
         acquisition.measure(op)
     else:
@@ -65,7 +65,7 @@ def _play(
     if parameters.phase is not None:
         qua.frame_rotation_2pi(parameters.phase, element)
 
-    if len(parameters.pulses) > 0:
+    if len(parameters.duration_ops) > 0:
         _play_multiple_waveforms(element, parameters)
     else:
         _play_single_waveform(op, element, parameters, acquisition)

--- a/src/qibolab/instruments/qm/program/instructions.py
+++ b/src/qibolab/instruments/qm/program/instructions.py
@@ -148,9 +148,12 @@ def sweep(
             ):
                 method = SWEEPER_METHODS[sweeper.parameter]
                 if sweeper.pulses is not None:
-                    method(sweeper.pulses, values, variable, configs, args)
+                    for pulse in sweeper.pulses:
+                        params = args.parameters[operation(pulse)]
+                        method(variable, params)
                 else:
-                    method(sweeper.channels, values, variable, configs, args)
+                    for channel in sweeper.channels:
+                        method(variable, channel, configs)
 
             sweep(sweepers[1:], configs, args)
 

--- a/src/qibolab/instruments/qm/program/sweepers.py
+++ b/src/qibolab/instruments/qm/program/sweepers.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import numpy as np
 import numpy.typing as npt
 from qibo.config import raise_error
@@ -30,18 +28,6 @@ def maximum_sweep_value(values: npt.NDArray, value0: npt.NDArray) -> float:
         value0 (float, int): Center value of the sweep.
     """
     return max(abs(min(values) + value0), abs(max(values) + value0))
-
-
-def check_max_offset(offset: Optional[float], max_offset: float = MAX_OFFSET):
-    """Checks if a given offset value exceeds the maximum supported offset.
-
-    This is to avoid sending high currents that could damage lab
-    equipment such as amplifiers.
-    """
-    if max_offset is not None and abs(offset) > max_offset:
-        raise_error(
-            ValueError, f"{offset} exceeds the maximum allowed offset {max_offset}."
-        )
 
 
 def _frequency(
@@ -104,7 +90,6 @@ def _offset(
     for channel in channels:
         name = str(channel.name)
         max_value = maximum_sweep_value(values, 0)
-        check_max_offset(max_value, MAX_OFFSET)
         with qua.if_(variable >= MAX_OFFSET):
             qua.set_dc_offset(name, "single", MAX_OFFSET)
         with qua.elif_(variable <= -MAX_OFFSET):

--- a/src/qibolab/sweeper.py
+++ b/src/qibolab/sweeper.py
@@ -7,7 +7,7 @@ import numpy.typing as npt
 from pydantic import model_validator
 
 from .identifier import ChannelId
-from .pulses import Pulse
+from .pulses import PulseLike
 from .serialize import Model
 
 _PULSE = "pulse"
@@ -80,7 +80,7 @@ class Sweeper(Model):
     parameter: Parameter
     values: Optional[npt.NDArray] = None
     range: Optional[tuple[float, float, float]] = None
-    pulses: Optional[list[Pulse]] = None
+    pulses: Optional[list[PulseLike]] = None
     channels: Optional[list[ChannelId]] = None
 
     @model_validator(mode="after")
@@ -99,6 +99,9 @@ class Sweeper(Model):
 
         if self.range is not None:
             object.__setattr__(self, "values", np.arange(*self.range))
+
+        if self.parameter is Parameter.amplitude and max(abs(self.values)) > 1:
+            raise ValueError("Amplitude sweeper cannot have values larger than 1.")
 
         return self
 

--- a/src/qibolab/sweeper.py
+++ b/src/qibolab/sweeper.py
@@ -101,7 +101,7 @@ class Sweeper(Model):
             object.__setattr__(self, "values", np.arange(*self.range))
 
         if self.parameter is Parameter.amplitude and max(abs(self.values)) > 1:
-            raise ValueError("Amplitude sweeper cannot have values larger than 1.")
+            raise ValueError("Amplitude sweeper cannot have absolute values larger than 1.")
 
         return self
 

--- a/src/qibolab/sweeper.py
+++ b/src/qibolab/sweeper.py
@@ -101,7 +101,9 @@ class Sweeper(Model):
             object.__setattr__(self, "values", np.arange(*self.range))
 
         if self.parameter is Parameter.amplitude and max(abs(self.values)) > 1:
-            raise ValueError("Amplitude sweeper cannot have absolute values larger than 1.")
+            raise ValueError(
+                "Amplitude sweeper cannot have absolute values larger than 1."
+            )
 
         return self
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -154,7 +154,7 @@ def execute(connected_platform: Platform) -> Execution:
             sequence.concatenate(qd_seq)
             sequence.concatenate(probe_seq)
             if sweepers is None:
-                freq_values = np.arange(-4e6, 4e6, 1e6)
+                amp_values = np.arange(0, 0.8, 0.1)
                 sweeper1 = Sweeper(
                     parameter=Parameter.offset,
                     range=(0.01, 0.06, 0.01),
@@ -162,7 +162,7 @@ def execute(connected_platform: Platform) -> Execution:
                 )
                 sweeper2 = Sweeper(
                     parameter=Parameter.amplitude,
-                    values=freq_values,
+                    values=amp_values,
                     pulses=[probe_pulse],
                 )
                 sweepers = [[sweeper1], [sweeper2]]

--- a/tests/test_sweeper.py
+++ b/tests/test_sweeper.py
@@ -68,3 +68,11 @@ def test_sweeper_errors():
             parameter=Parameter.frequency,
             channels=[channel],
         )
+    with pytest.raises(
+        ValueError, match="Amplitude sweeper cannot have values larger than 1."
+    ):
+        Sweeper(
+            parameter=Parameter.amplitude,
+            range=(0, 2, 0.2),
+            pulses=[pulse],
+        )

--- a/tests/test_sweeper.py
+++ b/tests/test_sweeper.py
@@ -68,9 +68,7 @@ def test_sweeper_errors():
             parameter=Parameter.frequency,
             channels=[channel],
         )
-    with pytest.raises(
-        ValueError, match="Amplitude sweeper cannot have values larger than 1."
-    ):
+    with pytest.raises(ValueError, match="Amplitude"):
         Sweeper(
             parameter=Parameter.amplitude,
             range=(0, 2, 0.2),


### PR DESCRIPTION
Following the discussion in #540, this PR makes all QM sweepers absolute. Since `SweeperType` is already dropped in 0.2, this will also close the issue. 

I tested on hardware with the Rabi routine using an absolute amplitude sweeper: http://login.qrccluster.com:9000/XftyLYqDSsG8xBCkcz6ibg==
In this case, the same amplitude range is used on all qubits. It is possible to use a different range per qubit using parallel sweepers (#1008), but I have not tested this.

@alecandido @andrea-pasquale note that although all amplitude sweepers are now absolute (no more factors and multiplications), flux pulses are always played on top of the DC offset (sweetspot). This is true even when not sweeping. Therefore, amplitude sweeps on flux pulses will also be played on top of the DC offset. I could change this behavior to zero the offset when we are sweeping flux pulses, however I don't think we want that, since in most cases we are operating all qubits at their sweetspot. Moreover, we already provide an interface to temporarily change the DC offset for one execution, by passing an alternate `DcConfig` when calling `platform.execute`.

EDIT: In contrast, `Parameter.offset` sweeps are really absolute, not around the sweetspot like in 0.1, because there we are sweeping the offset value directly (not a pulse amplitude on top).