### PR TITLE
Add support for OPX1000 in QM driver

### DIFF
--- a/src/qibolab/instruments/qm/__init__.py
+++ b/src/qibolab/instruments/qm/__init__.py
@@ -1,2 +1,2 @@
 from .controller import QMController
-from .devices import Octave, OPXplus
+from .devices import FEM, OPX1000, Octave, OPXplus

--- a/src/qibolab/instruments/qm/config.py
+++ b/src/qibolab/instruments/qm/config.py
@@ -81,15 +81,13 @@ class QMConfig:
             if is_octave:
                 self.register_port(port.opx_port)
                 subport = port.opx_port.i
+                con = subport.device
+                number = subport.number
                 if isinstance(subport, (FEMOutput, FEMInput)):
-                    con = subport.device
                     fem = subport.fem_number
-                    number = subport.number
                     device["connectivity"] = (con, fem)
                     self.controllers[con]["fems"][fem]["digital_outputs"][number] = {}
                 else:
-                    con = subport.device
-                    number = subport.number
                     device["connectivity"] = con
                     self.controllers[con]["digital_outputs"][number] = {}
 

--- a/src/qibolab/instruments/qm/controller.py
+++ b/src/qibolab/instruments/qm/controller.py
@@ -189,6 +189,9 @@ class QMController(Controller):
             # convert simulation duration from ns to clock cycles
             self.simulation_duration //= 4
 
+    def __str__(self):
+        return self.name
+
     def ports(self, name, output=True):
         """Provides instrument ports to the user.
 
@@ -255,7 +258,6 @@ class QMController(Controller):
         self._reset_temporary_calibration()
         if self.manager is not None:
             self.manager.close_all_quantum_machines()
-            self.manager.close()
             self.is_connected = False
 
     def calibrate_mixers(self, qubits):

--- a/src/qibolab/instruments/qm/controller.py
+++ b/src/qibolab/instruments/qm/controller.py
@@ -375,6 +375,10 @@ class QMController(Controller):
         # play pulses using QUA
         with qua.program() as experiment:
             n = declare(int)
+            for qubit in qubits.values():
+                if qubit.flux:
+                    qua.set_dc_offset(qubit.flux.name, "single", qubit.sweetspot)
+
             acquisitions = declare_acquisitions(ro_pulses, qubits, options)
             with for_(n, 0, n < options.nshots, n + 1):
                 sweep(

--- a/src/qibolab/instruments/qm/devices.py
+++ b/src/qibolab/instruments/qm/devices.py
@@ -45,6 +45,9 @@ class QMDevice(Instrument):
     inputs: Dict[int, QMInput] = field(init=False)
     """Dictionary containing the instrument's input ports."""
 
+    def __str__(self):
+        return self.name
+
     def ports(self, number, output=True):
         """Provides instrument's ports to the user.
 
@@ -115,10 +118,10 @@ class OPX1000(QMDevice):
             return {"fem_number": fem, "fem_type": self.fems[fem].type}
 
         self.outputs = PortsDefaultdict(
-            lambda fem, n: FEMOutput(self.name, n, **kwargs(fem))
+            lambda pair: FEMOutput(self.name, pair[1], **kwargs(pair[0]))
         )
         self.inputs = PortsDefaultdict(
-            lambda fem, n: FEMInput(self.name, n, **kwargs(fem))
+            lambda pair: FEMInput(self.name, pair[1], **kwargs(pair[0]))
         )
 
     def ports(self, fem_number: int, number: int, output: bool = True):

--- a/src/qibolab/instruments/qm/ports.py
+++ b/src/qibolab/instruments/qm/ports.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field, fields
-from typing import ClassVar, Dict, Optional, Union
+from typing import ClassVar, Dict, Literal, Optional, Union
 
 DIGITAL_DELAY = 57
 DIGITAL_BUFFER = 18
@@ -129,6 +129,34 @@ class OPXIQ:
     """Port implementing the I-component of the signal."""
     q: Union[OPXOutput, OPXInput]
     """Port implementing the Q-component of the signal."""
+
+
+@dataclass
+class FEMOutput(OPXOutput):
+    fem_number: int = 0
+    fem_type: Literal["LF", "MF"] = "LF"
+
+    @property
+    def name(self):
+        return f"{self.fem_number}/o{self.number}"
+
+    @property
+    def pair(self):
+        return (self.device, self.fem_number, self.number)
+
+
+@dataclass
+class FEMInput(OPXInput):
+    fem_number: int = 0
+    fem_type: Literal["LF", "MF"] = "LF"
+
+    @property
+    def name(self):
+        return f"{self.fem_number}/i{self.number}"
+
+    @property
+    def pair(self):
+        return (self.device, self.fem_number, self.number)
 
 
 @dataclass

--- a/src/qibolab/instruments/qm/ports.py
+++ b/src/qibolab/instruments/qm/ports.py
@@ -193,11 +193,14 @@ class OctaveOutput(QMOutput):
 
         Digital markers are used to switch LOs on in triggered mode.
         """
