### PR TITLE
Fixing compiler rule

### DIFF
--- a/src/qibolab/compilers/default.py
+++ b/src/qibolab/compilers/default.py
@@ -22,7 +22,7 @@ def z_rule(gate, platform):
 def rz_rule(gate, platform):
     """RZ gate applied virtually."""
     qubit = list(platform.qubits)[gate.target_qubits[0]]
-    return PulseSequence(), {qubit: gate.parameters[0]}
+    return PulseSequence(), {qubit: -gate.parameters[0]}
 
 
 def gpi2_rule(gate, platform):


### PR DESCRIPTION
I believe that this was the issue which was giving us a weird behavior in the single qubit tomography @stavros11 @alecandido.

If we consider the definition of GPI2 provided by Qibo we have that $GPI2(0) = R_X(\pi/2)$ and $GPI2(\pi /2) = R_Y(\pi/2)$ which means that the GPI2 should have the following representation

$$
GPI2(\phi) = e^{-i \frac{\pi}{2} ( \cos{\phi} X + \sin{\phi} Y)}
$$

We now need to compute how $GPI2(\phi)$ changes when we apply an $R_Z(\tilde \phi)$ gate

$$
R_Z(\tilde \phi) GPI2(\phi) R_Z(- \tilde \phi) = GPI2( \phi^*)
$$

We can find $\phi^*$ with the following passages

$$
R_Z ( \tilde \phi) e^{-i \frac{\pi}{2} ( \cos{\phi} X + \sin{\phi} Y)} R_Z (- \tilde \phi) = e^{-i \frac{\pi}{2} ( \cos{(\phi - \tilde \phi)} X + \sin{(\phi - \tilde \phi)} Y)} =GPI2 (\phi - \tilde \phi).
$$

Therefore $\phi^* = \phi - \tilde \phi$ which means that rule for $R_Z(\tilde \phi)$ should be $\phi \rightarrow \phi - \tilde \phi$


@stavros11 feel free to check and let me know if the fix works for you as well.
Currently this PR is pointing to `main` feel free to merge it directly to `0.2` or `0.1`.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
