### PR TITLE
fix: refactor QM frequency sweeper for resonator spectroscopy to work

### DIFF
--- a/src/qibolab/instruments/qm/program/arguments.py
+++ b/src/qibolab/instruments/qm/program/arguments.py
@@ -13,7 +13,7 @@ from .acquisition import Acquisitions
 
 @dataclass
 class Parameters:
-    """Container of swept QUA variables."""
+    """Container of QUA variables and other parameters needed for sweeping."""
 
     amplitude: Optional[_Variable] = None
     amplitude_pulse: Optional[Pulse] = None
@@ -25,6 +25,7 @@ class Parameters:
     duration_ops: list[tuple[float, str]] = field(default_factory=list)
     interpolated: bool = False
 
+    element: Optional[str] = None
     lo_frequency: Optional[int] = None
 
 

--- a/src/qibolab/instruments/qm/program/sweepers.py
+++ b/src/qibolab/instruments/qm/program/sweepers.py
@@ -32,13 +32,13 @@ def find_lo_frequencies(
     It also checks if frequency sweep is within the supported instrument
     bandwidth [-400, 400] MHz.
     """
-    los = {channel.lo for _, channel in channels}
-    if len(los) > 1:
+    lo_freqs = {configs[channel.lo].frequency for _, channel in channels}
+    if len(lo_freqs) > 1:
         raise ValueError(
             "Cannot sweep frequency of channels using different LO using the same `Sweeper` object. Please use parallel sweepers instead."
         )
+    lo_frequency = lo_freqs.pop()
     for id, channel in channels:
-        lo_frequency = configs[channel.lo].frequency
         max_freq = max(abs(values - lo_frequency))
         if max_freq > FREQUENCY_BANDWIDTH:
             raise ValueError(

--- a/src/qibolab/instruments/qm/program/sweepers.py
+++ b/src/qibolab/instruments/qm/program/sweepers.py
@@ -79,9 +79,10 @@ def normalize_duration(values: npt.NDArray) -> npt.NDArray:
 
 
 def normalize_frequency(values: npt.NDArray, lo_frequency: int) -> npt.NDArray:
-    """Convert frequencies to integer and substract LO frequency.
+    """Convert frequencies to integer and subtract LO frequency.
 
-    Because QUA does not support large numbers of ``fixed`` type.
+    QUA gives an error if the raw frequency values are uploaded to sweep
+    over.
     """
     return (values - lo_frequency).astype(int)
 


### PR DESCRIPTION
I tested the resonator spectroscopy on hardware and unfortunately I had to refactor again the QM sweeper to make it work. There were basically two issues:
1. The frequency sweeper is defined on probe channels, since these are the ones containing the `"frequency"` attribute in our parameters.json. However, due to the usual QM issue we need to translate this to a sweeper on the acquisition channel when writing the QUA program.
2. QUA seems to not like large numbers, even when defined as integers (?). It was giving me a weird error:
```py
2024-09-03 09:46:55,152 - qm - INFO     - Sending program to QOP for compilation
2024-09-03 09:46:55,284 - qm - ERROR    - Internal error: java.lang.IllegalStateException: given number cannot be presented by QUA int representation
at io.qualang.qua.ProgramConverter.toQuaInt(ProgramConverter.kt:30)
at io.qualang.qua.ProgramConverter.convert(ProgramConverter.kt:65)
at io.qualang.qua.ProgramConverter.convert(ProgramConverter.kt:10)
at qm.opx.gateway.CompileKt.rawCompile(compile.kt:62)
at qm.opx.gateway.CompileKt.compile(compile.kt:82)
at qm.opx.gateway.GatewayService$addToQueue$2$1.invoke(GatewayService.kt:158)
at qm.opx.gateway.GatewayService$addToQueue$2$1.invoke(GatewayService.kt:157)
at qm.opx.gateway.ThreadWithBlockingTimeoutKt.run$lambda$0(ThreadWithBlockingTimeout.kt:27)
at java.base/java.lang.Thread.run(Unknown Source)
```
The solution I found was to subtract the LO frequency before uploading the sweeper values to the instrument. This creates a limitation: we cannot sweep frequency of channels with different LO frequencies on the same sweeper. However, this should not be a big issue in practice, since parallel sweepers can still be used.