### PR TITLE
Qubit creation helpers

### DIFF
--- a/doc/source/main-documentation/qibolab.rst
+++ b/doc/source/main-documentation/qibolab.rst
@@ -55,9 +55,9 @@ We can easily access the names of channels and other components, and based on th
 .. testoutput:: python
     :hide:
 
-    Drive channel name: qubit_0/drive
+    Drive channel name: 0/drive
     Drive frequency: 4000000000.0
-    Drive channel qubit_0/drive does not use an LO.
+    Drive channel 0/drive does not use an LO.
 
 Now we can create a simple sequence (again, without explicitly giving any qubit specific parameter, as these are loaded automatically from the platform, as defined in the runcard):
 

--- a/src/qibolab/dummy/parameters.json
+++ b/src/qibolab/dummy/parameters.json
@@ -10,87 +10,87 @@
       "readout": 0,
       "instructions": 0
     },
-    "qubit_0/drive": {
+    "0/drive": {
       "kind": "iq",
       "frequency": 4000000000.0
     },
-    "qubit_1/drive": {
+    "1/drive": {
       "kind": "iq",
       "frequency": 4200000000.0
     },
-    "qubit_2/drive": {
+    "2/drive": {
       "kind": "iq",
       "frequency": 4500000000.0
     },
-    "qubit_3/drive": {
+    "3/drive": {
       "kind": "iq",
       "frequency": 4150000000.0
     },
-    "qubit_4/drive": {
+    "4/drive": {
       "kind": "iq",
       "frequency": 4155663000.0
     },
-    "qubit_0/drive12": {
+    "0/drive12": {
       "kind": "iq",
       "frequency": 4700000000.0
     },
-    "qubit_1/drive12": {
+    "1/drive12": {
       "kind": "iq",
       "frequency": 4855663000.0
     },
-    "qubit_2/drive12": {
+    "2/drive12": {
       "kind": "iq",
       "frequency": 2700000000.0
     },
-    "qubit_3/drive12": {
+    "3/drive12": {
       "kind": "iq",
       "frequency": 5855663000.0
     },
-    "qubit_4/drive12": {
+    "4/drive12": {
       "kind": "iq",
       "frequency": 5855663000.0
     },
-    "qubit_0/flux": {
+    "0/flux": {
       "kind": "dc",
       "offset": -0.1
     },
-    "qubit_1/flux": {
+    "1/flux": {
       "kind": "dc",
       "offset": 0.0
     },
-    "qubit_2/flux": {
+    "2/flux": {
       "kind": "dc",
       "offset": 0.1
     },
-    "qubit_3/flux": {
+    "3/flux": {
       "kind": "dc",
       "offset": 0.2
     },
-    "qubit_4/flux": {
+    "4/flux": {
       "kind": "dc",
       "offset": 0.15
     },
-    "qubit_0/probe": {
+    "0/probe": {
       "kind": "iq",
       "frequency": 5200000000.0
     },
-    "qubit_1/probe": {
+    "1/probe": {
       "kind": "iq",
       "frequency": 4900000000.0
     },
-    "qubit_2/probe": {
+    "2/probe": {
       "kind": "iq",
       "frequency": 6100000000.0
     },
-    "qubit_3/probe": {
+    "3/probe": {
       "kind": "iq",
       "frequency": 5800000000.0
     },
-    "qubit_4/probe": {
+    "4/probe": {
       "kind": "iq",
       "frequency": 5500000000.0
     },
-    "qubit_0/acquisition": {
+    "0/acquisition": {
       "kind": "acquisition",
       "delay": 0.0,
       "smearing": 0.0,
@@ -98,7 +98,7 @@
       "iq_angle": 0.0,
       "kernel": "k05VTVBZAQB2AHsnZGVzY3InOiAnPGY4JywgJ2ZvcnRyYW5fb3JkZXInOiBGYWxzZSwgJ3NoYXBlJzogKDEwLCksIH0gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAp5sDfS7uHlP2DIMKNvnKc/gCqN8KV/pT94FQCYYJC3PzSbwfi/894/APwg6C61rj8MSN3blizAP2ha9unQYsM/+BFjHTxcwT+gXaJazvbpPw=="
     },
-    "qubit_1/acquisition": {
+    "1/acquisition": {
       "kind": "acquisition",
       "delay": 0.0,
       "smearing": 0.0,
@@ -106,7 +106,7 @@
       "iq_angle": 0.0,
       "kernel": "k05VTVBZAQB2AHsnZGVzY3InOiAnPGY4JywgJ2ZvcnRyYW5fb3JkZXInOiBGYWxzZSwgJ3NoYXBlJzogKDEwLCksIH0gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAr4dT6V5tHrP1w+JhHImN8/sPePZeSUuj/4yTKrD5fRP/ysonZip98/6GJMAPV9xD/LTiJo4k7oP96aWXpxduU/6fUxETe/7z9GXEBNGebWPw=="
     },
-    "qubit_2/acquisition": {
+    "2/acquisition": {
       "kind": "acquisition",
       "delay": 0.0,
       "smearing": 0.0,
@@ -114,7 +114,7 @@
       "iq_angle": 0.0,
       "kernel": "k05VTVBZAQB2AHsnZGVzY3InOiAnPGY4JywgJ2ZvcnRyYW5fb3JkZXInOiBGYWxzZSwgJ3NoYXBlJzogKDEwLCksIH0gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIApUtcFdBpTsPzzwG8Xkbts/OAvkS0qo4z+OUcJpZ8HlP/jsO9cUwso/s6DVM7e/4T/NL4JYzUXvP9CibqEg98M/AENJ8QPkcD8wAOtI4pHNPw=="
     },
-    "qubit_3/acquisition": {
+    "3/acquisition": {
       "kind": "acquisition",
       "delay": 0.0,
       "smearing": 0.0,
@@ -122,7 +122,7 @@
       "iq_angle": 0.0,
       "kernel": "k05VTVBZAQB2AHsnZGVzY3InOiAnPGY4JywgJ2ZvcnRyYW5fb3JkZXInOiBGYWxzZSwgJ3NoYXBlJzogKDEwLCksIH0gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIAogk3D0+DqsP1ry/LSlMuM/ydJYpPk/6D8BJMdYs+zsP1CqhVqYz+o/1A3srA5z7j8CUqCE6lvqPwjNySZ1DuA/YHGvVmuFsz+XwaQKz/bqPw=="
     },
-    "qubit_4/acquisition": {
+    "4/acquisition": {
       "kind": "acquisition",
       "delay": 0.0,
       "smearing": 0.0,
@@ -157,7 +157,7 @@
       "0": {
         "RX": [
           [
-            "qubit_0/drive",
+            "0/drive",
             {
               "duration": 40.0,
               "amplitude": 0.1,
@@ -172,7 +172,7 @@
         ],
         "RX12": [
           [
-            "qubit_0/drive12",
+            "0/drive12",
             {
               "duration": 40.0,
               "amplitude": 0.005,
@@ -187,7 +187,7 @@
         ],
         "MZ": [
           [
-            "qubit_0/acquisition",
+            "0/acquisition",
             {
               "kind": "readout",
               "acquisition": {
@@ -213,7 +213,7 @@
       "1": {
         "RX": [
           [
-            "qubit_1/drive",
+            "1/drive",
             {
               "duration": 40.0,
               "amplitude": 0.3,
@@ -229,7 +229,7 @@
         ],
         "RX12": [
           [
-            "qubit_1/drive12",
+            "1/drive12",
             {
               "duration": 40.0,
               "amplitude": 0.0484,
@@ -245,7 +245,7 @@
         ],
         "MZ": [
           [
-            "qubit_1/acquisition",
+            "1/acquisition",
             {
               "kind": "readout",
               "acquisition": {
@@ -271,7 +271,7 @@
       "2": {
         "RX": [
           [
-            "qubit_2/drive",
+            "2/drive",
             {
               "duration": 40.0,
               "amplitude": 0.3,
@@ -287,7 +287,7 @@
         ],
         "RX12": [
           [
-            "qubit_2/drive12",
+            "2/drive12",
             {
               "duration": 40.0,
               "amplitude": 0.005,
@@ -302,7 +302,7 @@
         ],
         "MZ": [
           [
-            "qubit_2/acquisition",
+            "2/acquisition",
             {
               "kind": "readout",
               "acquisition": {
@@ -328,7 +328,7 @@
       "3": {
         "RX": [
           [
-            "qubit_3/drive",
+            "3/drive",
             {
               "duration": 40.0,
               "amplitude": 0.3,
@@ -344,7 +344,7 @@
         ],
         "RX12": [
           [
-            "qubit_3/drive12",
+            "3/drive12",
             {
               "duration": 40.0,
               "amplitude": 0.0484,
@@ -360,7 +360,7 @@
         ],
         "MZ": [
           [
-            "qubit_3/acquisition",
+            "3/acquisition",
             {
               "kind": "readout",
               "acquisition": {
@@ -386,7 +386,7 @@
       "4": {
         "RX": [
           [
-            "qubit_4/drive",
+            "4/drive",
             {
               "duration": 40.0,
               "amplitude": 0.3,
@@ -402,7 +402,7 @@
         ],
         "RX12": [
           [
-            "qubit_4/drive12",
+            "4/drive12",
             {
               "duration": 40.0,
               "amplitude": 0.0484,
@@ -418,7 +418,7 @@
         ],
         "MZ": [
           [
-            "qubit_4/acquisition",
+            "4/acquisition",
             {
               "kind": "readout",
               "acquisition": {
@@ -532,7 +532,7 @@
       "0-2": {
         "CZ": [
           [
-            "qubit_2/flux",
+            "2/flux",
             {
               "duration": 30.0,
               "amplitude": 0.05,
@@ -546,14 +546,14 @@
             }
           ],
           [
-            "qubit_0/drive",
+            "0/drive",
             {
               "phase": 0.0,
               "kind": "virtualz"
             }
           ],
           [
-            "qubit_2/drive",
+            "2/drive",
             {
               "phase": 0.0,
               "kind": "virtualz"
@@ -577,7 +577,7 @@
         "CNOT": null,
         "iSWAP": [
           [
-            "qubit_2/flux",
+            "2/flux",
             {
               "duration": 30.0,
               "amplitude": 0.05,
@@ -591,14 +591,14 @@
             }
           ],
           [
-            "qubit_0/drive",
+            "0/drive",
             {
               "phase": 0.0,
               "kind": "virtualz"
             }
           ],
           [
-            "qubit_2/drive",
+            "2/drive",
             {
               "phase": 0.0,
               "kind": "virtualz"
@@ -623,7 +623,7 @@
       "1-2": {
         "CZ": [
           [
-            "qubit_2/flux",
+            "2/flux",
             {
               "duration": 30.0,
               "amplitude": 0.05,
@@ -637,14 +637,14 @@
             }
           ],
           [
-            "qubit_1/drive",
+            "1/drive",
             {
               "phase": 0.0,
               "kind": "virtualz"
             }
           ],
           [
-            "qubit_2/drive",
+            "2/drive",
             {
               "phase": 0.0,
               "kind": "virtualz"
@@ -668,7 +668,7 @@
         "CNOT": null,
         "iSWAP": [
           [
-            "qubit_2/flux",
+            "2/flux",
             {
               "duration": 30.0,
               "amplitude": 0.05,
@@ -682,14 +682,14 @@
             }
           ],
           [
-            "qubit_1/drive",
+            "1/drive",
             {
               "phase": 0.0,
               "kind": "virtualz"
             }
           ],
           [
-            "qubit_2/drive",
+            "2/drive",
             {
               "phase": 0.0,
               "kind": "virtualz"
@@ -714,7 +714,7 @@
       "2-3": {
         "CZ": [
           [
-            "qubit_2/flux",
+            "2/flux",
             {
               "duration": 30.0,
               "amplitude": 0.05,
@@ -728,14 +728,14 @@
             }
           ],
           [
-            "qubit_2/drive",
+            "2/drive",
             {
               "phase": 0.0,
               "kind": "virtualz"
             }
           ],
           [
-            "qubit_3/drive",
+            "3/drive",
             {
               "phase": 0.0,
               "kind": "virtualz"
@@ -744,7 +744,7 @@
         ],
         "CNOT": [
           [
-            "qubit_2/drive",
+            "2/drive",
             {
               "duration": 40.0,
               "amplitude": 0.3,
@@ -760,7 +760,7 @@
         ],
         "iSWAP": [
           [
-            "qubit_2/flux",
+            "2/flux",
             {
               "duration": 30.0,
               "amplitude": 0.05,
@@ -774,14 +774,14 @@
             }
           ],
           [
-            "qubit_2/drive",
+            "2/drive",
             {
               "phase": 0.0,
               "kind": "virtualz"
             }
           ],
           [
-            "qubit_3/drive",
+            "3/drive",
             {
               "phase": 0.0,
               "kind": "virtualz"
@@ -792,7 +792,7 @@
       "2-4": {
         "CZ": [
           [
-            "qubit_2/flux",
+            "2/flux",
             {
               "duration": 30.0,
               "amplitude": 0.05,
@@ -806,7 +806,7 @@
             }
           ],
           [
-            "qubit_4/drive",
+            "4/drive",
             {
               "phase": 0.0,
               "kind": "virtualz"
@@ -830,7 +830,7 @@
         "CNOT": null,
         "iSWAP": [
           [
-            "qubit_2/flux",
+            "2/flux",
             {
               "duration": 30.0,
               "amplitude": 0.05,
@@ -844,14 +844,14 @@
             }
           ],
           [
-            "qubit_2/drive",
+            "2/drive",
             {
               "phase": 0.0,
               "kind": "virtualz"
             }
           ],
           [
-            "qubit_4/drive",
+            "4/drive",
             {
               "phase": 0.0,
               "kind": "virtualz"

--- a/src/qibolab/dummy/platform.py
+++ b/src/qibolab/dummy/platform.py
@@ -15,33 +15,22 @@ def create_dummy() -> Platform:
     # attach the channels
     pump_name = "twpa_pump"
     for q in range(5):
-        drive, drive12, flux, probe, acquisition = (
-            f"qubit_{q}/drive",
-            f"qubit_{q}/drive12",
-            f"qubit_{q}/flux",
-            f"qubit_{q}/probe",
-            f"qubit_{q}/acquisition",
-        )
+        drive12 = f"{q}/drive12"
+        qubits[q] = qubit = Qubit.default(q, drive_qudits={(1, 2): drive12})
         channels |= {
-            probe: IqChannel(mixer=None, lo=None),
-            acquisition: AcquisitionChannel(twpa_pump=pump_name, probe=probe),
-            drive: IqChannel(mixer=None, lo=None),
+            qubit.probe: IqChannel(mixer=None, lo=None),
+            qubit.acquisition: AcquisitionChannel(
+                twpa_pump=pump_name, probe=qubit.probe
+            ),
+            qubit.drive: IqChannel(mixer=None, lo=None),
             drive12: IqChannel(mixer=None, lo=None),
-            flux: DcChannel(),
+            qubit.flux: DcChannel(),
         }
-        qubits[q] = Qubit(
-            probe=probe,
-            acquisition=acquisition,
-            drive=drive,
-            drive_qudits={(1, 2): drive12},
-            flux=flux,
-        )
 
     couplers = {}
     for c in (0, 1, 3, 4):
-        flux = f"coupler_{c}/flux"
-        channels |= {flux: DcChannel()}
-        couplers[c] = Qubit(flux=flux)
+        couplers[c] = coupler = Qubit(flux=f"coupler_{c}/flux")
+        channels |= {coupler.flux: DcChannel()}
 
     # register the instruments
     instruments = {

--- a/src/qibolab/qubits.py
+++ b/src/qibolab/qubits.py
@@ -12,8 +12,9 @@ from .serialize import Model
 class Qubit(Model):
     """Representation of a physical qubit.
 
-    Qubit objects are instantiated by :class:`qibolab.platforms.platform.Platform`
-    but they are passed to instrument designs in order to play pulses.
+    Contains the channel ids used to control the qubit and is instantiated
+    in the function that creates the corresponding
+    :class:`qibolab.platforms.platform.Platform`
     """
 
     model_config = ConfigDict(frozen=False)
@@ -39,6 +40,27 @@ class Qubit(Model):
             )
             if x is not None
         ]
+
+    @classmethod
+    def with_channels(cls, name: QubitId, channels: list[str], **kwargs):
+        """Create a qubit with default channel names.
+
+        Default channel names follow the convention:
+        '{qubit_name}/{channel_type}'
+        """
+        return cls(**{ch: f"{name}/{ch}" for ch in channels}, **kwargs)
+
+    @classmethod
+    def default(cls, name: QubitId, flux: bool = True, **kwargs):
+        """Create a flux tunable qubit with the default channel names.
+
+        Flux tunable qubits have drive, flux, probe and acquisition
+        channels.
+        """
+        channels = ["probe", "acquisition", "drive"]
+        if flux:
+            channels.append("flux")
+        return cls.with_channels(name, channels, **kwargs)
 
 
 class QubitPair(Model):

--- a/src/qibolab/qubits.py
+++ b/src/qibolab/qubits.py
@@ -42,26 +42,21 @@ class Qubit(Model):
         ]
 
     @classmethod
-    def with_channels(cls, name: QubitId, channels: list[str], **kwargs):
+    def default(cls, name: QubitId, channels: Optional[list[str]] = None, **kwargs):
         """Create a qubit with default channel names.
 
         Default channel names follow the convention:
         '{qubit_name}/{channel_type}'
+
+        Args:
+            name: Name for the qubit to be used for channel ids.
+            channels: List of channels to add to the qubit.
+                If ``None`` the following channels will be added:
+                probe, acquisition, drive and flux.
         """
+        if channels is None:
+            channels = ["probe", "acquisition", "drive", "flux"]
         return cls(**{ch: f"{name}/{ch}" for ch in channels}, **kwargs)
-
-    @classmethod
-    def default(cls, name: QubitId, flux: bool = True, **kwargs):
-        """Create a qubit with the usual channels.
-
-        These are probe, acquisition, drive and flux.
-        For non flux-tunable qubits the flux channel can
-        be disabled using the ``flux: bool`` argument
-        """
-        channels = ["probe", "acquisition", "drive"]
-        if flux:
-            channels.append("flux")
-        return cls.with_channels(name, channels, **kwargs)
 
 
 class QubitPair(Model):

--- a/src/qibolab/qubits.py
+++ b/src/qibolab/qubits.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Annotated, Optional
 
 from pydantic import ConfigDict, Field
 
@@ -7,6 +7,9 @@ from pydantic import ConfigDict, Field
 # the unused ones from here
 from .identifier import ChannelId, QubitId, QubitPairId, TransitionId  # noqa
 from .serialize import Model
+
+DefaultChannelType = Annotated[Optional[ChannelId], True]
+"""If ``True`` the channel is included in the default qubit constructor."""
 
 
 class Qubit(Model):
@@ -19,15 +22,17 @@ class Qubit(Model):
 
     model_config = ConfigDict(frozen=False)
 
-    drive: Optional[ChannelId] = None
+    drive: DefaultChannelType = None
     """Ouput channel, to drive the qubit state."""
-    drive_qudits: dict[TransitionId, ChannelId] = Field(default_factory=dict)
+    drive_qudits: Annotated[dict[TransitionId, ChannelId], False] = Field(
+        default_factory=dict
+    )
     """Output channels collection, to drive non-qubit transitions."""
-    flux: Optional[ChannelId] = None
+    flux: DefaultChannelType = None
     """Output channel, to control the qubit flux."""
-    probe: Optional[ChannelId] = None
+    probe: DefaultChannelType = None
     """Output channel, to probe the resonator."""
-    acquisition: Optional[ChannelId] = None
+    acquisition: DefaultChannelType = None
     """Input channel, to acquire the readout results."""
 
     @property
@@ -55,7 +60,7 @@ class Qubit(Model):
                 probe, acquisition, drive and flux.
         """
         if channels is None:
-            channels = ["probe", "acquisition", "drive", "flux"]
+            channels = [name for name, f in cls.model_fields.items() if f.metadata[0]]
         return cls(**{ch: f"{name}/{ch}" for ch in channels}, **kwargs)
 
 

--- a/src/qibolab/qubits.py
+++ b/src/qibolab/qubits.py
@@ -52,10 +52,11 @@ class Qubit(Model):
 
     @classmethod
     def default(cls, name: QubitId, flux: bool = True, **kwargs):
-        """Create a flux tunable qubit with the default channel names.
+        """Create a qubit with the usual channels.
 
-        Flux tunable qubits have drive, flux, probe and acquisition
-        channels.
+        These are probe, acquisition, drive and flux.
+        For non flux-tunable qubits the flux channel can
+        be disabled using the ``flux: bool`` argument
         """
         channels = ["probe", "acquisition", "drive"]
         if flux:


### PR DESCRIPTION
Closes #1022. Originally planned for 0.2.1, I just implemented it because it was easy and is expected to simplify platform creation, so it is slightly interface facing (even though it is a new feature).

If we need to delay for some reason, we can keep this open and merge after 0.2.0 is released.