-        opx = self.opx_port.i.device
-        number = self.opx_port.i.number
+        opx_port = self.opx_port.i
+        if isinstance(opx_port, (FEMOutput, FEMInput)):
+            port = (opx_port.device, opx_port.fem_number, opx_port.number)
+        else:
+            port = (opx_port.device, opx_port.number)
         return {
             "output_switch": {
-                "port": (opx, number),
+                "port": port,
                 "delay": self.digital_delay,
                 "buffer": self.digital_buffer,
             }

--- a/src/qibolab/instruments/qm/ports.py
+++ b/src/qibolab/instruments/qm/ports.py
@@ -135,6 +135,9 @@ class OPXIQ:
 class FEMOutput(OPXOutput):
     fem_number: int = 0
     fem_type: Literal["LF", "MF"] = "LF"
+    output_mode: Literal["direct", "amplified"] = field(
+        default="direct", metadata={"config": "output_mode"}
+    )
 
     @property
     def name(self):

--- a/src/qibolab/instruments/qm/ports.py
+++ b/src/qibolab/instruments/qm/ports.py
@@ -180,7 +180,7 @@ class OctaveOutput(QMOutput):
 
     Can be external or internal.
     """
-    output_mode: str = field(default="triggered", metadata={"config": "output_mode"})
+    output_mode: str = field(default="always_on", metadata={"config": "output_mode"})
     """Can be: "always_on" / "always_off"/ "triggered" / "triggered_reversed"."""
     digital_delay: int = DIGITAL_DELAY
     """Delay for digital output channel."""

--- a/src/qibolab/instruments/qm/ports.py
+++ b/src/qibolab/instruments/qm/ports.py
@@ -136,7 +136,7 @@ class FEMOutput(OPXOutput):
     fem_number: int = 0
     fem_type: Literal["LF", "MF"] = "LF"
     output_mode: Literal["direct", "amplified"] = field(
-        default="direct", metadata={"config": "output_mode"}
+        default="direct", metadata={"config": "output_mode", "settings": True}
     )
 
     @property

--- a/src/qibolab/instruments/qm/sweepers.py
+++ b/src/qibolab/instruments/qm/sweepers.py
@@ -141,16 +141,18 @@ def _sweep_bias(sweepers, qubits, qmsequence, relaxation_time):
     for qubit in sweeper.qubits:
         b0 = qubit.flux.offset
         max_offset = qubit.flux.max_offset
+        if max_offset is None:
+            max_offset = 0.5
         max_value = maximum_sweep_value(sweeper.values, b0)
         check_max_offset(max_value, max_offset)
         offset0.append(declare(fixed, value=b0))
     b = declare(fixed)
     with for_(*from_array(b, sweeper.values)):
         for qubit, b0 in zip(sweeper.qubits, offset0):
-            with qua.if_((b + b0) >= 0.49):
-                qua.set_dc_offset(f"flux{qubit.name}", "single", 0.49)
-            with qua.elif_((b + b0) <= -0.49):
-                qua.set_dc_offset(f"flux{qubit.name}", "single", -0.49)
+            with qua.if_((b + b0) >= max_offset):
+                qua.set_dc_offset(f"flux{qubit.name}", "single", max_offset)
+            with qua.elif_((b + b0) <= -max_offset):
+                qua.set_dc_offset(f"flux{qubit.name}", "single", -max_offset)
             with qua.else_():
                 qua.set_dc_offset(f"flux{qubit.name}", "single", (b + b0))
 


### PR DESCRIPTION
There are some errors occuring, particularly when using multiple qubits in parallel, which I have not fully pinpointed yet.

So far I have been able to run some resonator spectroscopy (example http://login.qrccluster.com:9000/5qKIEfDTRHqYx64Y2bOt9g==) and punchout but at maximum 4 qubits simultaneously.