### PR TITLE
Parameters updater [extended syntax]

### DIFF
--- a/prototype.py
+++ b/prototype.py
@@ -1,0 +1,112 @@
+import re
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import Any, Union
+
+d = {
+    "a": [1, 2, 3],
+    "b": {
+        "c": [
+            {"d": 42},
+        ],
+    },
+}
+
+u = {
+    "b.c[0].d": 37,
+    "a[2]": 64,
+}
+
+Collection = Union[dict, list]
+Path = str
+Update = dict[Path, Any]
+
+
+@dataclass
+class Element:
+    key: int
+
+
+@dataclass
+class Attribute:
+    key: str
+
+
+Accessor = Union[Element, Attribute]
+
+
+class TokenKind(Enum):
+    BRACKET = r"[\[\]]"
+    DOT = r"\."
+    ID = r"\w+"
+
+    @classmethod
+    def regex(cls) -> str:
+        return "|".join(f"(?P<{var.name}>{var.value})" for var in cls)
+
+
+TOKEN_PATTERN = re.compile(TokenKind.regex())
+
+
+@dataclass
+class Token:
+    kind: TokenKind
+    value: str
+
+
+def tokenize(path: Path) -> list[Token]:
+    return [
+        Token(kind=TokenKind[m.lastgroup], value=m.group())
+        for m in TOKEN_PATTERN.finditer(path)
+    ]
+
+
+class State(Enum):
+    ATTRIBUTE = auto()
+    ELEMENT = auto()
+    CLOSE = auto()
+    RESET = auto()
+
+
+def parse(path: list[Token]) -> list[Accessor]:
+    accessors = []
+    state = State.ATTRIBUTE if path[0].kind is not TokenKind.BRACKET else State.RESET
+    for token in path:
+        if state in [State.ATTRIBUTE, State.ELEMENT]:
+            assert token.kind is TokenKind.ID
+            acc = (
+                Attribute(key=token.value)
+                if state is State.ATTRIBUTE
+                else Element(key=int(token.value))
+            )
+            accessors.append(acc)
+            state = State.RESET if state is State.ATTRIBUTE else State.CLOSE
+        elif state is State.RESET:
+            if token.kind is TokenKind.DOT:
+                state = State.ATTRIBUTE
+            elif token.kind is TokenKind.BRACKET:
+                state = State.ELEMENT
+            else:
+                assert False
+        elif state is State.CLOSE:
+            assert token.kind is TokenKind.BRACKET
+            state = State.RESET
+        else:
+            assert False
+    if state is not State.RESET:
+        assert False
+    return accessors
+
+
+def setvalue(d: Collection, path: Path, val: Any):
+    accessors = parse(tokenize(path))
+    current = d
+    for acc in accessors[:-1]:
+        current = current[acc.key]
+
+    current[accessors[-1].key] = val
+
+
+def update(d: Collection, up: Update):
+    for path, val in up.items():
+        setvalue(d, path, val)


### PR DESCRIPTION
While the specification was clear in my mind, and the update application as well, there was still a non-trivial problem to solve: how to process in a distinct way lists' and dictionaries' access operations. I.e. the only two compound types you may have in JSON.

In particular, thanks to the `__getitem__` (i.e. `collection[...]`) operation in Python being used by both dictionaries and lists, there are little differences between the two cases.
The only one is just that the access path will be a unique string, and it could be just `.`-separated, but then list indices have to be turned into integers.

In order to clarify the distinction between the two, I used the `[]` in the path syntax itself, favoring paths like `x.y[n].z`, instead of `x.y.n.z`.
To me, it seems clearer to write, but the price to pay is that you really need to parse paths. 

The easiest way to parse would have been writing a simple grammar, but this would have led to a dependency on a parser generator, or to find one that we could use at "compile time" (requiring one that doesn't need any runtime dependency as well), adding the need of some compilation step.
To keep it "simpler", I manually wrote the parser, but it seems that the easiest way is just going through the classical step: a regex-based lexer to tokenize the string, and then a state machine-based parser.

In the end, it works pretty well, but I acknowledge is a good chunk of code. The alternative is just to rely on the collections being generated from some objects, that yields that all dictionary keys have to be valid Python identifiers. And thus they could be distinguished from lists' indices, since indices will always start by digit, and keys will never.
So, I could make the parser terribly simpler, just by using the `x.y.n.z` syntax, splitting on `.`, and parsing just indices (i.e. I could even just try `int()` on all of them, and append successful conversions' results, or original values for failing conversions).

I tried to explore the `x.y[n].z` syntax, and we have a solution for that. But we also have a solution for the other.
Now, it's just a matter to decide if the more pleasant syntax is worth the code required (we may be able to optimize it a bit, but I believe we can not make it as simple as the uniform syntax, since a parsing step would be truly required).