### PR TITLE
Split RX from RXY

### DIFF
--- a/doc/source/main-documentation/qibolab.rst
+++ b/doc/source/main-documentation/qibolab.rst
@@ -73,7 +73,7 @@ as these are loaded automatically from the platform, as defined in the correspon
    qubit = platform.qubits[0]
    natives = platform.natives.single_qubit[0]
    ps.concatenate(natives.RX())
-   ps.concatenate(natives.RX(phi=np.pi / 2))
+   ps.concatenate(natives.RXY(phi=np.pi / 2))
    ps.append((qubit.probe, Delay(duration=200)))
    ps.concatenate(natives.MZ())
 

--- a/doc/source/main-documentation/qibolab.rst
+++ b/doc/source/main-documentation/qibolab.rst
@@ -73,7 +73,7 @@ as these are loaded automatically from the platform, as defined in the correspon
    qubit = platform.qubits[0]
    natives = platform.natives.single_qubit[0]
    ps.concatenate(natives.RX())
-   ps.concatenate(natives.RXY(phi=np.pi / 2))
+   ps.concatenate(natives.R(phi=np.pi / 2))
    ps.append((qubit.probe, Delay(duration=200)))
    ps.concatenate(natives.MZ())
 

--- a/doc/source/tutorials/pulses.rst
+++ b/doc/source/tutorials/pulses.rst
@@ -75,4 +75,4 @@ Alternatively, instead of using the pulse API directly, one can use the native g
 
     platform = create_platform("dummy")
     q0 = platform.natives.single_qubit[0]
-    sequence = q0.RXY(theta=np.pi / 2) | q0.MZ()
+    sequence = q0.R(theta=np.pi / 2) | q0.MZ()

--- a/doc/source/tutorials/pulses.rst
+++ b/doc/source/tutorials/pulses.rst
@@ -75,4 +75,4 @@ Alternatively, instead of using the pulse API directly, one can use the native g
 
     platform = create_platform("dummy")
     q0 = platform.natives.single_qubit[0]
-    sequence = q0.RX(theta=np.pi / 2) | q0.MZ()
+    sequence = q0.RXY(theta=np.pi / 2) | q0.MZ()

--- a/src/qibolab/_core/compilers/default.py
+++ b/src/qibolab/_core/compilers/default.py
@@ -31,7 +31,7 @@ def identity_rule(gate: Gate, natives: SingleQubitNatives) -> PulseSequence:
 
 def gpi2_rule(gate: Gate, natives: SingleQubitNatives) -> PulseSequence:
     """Rule for GPI2."""
-    return natives.ensure("RX").create_sequence(theta=np.pi / 2, phi=gate.parameters[0])
+    return natives.RXY(theta=np.pi / 2, phi=gate.parameters[0])
 
 
 def gpi_rule(gate: Gate, natives: SingleQubitNatives) -> PulseSequence:
@@ -40,7 +40,7 @@ def gpi_rule(gate: Gate, natives: SingleQubitNatives) -> PulseSequence:
     # to the matrix representation. See
     # https://github.com/qiboteam/qibolab/pull/804#pullrequestreview-1890205509
     # for more detail.
-    return natives.ensure("RX").create_sequence(theta=np.pi, phi=gate.parameters[0])
+    return natives.RXY(theta=np.pi, phi=gate.parameters[0])
 
 
 def cz_rule(gate: Gate, natives: TwoQubitNatives) -> PulseSequence:

--- a/src/qibolab/_core/compilers/default.py
+++ b/src/qibolab/_core/compilers/default.py
@@ -31,7 +31,7 @@ def identity_rule(gate: Gate, natives: SingleQubitNatives) -> PulseSequence:
 
 def gpi2_rule(gate: Gate, natives: SingleQubitNatives) -> PulseSequence:
     """Rule for GPI2."""
-    return natives.RXY(theta=np.pi / 2, phi=gate.parameters[0])
+    return natives.R(theta=np.pi / 2, phi=gate.parameters[0])
 
 
 def gpi_rule(gate: Gate, natives: SingleQubitNatives) -> PulseSequence:
@@ -40,7 +40,7 @@ def gpi_rule(gate: Gate, natives: SingleQubitNatives) -> PulseSequence:
     # to the matrix representation. See
     # https://github.com/qiboteam/qibolab/pull/804#pullrequestreview-1890205509
     # for more detail.
-    return natives.RXY(theta=np.pi, phi=gate.parameters[0])
+    return natives.R(theta=np.pi, phi=gate.parameters[0])
 
 
 def cz_rule(gate: Gate, natives: TwoQubitNatives) -> PulseSequence:

--- a/src/qibolab/_core/native.py
+++ b/src/qibolab/_core/native.py
@@ -29,7 +29,9 @@ def _normalize_angles(theta, phi):
     return theta, phi
 
 
-def rxy(seq: PulseSequence, theta: float = np.pi, phi: float = 0.0) -> PulseSequence:
+def rotation(
+    seq: PulseSequence, theta: float = np.pi, phi: float = 0.0
+) -> PulseSequence:
     """Create a sequence for single-qubit rotation.
 
     ``theta`` will be the angle of the rotation, while ``phi`` the angle that the rotation axis forms with x axis.
@@ -77,7 +79,7 @@ class SingleQubitNatives(NativeContainer):
         ``theta`` will be the angle of the rotation, while ``phi`` the angle that the rotation axis forms with x axis.
         """
         assert self.RX is not None
-        return rxy(self.RX, theta, phi)
+        return rotation(self.RX, theta, phi)
 
 
 class TwoQubitNatives(NativeContainer):

--- a/src/qibolab/_core/native.py
+++ b/src/qibolab/_core/native.py
@@ -71,7 +71,7 @@ class SingleQubitNatives(NativeContainer):
     CP: Optional[Native] = None
     """Pulse to activate coupler."""
 
-    def RXY(self, theta: float = np.pi, phi: float = 0.0) -> PulseSequence:
+    def R(self, theta: float = np.pi, phi: float = 0.0) -> PulseSequence:
         """Create a sequence for single-qubit rotation.
 
         ``theta`` will be the angle of the rotation, while ``phi`` the angle that the rotation axis forms with x axis.

--- a/src/qibolab/_core/native.py
+++ b/src/qibolab/_core/native.py
@@ -4,7 +4,7 @@ from typing import Annotated, Optional
 
 import numpy as np
 
-from .pulses import Drag, Gaussian, Pulse
+from .pulses import Pulse
 from .sequence import PulseSequence
 from .serialize import Model, replace
 
@@ -30,56 +30,18 @@ class Native(ABC, PulseSequence):
         return self.create_sequence(*args, **kwargs)
 
 
-class RxyFactory(Native):
-    """Factory for pulse sequences that generate single-qubit rotations around
-    an axis in xy plane.
+def rxy(seq: PulseSequence, theta: float = np.pi, phi: float = 0.0) -> PulseSequence:
+    """Create a sequence for single-qubit rotation.
 
-    It is assumed that the underlying sequence contains only a single pulse.
-    It is assumed that the base sequence corresponds to a calibrated pi rotation around X axis.
-    Other rotation angles are achieved by scaling the amplitude, assuming a linear transfer function.
-
-    Args:
-        sequence: The base sequence for the factory.
+    ``theta`` will be the angle of the rotation, while ``phi`` the angle that the rotation axis forms with x axis.
     """
