### PR TITLE
Support for QM OPX1000 in 0.2

### DIFF
--- a/src/qibolab/_core/instruments/qm/components/configs.py
+++ b/src/qibolab/_core/instruments/qm/components/configs.py
@@ -9,7 +9,6 @@ __all__ = [
     "QmAcquisitionConfig",
     "QmConfigs",
     "OctaveOscillatorConfig",
-    "OctaveOutputModes",
 ]
 
 OctaveOutputModes = Literal[

--- a/src/qibolab/_core/instruments/qm/components/configs.py
+++ b/src/qibolab/_core/instruments/qm/components/configs.py
@@ -2,9 +2,19 @@ from typing import Literal, Union
 
 from pydantic import Field
 
-from qibolab._core.components import AcquisitionConfig, DcConfig
+from qibolab._core.components import AcquisitionConfig, DcConfig, OscillatorConfig
 
-__all__ = ["OpxOutputConfig", "QmAcquisitionConfig", "QmConfigs"]
+__all__ = [
+    "OpxOutputConfig",
+    "QmAcquisitionConfig",
+    "QmConfigs",
+    "OctaveOscillatorConfig",
+    "OctaveOutputModes",
+]
+
+OctaveOutputModes = Literal[
+    "always_on", "always_off", "triggered", "triggered_reversed"
+]
 
 
 class OpxOutputConfig(DcConfig):
@@ -28,6 +38,14 @@ class OpxOutputConfig(DcConfig):
     output_mode: Literal["direct", "amplified"] = "direct"
 
 
+class OctaveOscillatorConfig(OscillatorConfig):
+    """Oscillator confing that allows switching the output mode."""
+
+    kind: Literal["octave-oscillator"] = "octave-oscillator"
+
+    output_mode: OctaveOutputModes = "triggered"
+
+
 class QmAcquisitionConfig(AcquisitionConfig):
     """Acquisition config for QM OPX+."""
 
@@ -42,4 +60,4 @@ class QmAcquisitionConfig(AcquisitionConfig):
     """Constant voltage to be applied on the input."""
 
 
-QmConfigs = Union[OpxOutputConfig, QmAcquisitionConfig]
+QmConfigs = Union[OpxOutputConfig, OctaveOscillatorConfig, QmAcquisitionConfig]

--- a/src/qibolab/_core/instruments/qm/components/configs.py
+++ b/src/qibolab/_core/instruments/qm/components/configs.py
@@ -25,6 +25,7 @@ class OpxOutputConfig(DcConfig):
     for more details.
     Changing the filters affects the calibration of single shot discrimination (threshold and angle).
     """
+    output_mode: Literal["direct", "amplified"] = "direct"
 
 
 class QmAcquisitionConfig(AcquisitionConfig):

--- a/src/qibolab/_core/instruments/qm/config/__init__.py
+++ b/src/qibolab/_core/instruments/qm/config/__init__.py
@@ -1,3 +1,3 @@
 from .config import Configuration
-from .devices import ControllerId
+from .devices import ControllerId, ModuleTypes
 from .pulses import SAMPLING_RATE, operation

--- a/src/qibolab/_core/instruments/qm/config/__init__.py
+++ b/src/qibolab/_core/instruments/qm/config/__init__.py
@@ -1,2 +1,3 @@
 from .config import Configuration
+from .devices import ControllerId
 from .pulses import SAMPLING_RATE, operation

--- a/src/qibolab/_core/instruments/qm/config/config.py
+++ b/src/qibolab/_core/instruments/qm/config/config.py
@@ -17,6 +17,7 @@ from .devices import (
     Controller,
     ControllerId,
     Controllers,
+    FemAnalogOutput,
     Octave,
     OctaveInput,
     OctaveOutput,
@@ -74,7 +75,12 @@ class Configuration:
         self, id: ChannelId, channel: DcChannel, config: OpxOutputConfig
     ):
         controller = self.controllers[channel.device]
-        controller.analog_outputs[channel.port] = AnalogOutput.from_config(config)
+        if controller.type == "opx1":
+            controller.analog_outputs[channel.port] = AnalogOutput.from_config(config)
+        else:
+            controller.analog_outputs[channel.port] = FemAnalogOutput.from_config(
+                config
+            )
         self.elements[id] = DcElement.from_channel(channel)
 
     def configure_iq_line(

--- a/src/qibolab/_core/instruments/qm/config/config.py
+++ b/src/qibolab/_core/instruments/qm/config/config.py
@@ -18,6 +18,7 @@ from .devices import (
     ControllerId,
     Controllers,
     FemAnalogOutput,
+    ModuleTypes,
     Octave,
     OctaveInput,
     OctaveOutput,
@@ -62,13 +63,15 @@ class Configuration:
     integration_weights: dict = field(default_factory=dict)
     mixers: dict = field(default_factory=dict)
 
-    def add_controller(self, device: ControllerId):
+    def add_controller(self, device: ControllerId, modules: dict[str, ModuleTypes]):
         if device not in self.controllers:
-            self.controllers[device] = Controller()
+            self.controllers[device] = Controller(type=modules[device])
 
-    def add_octave(self, device: str, connectivity: ControllerId):
+    def add_octave(
+        self, device: str, connectivity: ControllerId, modules: dict[str, ModuleTypes]
+    ):
         if device not in self.octaves:
-            self.add_controller(connectivity)
+            self.add_controller(connectivity, modules)
             self.octaves[device] = Octave(connectivity)
 
     def configure_dc_line(

--- a/src/qibolab/_core/instruments/qm/config/config.py
+++ b/src/qibolab/_core/instruments/qm/config/config.py
@@ -12,7 +12,15 @@ from qibolab._core.identifier import ChannelId
 from qibolab._core.pulses import Pulse, Readout
 
 from ..components import OpxOutputConfig, QmAcquisitionConfig
-from .devices import AnalogOutput, Controller, Octave, OctaveInput, OctaveOutput
+from .devices import (
+    AnalogOutput,
+    Controller,
+    ControllerId,
+    Controllers,
+    Octave,
+    OctaveInput,
+    OctaveOutput,
+)
 from .elements import AcquireOctaveElement, DcElement, Element, RfOctaveElement
 from .pulses import (
     QmAcquisition,
@@ -42,7 +50,7 @@ class Configuration:
     """
 
     version: int = 1
-    controllers: dict[str, Controller] = field(default_factory=dict)
+    controllers: Controllers = field(default_factory=Controllers)
     octaves: dict[str, Octave] = field(default_factory=dict)
     elements: dict[str, Element] = field(default_factory=dict)
     pulses: dict[str, Union[QmPulse, QmAcquisition]] = field(default_factory=dict)
@@ -53,11 +61,11 @@ class Configuration:
     integration_weights: dict = field(default_factory=dict)
     mixers: dict = field(default_factory=dict)
 
-    def add_controller(self, device: str):
+    def add_controller(self, device: ControllerId):
         if device not in self.controllers:
             self.controllers[device] = Controller()
 
-    def add_octave(self, device: str, connectivity: str):
+    def add_octave(self, device: str, connectivity: ControllerId):
         if device not in self.octaves:
             self.add_controller(connectivity)
             self.octaves[device] = Octave(connectivity)

--- a/src/qibolab/_core/instruments/qm/config/config.py
+++ b/src/qibolab/_core/instruments/qm/config/config.py
@@ -133,7 +133,11 @@ class Configuration:
         )
 
     def register_waveforms(
-        self, pulse: Pulse, element: Optional[str] = None, dc: bool = False
+        self,
+        pulse: Pulse,
+        max_voltage: float,
+        element: Optional[str] = None,
+        dc: bool = False,
     ):
         if dc:
             qmpulse = QmPulse.from_dc_pulse(pulse)
