### PR TITLE
Add properties in QibolabBackend

### DIFF
--- a/src/qibolab/_core/backends.py
+++ b/src/qibolab/_core/backends.py
@@ -48,6 +48,29 @@ class QibolabBackend(NumpyBackend):
         }
         self.compiler = Compiler.default()
 
+    @property
+    def qubits(self) -> list[str | int]:
+        return list(self.platform.qubits.keys())
+
+    @property
+    def connectivity(self) -> list[tuple[str | int, str | int]]:
+        return self.platform.pairs
+
+    @property
+    def natives(self) -> list[str]:
+        native_gates = set()
+        for _, natives_s in self.platform.natives.single_qubit.items():
+            native_gates |= {k for k, v in natives_s.__dict__.items() if v is not None}
+        
+        for _, natives_c in self.platform.natives.coupler.items():
+            native_gates |= {k for k, v in natives_c.__dict__.items() if v is not None}
+
+        for _, natives_t in self.platform.natives.two_qubit.items():
+            native_gates |= {k for k, v in natives_t.__dict__.items() if v is not None}
+
+        return list(native_gates)
+
+
     def apply_gate(self, gate, state, nqubits):  # pragma: no cover
         raise_error(NotImplementedError, "Qibolab cannot apply gates directly.")
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -24,6 +24,21 @@ def connected_backend(connected_platform):
     yield QibolabBackend(connected_platform)
 
 
+def test_qubits():
+    backend = QibolabBackend("dummy")
+    assert isinstance(backend.qubits, list)
+    assert set(backend.qubits) == set([0, 1, 2, 3, 4])
+
+def test_connectivity():
+    backend = QibolabBackend("dummy")
+    assert isinstance(backend.connectivity, list)
+    assert set(backend.connectivity) == set([(0, 2), (1, 2), (2, 3), (2, 4)])
+
+def test_natives():
+    backend = QibolabBackend("dummy")
+    assert isinstance(backend.natives, list)
+    assert set(backend.natives) == set(['RX12', 'RX', 'CZ', 'iSWAP', 'MZ', 'CP', 'CNOT'])
+
 def test_execute_circuit_initial_state():
     backend = QibolabBackend("dummy")
     circuit = Circuit(1)


### PR DESCRIPTION
Qibo needs `qubits`, `connectivity`, and `natives` to create a default transpiler.

https://github.com/qiboteam/qibo/blob/731b8a126edfd64a7ae76b0ab2a7bb002ae119ab/src/qibo/backends/abstract.py#L32-L48

(An additional update will be done shortly to enable `int | str` qubit names. Currently, only `str` in the `_Global` update.)

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.

