### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The qibolab backend documentation is available at [https://qibo.science/qibolab/
 A simple example on how to connect to a platform and use it execute a pulse sequence:
 
 ```python
-from qibolab import create_platform, ExecutionParameters
+from qibolab import create_platform
 
 # Define platform and load specific runcard
 platform = create_platform("my_platform")
@@ -38,8 +38,7 @@ sequence = natives.RX() | natives.MZ()
 platform.connect()
 
 # Execute a pulse sequence
-options = ExecutionParameters(nshots=1000)
-results = platform.execute([sequence], options)
+results = platform.execute([sequence], nshots=1000)
 
 # Print the acquired shots
 readout_id = sequence.acquisitions[0][1].id

--- a/README.md
+++ b/README.md
@@ -40,7 +40,11 @@ platform.connect()
 # Execute a pulse sequence
 results = platform.execute([sequence], nshots=1000)
 
-# Print the acquired shots
+# Grab the acquired shots corresponding to
+# the measurement using its pulse id.
+# The ``PulseSequence`` structure is list[tuple[ChannelId, Pulse]]
+# thererefore we need to index it appropriately
+# to get the acquisition pulse
 readout_id = sequence.acquisitions[0][1].id
 print(results[readout_id])
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -23,9 +23,9 @@ Key features
 ------------
 
 * Deploy Qibo models on quantum hardware easily.
-* Create custom experimental drivers for custom lab setup.
+* Create experimental drivers for custom lab setup.
 * Support multiple heterogeneous platforms.
-* Use existing calibration procedures for experimentalists.
+* Use calibration procedures from `Qibocal <https://github.com/qiboteam/qibocal>`_.
 
 How to Use the Documentation
 ============================

--- a/src/qibolab/_core/platform/platform.py
+++ b/src/qibolab/_core/platform/platform.py
@@ -171,14 +171,13 @@ class Platform:
     def connect(self):
         """Connect to all instruments."""
         if not self.is_connected:
-            for instrument in self.instruments.values():
+            for name, instrument in self.instruments.items():
                 try:
-                    log.info(f"Connecting to instrument {instrument}.")
                     instrument.connect()
                 except Exception as exception:
                     raise_error(
                         RuntimeError,
-                        f"Cannot establish connection to {instrument} instruments. Error captured: '{exception}'",
+                        f"Cannot establish connection to instrument {name}. Error captured: '{exception}'",
                     )
         self.is_connected = True
 


### PR DESCRIPTION
Close #1043. I also removed a `log` message from `platform.connect` because it would trigger very long output if the default dataclass (pydantic) representation is used for the instrument object (which has been overlooked mainly due to QM hiding the logger).

This should be ready, but maybe further changes will be needed if we do any last minute tweaks in the interface.