@@ -142,7 +146,7 @@ class Configuration:
                 qmpulse = QmPulse.from_pulse(pulse)
             else:
                 qmpulse = QmAcquisition.from_pulse(pulse, element)
-        waveforms = waveforms_from_pulse(pulse)
+        waveforms = waveforms_from_pulse(pulse, max_voltage)
         if dc:
             self.waveforms[qmpulse.waveforms["single"]] = waveforms["I"]
         else:
@@ -150,26 +154,30 @@ class Configuration:
                 self.waveforms[getattr(qmpulse.waveforms, mode)] = waveforms[mode]
         return qmpulse
 
-    def register_iq_pulse(self, element: str, pulse: Pulse):
+    def register_iq_pulse(self, element: str, pulse: Pulse, max_voltage: float):
         op = operation(pulse)
         if op not in self.pulses:
-            self.pulses[op] = self.register_waveforms(pulse)
+            self.pulses[op] = self.register_waveforms(pulse, max_voltage)
         self.elements[element].operations[op] = op
         return op
 
-    def register_dc_pulse(self, element: str, pulse: Pulse):
+    def register_dc_pulse(self, element: str, pulse: Pulse, max_voltage: float):
         op = operation(pulse)
         if op not in self.pulses:
-            self.pulses[op] = self.register_waveforms(pulse, dc=True)
+            self.pulses[op] = self.register_waveforms(pulse, max_voltage, dc=True)
         self.elements[element].operations[op] = op
         return op
 