-
-    def __init__(self, iterable):
-        super().__init__(iterable)
-        cls = type(self)
-        if len(self.channels) != 1:
-            raise ValueError(
-                f"Incompatible number of channels: {len(self.channels)}. "
-                f"{cls} expects a sequence on exactly one channel."
-            )
-
-        if len(self) != 1:
-            raise ValueError(
-                f"Incompatible number of pulses: {len(self)}. "
-                f"{cls} expects a sequence with exactly one pulse."
-            )
-
-        pulse = self[0][1]
-        assert isinstance(pulse, Pulse)
-        expected_envelopes = (Gaussian, Drag)
-        if not isinstance(pulse.envelope, expected_envelopes):
-            raise ValueError(
-                f"Incompatible pulse envelope: {pulse.envelope.__class__}. "
-                f"{cls} expects {expected_envelopes} envelope."
-            )
-
-    def create_sequence(self, theta: float = np.pi, phi: float = 0.0) -> PulseSequence:
-        """Create a sequence for single-qubit rotation.
-
-        Args:
-            theta: the angle of rotation.
-            phi: the angle that rotation axis forms with x axis.
-        """
-        theta, phi = _normalize_angles(theta, phi)
-        ch, pulse = self[0]
-        assert isinstance(pulse, Pulse)
-        new_amplitude = pulse.amplitude * theta / np.pi
-        return PulseSequence(
-            [(ch, replace(pulse, amplitude=new_amplitude, relative_phase=phi))]
-        )
+    theta, phi = _normalize_angles(theta, phi)
+    ch, pulse = seq[0]
+    assert isinstance(pulse, Pulse)
+    new_amplitude = pulse.amplitude * theta / np.pi
+    return PulseSequence(
+        [(ch, replace(pulse, amplitude=new_amplitude, relative_phase=phi))]
+    )
 
 
 class FixedSequenceFactory(Native):
@@ -108,7 +70,7 @@ class SingleQubitNatives(NativeContainer):
     """Container with the native single-qubit gates acting on a specific
     qubit."""
 
-    RX: Optional[RxyFactory] = None
+    RX: Optional[FixedSequenceFactory] = None
     """Pulse to drive the qubit from state 0 to state 1."""
     RX12: Optional[FixedSequenceFactory] = None
     """Pulse to drive to qubit from state 1 to state 2."""
@@ -116,6 +78,14 @@ class SingleQubitNatives(NativeContainer):
     """Measurement pulse."""
     CP: Optional[FixedSequenceFactory] = None
     """Pulse to activate coupler."""
+
+    def RXY(self, theta: float = np.pi, phi: float = 0.0) -> PulseSequence:
+        """Create a sequence for single-qubit rotation.
+
+        ``theta`` will be the angle of the rotation, while ``phi`` the angle that the rotation axis forms with x axis.
+        """
+        assert self.RX is not None
+        return rxy(self.RX, theta, phi)
 
 
 class TwoQubitNatives(NativeContainer):

--- a/tests/test_compilers_default.py
+++ b/tests/test_compilers_default.py
@@ -7,7 +7,7 @@ from qibo.models import Circuit
 from qibolab import create_platform
 from qibolab._core.compilers import Compiler
 from qibolab._core.identifier import ChannelId
-from qibolab._core.native import FixedSequenceFactory, TwoQubitNatives
+from qibolab._core.native import Native, TwoQubitNatives
 from qibolab._core.platform import Platform
 from qibolab._core.pulses import Delay, Pulse
 from qibolab._core.pulses.envelope import Rectangular
@@ -221,7 +221,7 @@ def test_inactive_qubits(platform: Platform, joint: bool):
         circuit.add(gates.M(coupled))
 
     natives = platform.natives.two_qubit[(main, coupled)] = TwoQubitNatives(
-        CZ=FixedSequenceFactory([])
+        CZ=Native([])
     )
     assert natives.CZ is not None
     natives.CZ.clear()

--- a/tests/test_compilers_default.py
+++ b/tests/test_compilers_default.py
@@ -99,7 +99,7 @@ def test_gpi_to_sequence(platform: Platform):
     sequence = compile_circuit(circuit, platform)
     assert len(sequence.channels) == 1
 
-    rx_seq = natives.single_qubit[0].RX.create_sequence(phi=0.2)
+    rx_seq = natives.single_qubit[0].RXY(phi=0.2)
 
     np.testing.assert_allclose(sequence.duration, rx_seq.duration)
 
@@ -112,7 +112,7 @@ def test_gpi2_to_sequence(platform: Platform):
     sequence = compile_circuit(circuit, platform)
     assert len(sequence.channels) == 1
 
