### PR TITLE
Drop `is_connected` from instruments

### DIFF
--- a/src/qibolab/backends.py
+++ b/src/qibolab/backends.py
@@ -100,8 +100,7 @@ class QibolabBackend(NumpyBackend):
 
         sequence, measurement_map = self.compiler.compile(circuit, self.platform)
 
-        if not self.platform.is_connected:
-            self.platform.connect()
+        self.platform.connect()
 
         readout_ = self.platform.execute(
             [sequence],
@@ -146,8 +145,7 @@ class QibolabBackend(NumpyBackend):
             *(self.compiler.compile(circuit, self.platform) for circuit in circuits)
         )
 
-        if not self.platform.is_connected:
-            self.platform.connect()
+        self.platform.connect()
 
         readout = self.platform.execute(sequences, ExecutionParameters(nshots=nshots))
 

--- a/src/qibolab/instruments/abstract.py
+++ b/src/qibolab/instruments/abstract.py
@@ -32,7 +32,6 @@ class Instrument(Model, ABC):
 
     name: InstrumentId
     address: str
-    is_connected: bool = False
     settings: Optional[InstrumentSettings] = None
 
     @property

--- a/src/qibolab/instruments/bluefors.py
+++ b/src/qibolab/instruments/bluefors.py
@@ -27,21 +27,22 @@ class TemperatureController(Instrument):
     client_socket: socket.socket = Field(
         default_factory=lambda: socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     )
+    _is_connected: bool = False
 
     def connect(self):
         """Connect to the socket."""
-        if self.is_connected:
+        if self._is_connected:
             return
         log.info(f"Bluefors connection. IP: {self.address} Port: {self.port}")
         self.client_socket.connect((self.address, self.port))
-        self.is_connected = True
+        self._is_connected = True
         log.info("Bluefors Temperature Controller Connected")
 
     def disconnect(self):
         """Disconnect from the socket."""
-        if self.is_connected:
+        if self._is_connected:
             self.client_socket.close()
-            self.is_connected = False
+            self._is_connected = False
 
     def setup(self):
         """Required by parent class, but not used here."""

--- a/src/qibolab/instruments/qm/controller.py
+++ b/src/qibolab/instruments/qm/controller.py
@@ -161,8 +161,6 @@ class QmController(Controller):
 
     manager: Optional[QuantumMachinesManager] = None
     """Manager object used for controlling the Quantum Machines cluster."""
-    is_connected: bool = False
-    """Boolean that shows whether we are connected to the QM manager."""
 
     config: QmConfig = Field(default_factory=QmConfig)
     """Configuration dictionary required for pulse execution on the OPXs."""
@@ -227,7 +225,6 @@ class QmController(Controller):
         self.manager = QuantumMachinesManager(
             host=host, port=int(port), octave=octave, credentials=credentials
         )
-        self.is_connected = True
 
     def disconnect(self):
         """Disconnect from QM manager."""
@@ -235,7 +232,7 @@ class QmController(Controller):
         if self.manager is not None:
             self.manager.close_all_quantum_machines()
             self.manager.close()
-            self.is_connected = False
+            self.manager = None
 
     def configure_device(self, device: str):
         """Add device in the ``config``."""

--- a/src/qibolab/instruments/zhinst/executor.py
+++ b/src/qibolab/instruments/zhinst/executor.py
@@ -111,17 +111,16 @@ class Zurich(Controller):
         }
 
     def connect(self):
-        if self.is_connected is False:
+        if self.session is None:
             # To fully remove logging #configure_logging=False
             # I strongly advise to set it to 20 to have time estimates of the experiment duration!
             self.session = laboneq.Session(self.device_setup, log_level=20)
             _ = self.session.connect()
-            self.is_connected = True
 
     def disconnect(self):
-        if self.is_connected:
+        if self.session is None:
             _ = self.session.disconnect()
-            self.is_connected = False
+            self.session = None
 
     def calibration_step(self, configs: dict[str, Config], options):
         """Zurich general pre experiment calibration definitions.

--- a/tests/instruments/test_bluefors.py
+++ b/tests/instruments/test_bluefors.py
@@ -15,11 +15,9 @@ messages = [
 def test_connect():
     with mock.patch("socket.socket"):
         tc = TemperatureController(name="Test_Temperature_Controller", address="")
-        assert tc.is_connected is False
         # if already connected, it should stay connected
         for _ in range(2):
             tc.connect()
-            assert tc.is_connected is True
 
 
 @pytest.mark.parametrize("already_connected", [True, False])
@@ -31,7 +29,6 @@ def test_disconnect(already_connected):
         # if already disconnected, it should stay disconnected
         for _ in range(2):
             tc.disconnect()
-            assert tc.is_connected is False
 
 
 def test_continuously_read_data():

--- a/tests/instruments/test_erasynth.py
+++ b/tests/instruments/test_erasynth.py
@@ -12,7 +12,7 @@ def era(connected_platform):
 
 @pytest.mark.qpu
 def test_instruments_erasynth_connect(era):
-    assert era.is_connected == True
+    assert instrument.device is not None
 
 
 @pytest.mark.qpu

--- a/tests/instruments/test_oscillator.py
+++ b/tests/instruments/test_oscillator.py
@@ -18,10 +18,9 @@ def test_oscillator_init(lo):
 def test_oscillator_connect(lo):
     assert lo.device is None
     lo.connect()
-    assert lo.is_connected
     assert isinstance(lo.device, DummyDevice)
     lo.disconnect()
-    assert not lo.is_connected
+    assert lo.device is None
 
 
 def test_oscillator_setup(lo):

--- a/tests/instruments/test_rohde_schwarz.py
+++ b/tests/instruments/test_rohde_schwarz.py
@@ -13,8 +13,7 @@ def instrument(connected_platform):
 
 @pytest.mark.qpu
 def test_instruments_rohde_schwarz_init(instrument):
-    assert instrument.is_connected
-    assert instrument.device
+    assert instrument.device is not None
 
 
 @pytest.mark.qpu


### PR DESCRIPTION
I think it is redundant, as for most instruments there are different ways to check if they are connected, such as `if self.device is not None`. If it is needed for some instrument, we can have an internal private variable (`_is_connected`).

I left `is_connected` in the platform, however in principle we could convert it to a propery and query the instruments if they are connected. That would require re-implementing `is_connected` to the instruments as a public property.