-    def register_acquisition_pulse(self, element: str, readout: Readout):
+    def register_acquisition_pulse(
+        self, element: str, readout: Readout, max_voltage: float
+    ):
         """Registers pulse, waveforms and integration weights in QM config."""
         op = operation(readout)
         acquisition = f"{op}_{element}"
         if acquisition not in self.pulses:
-            self.pulses[acquisition] = self.register_waveforms(readout.probe, element)
+            self.pulses[acquisition] = self.register_waveforms(
+                readout.probe, max_voltage, element
+            )
         self.elements[element].operations[op] = acquisition
         return op
 

--- a/src/qibolab/_core/instruments/qm/config/devices.py
+++ b/src/qibolab/_core/instruments/qm/config/devices.py
@@ -12,6 +12,7 @@ from ..components import (
 
 __all__ = [
     "AnalogOutput",
+    "FemAnalogOutput",
     "OctaveOutput",
     "OctaveInput",
     "Controller",
@@ -46,6 +47,14 @@ class PortDict(Generic[V], dict[str, V]):
 class AnalogOutput:
     offset: float = 0.0
     filter: dict[str, float] = field(default_factory=dict)
+
+    @classmethod
+    def from_config(cls, config: OpxOutputConfig):
+        return cls(offset=config.offset, filter=config.filter)
+
+
+@dataclass(frozen=True)
+class FemAnalogOutput(AnalogOutput):
     output_mode: Literal["direct", "amplified"] = "direct"
 
     @classmethod

--- a/src/qibolab/_core/instruments/qm/config/devices.py
+++ b/src/qibolab/_core/instruments/qm/config/devices.py
@@ -19,7 +19,7 @@ __all__ = [
 ]
 
 
-DEFAULT_INPUTS = {"1": {}, "2": {}}
+DEFAULT_INPUTS = {"1": {"offset": 0}, "2": {"offset": 0}}
 """Default controller config section.
 
 Inputs are always registered to avoid issues with automatic mixer
@@ -103,9 +103,9 @@ class Controller:
     """https://docs.quantum-machines.co/latest/docs/Introduction/config/?h=opx10#controllers"""
     analog_outputs: PortDict[dict[str, AnalogOutput]] = field(default_factory=PortDict)
     digital_outputs: PortDict[dict[str, dict]] = field(default_factory=PortDict)
-    analog_inputs: PortDict[dict[str, AnalogInput]] = field(default_factory=PortDict)
-    # default_factory=lambda: PortDict(DEFAULT_INPUTS)
-    # )
+    analog_inputs: PortDict[dict[str, AnalogInput]] = field(
+        default_factory=lambda: PortDict(DEFAULT_INPUTS)
+    )
 
     def add_octave_output(self, port: int):
         # TODO: Add offset here?

--- a/src/qibolab/_core/instruments/qm/config/devices.py
+++ b/src/qibolab/_core/instruments/qm/config/devices.py
@@ -3,12 +3,8 @@ from typing import Generic, Literal, TypeVar, Union
 
 from qibolab._core.components import OscillatorConfig
 
-from ..components import (
-    OctaveOscillatorConfig,
-    OctaveOutputModes,
-    OpxOutputConfig,
-    QmAcquisitionConfig,
-)
+from ..components import OctaveOscillatorConfig, OpxOutputConfig, QmAcquisitionConfig
+from ..components.configs import OctaveOutputModes
 
 __all__ = [
     "AnalogOutput",

--- a/src/qibolab/_core/instruments/qm/config/devices.py
+++ b/src/qibolab/_core/instruments/qm/config/devices.py
@@ -41,10 +41,13 @@ class PortDict(Generic[V], dict[str, V]):
 class AnalogOutput:
     offset: float = 0.0
     filter: dict[str, float] = field(default_factory=dict)
+    output_mode: Literal["direct", "amplified"] = "direct"
 
     @classmethod
     def from_config(cls, config: OpxOutputConfig):
-        return cls(offset=config.offset, filter=config.filter)
+        return cls(
+            offset=config.offset, filter=config.filter, output_mode=config.output_mode
+        )
 
 
 @dataclass(frozen=True)

--- a/src/qibolab/_core/instruments/qm/config/devices.py
+++ b/src/qibolab/_core/instruments/qm/config/devices.py
@@ -3,7 +3,12 @@ from typing import Generic, Literal, TypeVar, Union
 
 from qibolab._core.components import OscillatorConfig
 
-from ..components import OpxOutputConfig, QmAcquisitionConfig
+from ..components import (
+    OctaveOscillatorConfig,
+    OctaveOutputModes,
+    OpxOutputConfig,
+    QmAcquisitionConfig,
+)
 
 __all__ = [
     "AnalogOutput",
@@ -65,13 +70,14 @@ class OctaveOutput:
     LO_frequency: int
     gain: int = 0
     LO_source: Literal["internal", "external"] = "internal"
-    output_mode: Literal[
-        "always_on", "always_off", "triggered", "triggered_reversed"
-    ] = "triggered"
+    output_mode: OctaveOutputModes = "triggered"
 
     @classmethod
-    def from_config(cls, config: OscillatorConfig):
-        return cls(LO_frequency=config.frequency, gain=config.power)
+    def from_config(cls, config: Union[OscillatorConfig, OctaveOscillatorConfig]):
+        kwargs = dict(LO_frequency=config.frequency, gain=config.power)
+        if isinstance(config, OctaveOscillatorConfig):
+            kwargs["output_mode"] = config.output_mode
+        return cls(**kwargs)
 
 
 @dataclass(frozen=True)

--- a/src/qibolab/_core/instruments/qm/config/elements.py
+++ b/src/qibolab/_core/instruments/qm/config/elements.py
@@ -1,15 +1,16 @@
 from dataclasses import dataclass, field
-from typing import Literal, Union
+from typing import Union
+
+from typing_extensions import TypedDict
 
 from qibolab._core.components import Channel
 
 __all__ = ["DcElement", "RfOctaveElement", "AcquireOctaveElement", "Element"]
 
 
-StandardInOutType = tuple[str, int]
-FemInOutType = tuple[str, int, int]
-InOutType = Union[StandardInOutType, FemInOutType]
-Port = Literal["port"]
+InOutType = Union[tuple[str, int], tuple[str, int, int]]
+OctavePort = TypedDict("OpxPlusPort", {"port": tuple[str, int]})
+Port = TypedDict("Port", {"port": InOutType})
 ConnectivityType = Union[str, tuple[str, int]]
 
 
@@ -26,7 +27,7 @@ class OutputSwitch:
     """
 
 
-def _to_port(channel: Channel) -> dict[Port, InOutType]:
+def _to_port(channel: Channel) -> Port:
     """Convert a channel to the port dictionary required for the QUA config.
 
     The following syntax is assumed for ``channel.device``:
@@ -52,7 +53,7 @@ def output_switch(connectivity: ConnectivityType, port: int):
 
 @dataclass
 class DcElement:
-    singleInput: dict[Port, InOutType]
+    singleInput: Port
     intermediate_frequency: int = 0
     operations: dict[str, str] = field(default_factory=dict)
 
@@ -61,10 +62,13 @@ class DcElement:
         return cls(_to_port(channel))
 
 
+DigitalInputs = TypedDict("digitalInputs", {"output_switch": OutputSwitch})
+
+
 @dataclass
 class RfOctaveElement:
-    RF_inputs: dict[Port, StandardInOutType]
-    digitalInputs: dict[Literal["output_switch"], OutputSwitch]
+    RF_inputs: OctavePort
+    digitalInputs: DigitalInputs
     intermediate_frequency: int
     operations: dict[str, str] = field(default_factory=dict)
 
@@ -84,9 +88,9 @@ class RfOctaveElement:
 
 @dataclass
 class AcquireOctaveElement:
-    RF_inputs: dict[Port, StandardInOutType]
-    RF_outputs: dict[Port, StandardInOutType]
-    digitalInputs: dict[Literal["output_switch"], OutputSwitch]
+    RF_inputs: OctavePort
+    RF_outputs: OctavePort
+    digitalInputs: DigitalInputs
     intermediate_frequency: int
     time_of_flight: int = 24
     smearing: int = 0

--- a/src/qibolab/_core/instruments/qm/config/elements.py
+++ b/src/qibolab/_core/instruments/qm/config/elements.py
@@ -1,8 +1,6 @@
 from dataclasses import dataclass, field
 from typing import Literal, Union
 
-import numpy as np
-
 from qibolab._core.components import Channel
 
 __all__ = ["DcElement", "RfOctaveElement", "AcquireOctaveElement", "Element"]
@@ -12,26 +10,6 @@ StandardInOutType = tuple[str, int]
 FemInOutType = tuple[str, int, int]
 InOutType = Union[StandardInOutType, FemInOutType]
 Port = Literal["port"]
-
-
-def iq_imbalance(g, phi):
-    """Create the correction matrix for the mixer imbalance.
-
-    Mixer imbalance is caused by the gain and phase imbalances.
-
-    More information here:
-    https://docs.qualang.io/libs/examples/mixer-calibration/#non-ideal-mixer
-
-    Args:
-        g (float): relative gain imbalance between the I & Q ports (unit-less).
-            Set to 0 for no gain imbalance.
-        phi (float): relative phase imbalance between the I & Q ports (radians).
-            Set to 0 for no phase imbalance.
-    """
-    c = np.cos(phi)
-    s = np.sin(phi)
-    N = 1 / ((1 - g**2) * (2 * c**2 - 1))
-    return [float(N * x) for x in [(1 - g) * c, (1 + g) * s, (1 - g) * s, (1 + g) * c]]
 
 
 @dataclass(frozen=True)

--- a/src/qibolab/_core/instruments/qm/config/elements.py
+++ b/src/qibolab/_core/instruments/qm/config/elements.py
@@ -10,6 +10,7 @@ StandardInOutType = tuple[str, int]
 FemInOutType = tuple[str, int, int]
 InOutType = Union[StandardInOutType, FemInOutType]
 Port = Literal["port"]
+ConnectivityType = Union[str, tuple[str, int]]
 
 
 @dataclass(frozen=True)
@@ -40,9 +41,13 @@ def _to_port(channel: Channel) -> dict[Port, InOutType]:
     return {"port": port}
 
 
-def output_switch(opx: str, port: int):
+def output_switch(connectivity: ConnectivityType, port: int):
     """Create output switch section."""
-    return {"output_switch": OutputSwitch((opx, 2 * port - 1))}
+    if isinstance(connectivity, tuple):
+        args = connectivity + (2 * port - 1,)
+    else:
+        args = (connectivity, 2 * port - 1)
+    return {"output_switch": OutputSwitch(args)}
 
 
 @dataclass
@@ -65,7 +70,10 @@ class RfOctaveElement:
 
     @classmethod
     def from_channel(
-        cls, channel: Channel, connectivity: str, intermediate_frequency: int
+        cls,
+        channel: Channel,
+        connectivity: ConnectivityType,
+        intermediate_frequency: int,
     ):
         return cls(
             _to_port(channel),
@@ -89,7 +97,7 @@ class AcquireOctaveElement:
         cls,
         probe_channel: Channel,
         acquire_channel: Channel,
-        connectivity: str,
+        connectivity: ConnectivityType,
         intermediate_frequency: int,
         time_of_flight: int,
         smearing: int,

--- a/src/qibolab/_core/instruments/qm/controller.py
+++ b/src/qibolab/_core/instruments/qm/controller.py
@@ -229,7 +229,6 @@ class QmController(Controller):
         self._reset_temporary_calibration()
         if self.manager is not None:
             self.manager.close_all_quantum_machines()
-            self.manager.close()
             self.manager = None
 
     def configure_device(self, device: str):

--- a/src/qibolab/_core/instruments/qm/controller.py
+++ b/src/qibolab/_core/instruments/qm/controller.py
@@ -30,7 +30,7 @@ from qibolab._core.sweeper import ParallelSweepers, Parameter, Sweeper
 from qibolab._core.unrolling import Bounds, unroll_sequences
 
 from .components import OpxOutputConfig, QmAcquisitionConfig
-from .config import SAMPLING_RATE, Configuration
+from .config import SAMPLING_RATE, Configuration, ControllerId
 from .program import ExecutionArguments, create_acquisition, program
 from .program.sweepers import find_lo_frequencies, sweeper_amplitude
 
@@ -54,7 +54,7 @@ class Octave:
     """Name of the device."""
     port: int
     """Network port of the Octave in the cluster configuration."""
-    connectivity: str
+    connectivity: ControllerId
     """OPXplus that acts as the waveform generator for the Octave."""
 
 

--- a/src/qibolab/_core/instruments/qm/controller.py
+++ b/src/qibolab/_core/instruments/qm/controller.py
@@ -460,9 +460,11 @@ class QmController(Controller):
 
         # register DC elements so that all qubits are
         # sweetspot even when they are not used
+        offsets = []
         for id, channel in self.channels.items():
             if isinstance(channel, DcChannel):
                 self.configure_channel(id, configs)
+                offsets.append((id, configs[id].offset))
 
         probe_map = self.configure_channels(configs, sequence.channels)
         self.register_pulses(configs, sequence)
@@ -470,7 +472,7 @@ class QmController(Controller):
 
         args = ExecutionArguments(sequence, acquisitions, options.relaxation_time)
         self.preprocess_sweeps(sweepers, configs, args, probe_map)
-        experiment = program(args, options, sweepers)
+        experiment = program(args, options, sweepers, offsets)
 
         if self.script_file_name is not None:
             script_config = (

--- a/src/qibolab/_core/instruments/qm/program/acquisition.py
+++ b/src/qibolab/_core/instruments/qm/program/acquisition.py
@@ -56,6 +56,7 @@ class Acquisition(ABC):
     @property
     def name(self):
         """Identifier to download results from the instruments."""
+        # FIXME: QUA 1.2.1a2 and OPX1000 don't like `/` character in stream processing ``save``
         return f"{self.operation}_{self.element}".replace("/", "|")
 
     @property

--- a/src/qibolab/_core/instruments/qm/program/acquisition.py
+++ b/src/qibolab/_core/instruments/qm/program/acquisition.py
@@ -56,7 +56,7 @@ class Acquisition(ABC):
     @property
     def name(self):
         """Identifier to download results from the instruments."""
-        return f"{self.operation}_{self.element}"
+        return f"{self.operation}_{self.element}".replace("/", "|")
 
     @property
     def npulses(self):

--- a/src/qibolab/_core/instruments/qm/program/arguments.py
+++ b/src/qibolab/_core/instruments/qm/program/arguments.py
@@ -27,6 +27,7 @@ class Parameters:
 
     element: Optional[str] = None
     lo_frequency: Optional[int] = None
+    max_offset: float = 0.5
 
 
 @dataclass

--- a/src/qibolab/_core/instruments/qm/program/instructions.py
+++ b/src/qibolab/_core/instruments/qm/program/instructions.py
@@ -175,7 +175,7 @@ def program(
 ):
     """QUA program implementing the required experiment."""
     with qua.program() as experiment:
-        # force offset setting due to a bug in newer QUA versions and the OPX1000
+        # FIXME: force offset setting due to a bug in QUA 1.2.1a2 and OPX1000
         for channel_id, offset in offsets:
             qua.set_dc_offset(channel_id, "single", offset)
 

--- a/src/qibolab/_core/instruments/qm/program/instructions.py
+++ b/src/qibolab/_core/instruments/qm/program/instructions.py
@@ -5,6 +5,7 @@ from qm.qua import declare, fixed, for_
 from qualang_tools.loops import from_array
 
 from qibolab._core.execution_parameters import AcquisitionType, ExecutionParameters
+from qibolab._core.identifier import ChannelId
 from qibolab._core.pulses import Align, Delay, Pulse, Readout, VirtualZ
 from qibolab._core.sweeper import ParallelSweepers, Parameter, Sweeper
 
@@ -170,9 +171,14 @@ def program(
     args: ExecutionArguments,
     options: ExecutionParameters,
     sweepers: list[ParallelSweepers],
+    offsets: list[tuple[ChannelId, float]],
 ):
     """QUA program implementing the required experiment."""
     with qua.program() as experiment:
+        # force offset setting due to a bug in newer QUA versions and the OPX1000
+        for channel_id, offset in offsets:
+            qua.set_dc_offset(channel_id, "single", offset)
+
         n = declare(int)
         # declare acquisition variables
         for acquisition in args.acquisitions.values():

--- a/src/qibolab/_core/instruments/qm/program/sweepers.py
+++ b/src/qibolab/_core/instruments/qm/program/sweepers.py
@@ -9,8 +9,6 @@ from qibolab._core.sweeper import Parameter
 
 from .arguments import ExecutionArguments, Parameters
 
-MAX_OFFSET = 0.5
-"""Maximum voltage supported by Quantum Machines OPX+ instrument in volts."""
 MAX_AMPLITUDE_FACTOR = 1.99
 """Maximum multiplication factor for ``qua.amp`` used when sweeping amplitude.
 
@@ -105,10 +103,10 @@ def _duration_interpolated(variable: _Variable, parameters: Parameters):
 
 
 def _offset(variable: _Variable, parameters: Parameters):
-    with qua.if_(variable >= MAX_OFFSET):
-        qua.set_dc_offset(parameters.element, "single", MAX_OFFSET)
-    with qua.elif_(variable <= -MAX_OFFSET):
-        qua.set_dc_offset(parameters.element, "single", -MAX_OFFSET)
+    with qua.if_(variable >= parameters.max_offset):
+        qua.set_dc_offset(parameters.element, "single", parameters.max_offset)
+    with qua.elif_(variable <= -parameters.max_offset):
+        qua.set_dc_offset(parameters.element, "single", -parameters.max_offset)
     with qua.else_():
         qua.set_dc_offset(parameters.element, "single", variable)
 


### PR DESCRIPTION
Ports #1045 to qibolab 0.2.

TODO:
- [x] Force offset set in program
- [x] Support amplified mode and expose via configs
- [x] Expose Octave LO output mode to configs (to switch between `triggered` and `always_on`)
- [x] Test on hardware