-    rx90_seq = natives.single_qubit[0].RX.create_sequence(theta=np.pi / 2, phi=0.2)
+    rx90_seq = natives.single_qubit[0].RXY(theta=np.pi / 2, phi=0.2)
 
     np.testing.assert_allclose(sequence.duration, rx90_seq.duration)
     assert sequence == rx90_seq
@@ -157,8 +157,8 @@ def test_add_measurement_to_sequence(platform: Platform):
     assert len(list(sequence.channel(qubit.acquisition))) == 2  # include delay
 
     s = PulseSequence()
-    s.concatenate(natives.single_qubit[0].RX.create_sequence(theta=np.pi / 2, phi=0.1))
-    s.concatenate(natives.single_qubit[0].RX.create_sequence(theta=np.pi / 2, phi=0.2))
+    s.concatenate(natives.single_qubit[0].RXY(theta=np.pi / 2, phi=0.1))
+    s.concatenate(natives.single_qubit[0].RXY(theta=np.pi / 2, phi=0.2))
     s.append((qubit.acquisition, Delay(duration=s.duration)))
     s.concatenate(natives.single_qubit[0].MZ.create_sequence())
 

--- a/tests/test_compilers_default.py
+++ b/tests/test_compilers_default.py
@@ -99,7 +99,7 @@ def test_gpi_to_sequence(platform: Platform):
     sequence = compile_circuit(circuit, platform)
     assert len(sequence.channels) == 1
 
-    rx_seq = natives.single_qubit[0].RXY(phi=0.2)
+    rx_seq = natives.single_qubit[0].R(phi=0.2)
 
     np.testing.assert_allclose(sequence.duration, rx_seq.duration)
 
@@ -112,7 +112,7 @@ def test_gpi2_to_sequence(platform: Platform):
     sequence = compile_circuit(circuit, platform)
     assert len(sequence.channels) == 1
 
-    rx90_seq = natives.single_qubit[0].RXY(theta=np.pi / 2, phi=0.2)
+    rx90_seq = natives.single_qubit[0].R(theta=np.pi / 2, phi=0.2)
 
     np.testing.assert_allclose(sequence.duration, rx90_seq.duration)
     assert sequence == rx90_seq
@@ -157,8 +157,8 @@ def test_add_measurement_to_sequence(platform: Platform):
     assert len(list(sequence.channel(qubit.acquisition))) == 2  # include delay
 
     s = PulseSequence()
-    s.concatenate(natives.single_qubit[0].RXY(theta=np.pi / 2, phi=0.1))
-    s.concatenate(natives.single_qubit[0].RXY(theta=np.pi / 2, phi=0.2))
+    s.concatenate(natives.single_qubit[0].R(theta=np.pi / 2, phi=0.1))
+    s.concatenate(natives.single_qubit[0].R(theta=np.pi / 2, phi=0.2))
     s.append((qubit.acquisition, Delay(duration=s.duration)))
     s.concatenate(natives.single_qubit[0].MZ.create_sequence())
 

--- a/tests/test_native.py
+++ b/tests/test_native.py
@@ -1,18 +1,8 @@
-import contextlib
-
 import numpy as np
 import pytest
-from pydantic import TypeAdapter
 
-from qibolab._core.native import Native, RxyFactory, TwoQubitNatives
-from qibolab._core.pulses import (
-    Drag,
-    Exponential,
-    Gaussian,
-    GaussianSquare,
-    Pulse,
-    Rectangular,
-)
+from qibolab._core.native import Native, TwoQubitNatives, rxy
+from qibolab._core.pulses import Drag, Gaussian, Pulse, Rectangular
 from qibolab._core.sequence import PulseSequence
 
 
@@ -65,7 +55,7 @@ def test_fixed_sequence_factory():
         ({"phi": 7.5 * np.pi}, 1.0, 1.5 * np.pi),
     ],
 )
-def test_rxy_rotation_factory(args, amplitude, phase):
+def test_rxy(args, amplitude, phase):
     seq = PulseSequence(
         [
             (
@@ -74,10 +64,9 @@ def test_rxy_rotation_factory(args, amplitude, phase):
             )
         ]
     )
