### PR TITLE
Fix some docstrings

### DIFF
--- a/doc/source/tutorials/instrument.rst
+++ b/doc/source/tutorials/instrument.rst
@@ -89,12 +89,12 @@ Let's see a minimal example:
 
     from proprietary_instruments import ControllerType, controller_driver
 
-    from qibolab.components import Config
-    from qibolab.execution_parameters import ExecutionParameters
-    from qibolab.identifier import Result
-    from qibolab.sequence import PulseSequence
-    from qibolab.sweeper import ParallelSweepers
-    from qibolab.instruments.abstract import Controller
+    from qibolab._core.components import Config
+    from qibolab._core.execution_parameters import ExecutionParameters
+    from qibolab._core.identifier import Result
+    from qibolab._core.sequence import PulseSequence
+    from qibolab._core.sweeper import ParallelSweepers
+    from qibolab._core.instruments.abstract import Controller
 
 
     class MyController(Controller):

--- a/src/qibolab/_core/backends.py
+++ b/src/qibolab/_core/backends.py
@@ -58,12 +58,12 @@ class QibolabBackend(NumpyBackend):
         """Assigning measurement outcomes to
         :class:`qibo.states.MeasurementResult` for each gate.
 
-        This allows properly obtaining the measured shots from the :class:`qibolab.pulses.ReadoutPulse` object obtaned after pulse sequence execution.
+        This allows properly obtaining the measured shots from the :class:`qibolab.Readout` object obtaned after pulse sequence execution.
 
         Args:
             measurement_map (dict): Map from each measurement gate to the sequence of
                 readout pulses implementing it.
-            readout (:class:`qibolab.pulses.ReadoutPulse`): Readout result object
+            readout (:class:`qibolab.Readout`): Readout result object
                 containing the readout measurement shots. This is created in ``execute_circuit``.
         """
         for gate, sequence in measurement_map.items():

--- a/src/qibolab/_core/compilers/compiler.py
+++ b/src/qibolab/_core/compilers/compiler.py
@@ -28,22 +28,10 @@ Rule = Callable[..., PulseSequence]
 class Compiler:
     """Compile native circuits into pulse sequences.
 
-    It transforms a :class:`qibo.models.Circuit` to a :class:`qibolab.pulses.PulseSequence`.
+    It transforms a :class:`qibo.models.Circuit` to a :class:`qibolab.PulseSequence`.
 
     The transformation is done using a dictionary of rules which map each Qibo gate to a
     pulse sequence and some virtual Z-phases.
-
-    A rule is a function that takes two argumens:
-        - gate (:class:`qibo.gates.abstract.Gate`): Gate object to be compiled.
-        - platform (:class:`qibolab.platforms.abstract.AbstractPlatform`): Platform object to read
-            native gate pulses from.
-
-    and returns:
-        - sequence (:class:`qibolab.pulses.PulseSequence`): Sequence of pulses that implement
-            the given gate.
-        - virtual_z_phases (dict): Dictionary mapping qubits to virtual Z-phases induced by the gate.
-
-    See :class:`qibolab.compilers.default` for an example of a compiler implementation.
     """
 
     rules: dict[type[gates.Gate], Rule] = field(default_factory=dict)
@@ -88,7 +76,7 @@ class Compiler:
 
         Args:
             gate (:class:`qibo.gates.Gate`): Qibo gate to convert to pulses.
-            platform (:class:`qibolab.platform.Platform`): Qibolab platform to read the native gates from.
+            platform (:class:`qibolab.Platform`): Qibolab platform to read the native gates from.
         """
         # get local sequence for the current gate
         rule = self.rules[type(gate)]
@@ -180,14 +168,12 @@ class Compiler:
         """Transform a circuit to pulse sequence.
 
         Args:
-            circuit (qibo.models.Circuit): Qibo circuit that respects the platform's
-                                           connectivity and native gates.
-            platform (qibolab.platforms.abstract.AbstractPlatform): Platform used
-                to load the native pulse representations.
+            circuit: Qibo circuit that respects the platform's connectivity and native gates.
+            platform: Platform used to load the native pulse representations.
 
         Returns:
-            sequence (qibolab.pulses.PulseSequence): Pulse sequence that implements the circuit.
-            measurement_map (dict): Map from each measurement gate to the sequence of  readout pulse implementing it.
+            sequence: Pulse sequence that implements the circuit.
+            measurement_map: Map from each measurement gate to the sequence of  readout pulse implementing it.
         """
         sequence = PulseSequence()
 

--- a/src/qibolab/_core/instruments/abstract.py
+++ b/src/qibolab/_core/instruments/abstract.py
@@ -75,7 +75,7 @@ class Controller(Instrument):
     ) -> dict[int, Result]:
         """Play a pulse sequence and retrieve feedback.
 
-        If :class:`qibolab.sweeper.Sweeper` objects are passed as arguments, they are
+        If :class:`qibolab.Sweeper` objects are passed as arguments, they are
         executed in real-time. If not possible, an error is raised.
 
         Returns a mapping with the id of the probe pulses used to acquired data.

--- a/src/qibolab/_core/instruments/qm/program/acquisition.py
+++ b/src/qibolab/_core/instruments/qm/program/acquisition.py
@@ -251,14 +251,8 @@ def create_acquisition(
     """Create container for the variables used for saving acquisition in the
     QUA program.
 
-    Args:
-        operation (str):
-        element (str):
-        options (:class:`qibolab.execution_parameters.ExecutionParameters`): Execution
-            options containing acquisition type and averaging mode.
-
     Returns:
-        :class:`qibolab.instruments.qm.acquisition.Acquisition` object containing acquisition variables.
+        ``Acquisition`` object containing acquisition variables.
     """
     average = options.averaging_mode is AveragingMode.CYCLIC
     kwargs = {}

--- a/src/qibolab/_core/pulses/pulse.py
+++ b/src/qibolab/_core/pulses/pulse.py
@@ -47,7 +47,10 @@ class Pulse(_PulseLike):
     Pulse amplitudes are normalised between -1 and 1.
     """
     envelope: Envelope
-    """The pulse envelope shape."""
+    """The pulse envelope shape.
+
+    See :class:`qibolab.Envelope` for list of available shapes.
+    """
     relative_phase: float = 0.0
     """Relative phase of the pulse, in radians."""
 

--- a/src/qibolab/_core/pulses/pulse.py
+++ b/src/qibolab/_core/pulses/pulse.py
@@ -47,11 +47,7 @@ class Pulse(_PulseLike):
     Pulse amplitudes are normalised between -1 and 1.
     """
     envelope: Envelope
-    """The pulse envelope shape.
-
-    See
-    :class:`qibolab.pulses.envelope.Envelopes` for list of available shapes.
-    """
+    """The pulse envelope shape."""
     relative_phase: float = 0.0
     """Relative phase of the pulse, in radians."""
 

--- a/src/qibolab/_core/sweeper.py
+++ b/src/qibolab/_core/sweeper.py
@@ -46,9 +46,9 @@ def _alternative_fields(a: _Field, b: _Field):
 class Sweeper(Model):
     """Data structure for Sweeper object.
 
-    This object is passed as an argument to the method :func:`qibolab.platforms.platform.Platform.execute`
+    This object is passed as an argument to the method :func:`qibolab.Platform.execute`
     which enables the user to sweep a specific parameter for one or more pulses. For information on how to
-    perform sweeps see :func:`qibolab.platforms.platform.Platform.execute`.
+    perform sweeps see :func:`qibolab.Platform.execute`.
 
     Example:
         .. testcode::
@@ -72,7 +72,7 @@ class Sweeper(Model):
         values: array of parameter values to sweep over.
         range: tuple of ``(start, stop, step)`` to sweep over the array ``np.arange(start, stop, step)``.
             Can be provided instead of ``values`` for more efficient sweeps on some instruments.
-        pulses : list of `qibolab.pulses.Pulse` to be swept.
+        pulses : list of `qibolab.Pulse` to be swept.
         channels: list of channel names for which the parameter should be swept.
     """
 

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -1,6 +1,3 @@
-"""Tests :class:`qibolab.platforms.multiqubit.MultiqubitPlatform` and
-:class:`qibolab.platforms.platform.DesignPlatform`."""
-
 import inspect
 import os
 import pathlib


### PR DESCRIPTION
While checking for `ExecutionParameters`, I found various leftovers, mainly in docstrings, which should have been updated to the new public API (and `_core` structure).