-    factory = RxyFactory(seq)
 
-    fseq1 = factory.create_sequence(**args)
-    fseq2 = factory.create_sequence(**args)
+    fseq1 = rxy(seq, **args)
+    fseq2 = rxy(seq, **args)
     assert fseq1 == fseq2
     np = "new/probe"
     fseq2.append((np, Pulse(duration=56, amplitude=0.43, envelope=Rectangular())))
@@ -86,66 +75,6 @@ def test_rxy_rotation_factory(args, amplitude, phase):
     pulse = next(iter(fseq1.channel("1/drive")))
     assert pulse.amplitude == pytest.approx(amplitude)
     assert pulse.relative_phase == pytest.approx(phase)
-
-
-def test_rxy_factory_multiple_channels():
-    seq = PulseSequence(
-        [
-            (
-                "1/drive",
-                Pulse(duration=40, amplitude=0.7, envelope=Gaussian(rel_sigma=5.0)),
-            ),
-            (
-                "2/drive",
-                Pulse(duration=30, amplitude=1.0, envelope=Gaussian(rel_sigma=3.0)),
-            ),
-        ]
-    )
-
-    with pytest.raises(ValueError, match="Incompatible number of channels"):
-        _ = RxyFactory(seq)
-
-
-def test_rxy_factory_multiple_pulses():
-    seq = PulseSequence(
-        [
-            (
-                "1/drive",
-                Pulse(duration=40, amplitude=0.08, envelope=Gaussian(rel_sigma=4.0)),
-            ),
-            (
-                "1/drive",
-                Pulse(duration=80, amplitude=0.76, envelope=Gaussian(rel_sigma=4.0)),
-            ),
-        ]
-    )
-
-    with pytest.raises(ValueError, match="Incompatible number of pulses"):
-        _ = RxyFactory(seq)
-
-
-@pytest.mark.parametrize(
-    "envelope",
-    [
-        Gaussian(rel_sigma=3.0),
-        GaussianSquare(rel_sigma=3.0, width=80),
-        Drag(rel_sigma=5.0, beta=-0.037),
-        Rectangular(),
-        Exponential(tau=0.7, upsilon=0.8),
-    ],
-)
-def test_rxy_rotation_factory_envelopes(envelope):
-    seq = PulseSequence(
-        [("1/drive", Pulse(duration=100, amplitude=1.0, envelope=envelope))]
-    )
-
-    if isinstance(envelope, (Gaussian, Drag)):
-        context = contextlib.nullcontext()
-    else:
-        context = pytest.raises(ValueError, match="Incompatible pulse envelope")
-
-    with context:
-        _ = TypeAdapter(RxyFactory).validate_python(seq)
 
 
 def test_two_qubit_natives_symmetric():

--- a/tests/test_native.py
+++ b/tests/test_native.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 from pydantic import TypeAdapter
 
-from qibolab._core.native import FixedSequenceFactory, RxyFactory, TwoQubitNatives
+from qibolab._core.native import Native, RxyFactory, TwoQubitNatives
 from qibolab._core.pulses import (
     Drag,
     Exponential,
@@ -29,7 +29,7 @@ def test_fixed_sequence_factory():
             ),
         ]
     )
-    factory = FixedSequenceFactory(seq)
+    factory = Native(seq)
 
     fseq1 = factory.create_sequence()
     fseq2 = factory.create_sequence()
@@ -150,41 +150,41 @@ def test_rxy_rotation_factory_envelopes(envelope):
 
 def test_two_qubit_natives_symmetric():
     natives = TwoQubitNatives(
-        CZ=FixedSequenceFactory(PulseSequence()),
-        CNOT=FixedSequenceFactory(PulseSequence()),
-        iSWAP=FixedSequenceFactory(PulseSequence()),
+        CZ=Native(PulseSequence()),
+        CNOT=Native(PulseSequence()),
+        iSWAP=Native(PulseSequence()),
     )
     assert natives.symmetric is False
 
     natives = TwoQubitNatives(
-        CZ=FixedSequenceFactory(PulseSequence()),
-        iSWAP=FixedSequenceFactory(PulseSequence()),
+        CZ=Native(PulseSequence()),
+        iSWAP=Native(PulseSequence()),
     )
     assert natives.symmetric is True
 
     natives = TwoQubitNatives(
-        CZ=FixedSequenceFactory(PulseSequence()),
+        CZ=Native(PulseSequence()),
     )
     assert natives.symmetric is True
 
     natives = TwoQubitNatives(
-        iSWAP=FixedSequenceFactory(PulseSequence()),
+        iSWAP=Native(PulseSequence()),
     )
     assert natives.symmetric is True
 
     natives = TwoQubitNatives(
-        CNOT=FixedSequenceFactory(PulseSequence()),
+        CNOT=Native(PulseSequence()),
     )
     assert natives.symmetric is False
 
     natives = TwoQubitNatives(
-        CZ=FixedSequenceFactory(PulseSequence()),
-        CNOT=FixedSequenceFactory(PulseSequence()),
+        CZ=Native(PulseSequence()),
+        CNOT=Native(PulseSequence()),
     )
     assert natives.symmetric is False
 
     natives = TwoQubitNatives(
-        CNOT=FixedSequenceFactory(PulseSequence()),
-        iSWAP=FixedSequenceFactory(PulseSequence()),
+        CNOT=Native(PulseSequence()),
+        iSWAP=Native(PulseSequence()),
     )
     assert natives.symmetric is False

--- a/tests/test_native.py
+++ b/tests/test_native.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from qibolab._core.native import Native, TwoQubitNatives, rxy
+from qibolab._core.native import Native, TwoQubitNatives, rotation
 from qibolab._core.pulses import Drag, Gaussian, Pulse, Rectangular
 from qibolab._core.sequence import PulseSequence
 
@@ -55,7 +55,7 @@ def test_fixed_sequence_factory():
         ({"phi": 7.5 * np.pi}, 1.0, 1.5 * np.pi),
     ],
 )
-def test_rxy(args, amplitude, phase):
+def test_rotation(args, amplitude, phase):
     seq = PulseSequence(
         [
             (
@@ -65,8 +65,8 @@ def test_rxy(args, amplitude, phase):
         ]
     )
 
-    fseq1 = rxy(seq, **args)
-    fseq2 = rxy(seq, **args)
+    fseq1 = rotation(seq, **args)
+    fseq2 = rotation(seq, **args)
     assert fseq1 == fseq2
     np = "new/probe"
     fseq2.append((np, Pulse(duration=56, amplitude=0.43, envelope=Rectangular())))

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -3,7 +3,7 @@ from typing import Literal
 import pytest
 
 from qibolab._core.components.configs import Config
-from qibolab._core.native import FixedSequenceFactory, TwoQubitNatives
+from qibolab._core.native import Native, TwoQubitNatives
 from qibolab._core.parameters import ConfigKinds, Parameters, TwoQubitContainer
 
 
@@ -13,12 +13,10 @@ def test_two_qubit_container():
     Swapped indexing is working (only with getitem, not other dict
     methods) if all the registered natives are symmetric.
     """
-    symmetric = TwoQubitContainer({(0, 1): TwoQubitNatives(CZ=FixedSequenceFactory())})
+    symmetric = TwoQubitContainer({(0, 1): TwoQubitNatives(CZ=Native())})
     assert symmetric[1, 0].CZ is not None
 
-    asymmetric = TwoQubitContainer(
-        {(0, 1): TwoQubitNatives(CNOT=FixedSequenceFactory())}
-    )
+    asymmetric = TwoQubitContainer({(0, 1): TwoQubitNatives(CNOT=Native())})
     with pytest.raises(KeyError):
         asymmetric[(1, 0)]
 


### PR DESCRIPTION
Unfortunately, the `RXY` name is non-standard, but I was lacking a better one.
Any suggestion? @stavros11 @andrea-pasquale 

- ~~restore some validation?~~