### PR TITLE
Add properties in QibolabBackend

### DIFF
--- a/src/qibolab/backends.py
+++ b/src/qibolab/backends.py
@@ -62,20 +62,6 @@ class QibolabBackend(NumpyBackend):
         """Returns the list of connected qubits."""
         return list(self.platform.pairs)
 
-    # @property
-    # def natives(self) -> list[str]:
-    #     """Returns the list of native gates supported by the platform."""
-    #     compiler = Compiler.default()
-    #     natives = [g.__name__ for g in list(compiler.rules)]
-
-    #     check_2q = ["CZ", "CNOT"]
-    #     for gate in check_2q:
-    #         if gate in natives and any(
-    #             not self._is_gate_calibrated(getattr(gates, gate)(*pair), compiler)
-    #             for pair in self.connectivity
-    #         ):
-    #             natives.remove(gate)
-    #     return natives
     @property
     def natives(self) -> list[str]:
         """Returns the list of native gates supported by the platform."""

--- a/src/qibolab/backends.py
+++ b/src/qibolab/backends.py
@@ -1,4 +1,5 @@
 from collections import deque
+from dataclasses import fields
 from typing import Union
 
 import numpy as np
@@ -63,11 +64,18 @@ class QibolabBackend(NumpyBackend):
     def natives(self) -> list[str]:
         native_gates = set()
         for _, q in self.platform.qubits.items():
-            native_gates |= {k for k, v in asdict(q.native_gates).items() if v is not None}
-        
-        for _, p in self.platform.pairs.items():
-            native_gates |= {k for k, v in p.native_gates.__dict__.items() if v is not None}
+            native_gates |= {
+                fld.name
+                for fld in fields(q.native_gates)
+                if getattr(q.native_gates, fld.name) is not None
+            }
 
+        for _, p in self.platform.pairs.items():
+            native_gates |= {
+                fld.name
+                for fld in fields(p.native_gates)
+                if getattr(p.native_gates, fld.name) is not None
+            }
         return list(native_gates)
 
     def apply_gate(self, gate, state, nqubits):  # pragma: no cover

--- a/src/qibolab/backends.py
+++ b/src/qibolab/backends.py
@@ -73,7 +73,7 @@ class QibolabBackend(NumpyBackend):
                 cz = gates.CZ(*pair)
                 cnot = gates.CNOT(*pair)
 
-                if not self._is_gate_calibrated(cz, compiler):
+                if not self._is_gate_calibrated(cz, compiler):  # pragma: no cover
                     natives.remove("CZ")
                     break
 

--- a/src/qibolab/backends.py
+++ b/src/qibolab/backends.py
@@ -13,6 +13,7 @@ from qibolab.execution_parameters import ExecutionParameters
 from qibolab.platform import Platform, create_platform
 from qibolab.platform.load import available_platforms
 from qibolab.version import __version__ as qibolab_version
+from qibolab.qubits import QubitId, QubitPairId
 
 
 def execute_qasm(circuit: str, platform, initial_state=None, nshots=1000):
@@ -52,12 +53,12 @@ class QibolabBackend(NumpyBackend):
         self.compiler = Compiler.default()
 
     @property
-    def qubits(self) -> list[Union[str, int]]:
+    def qubits(self) -> list[QubitId]:
         """Returns the qubits in the platform."""
         return list(self.platform.qubits)
 
     @property
-    def connectivity(self) -> list[tuple[Union[str, int], Union[str, int]]]:
+    def connectivity(self) -> list[QubitPairId]:
         """Returns the list of connected qubits."""
         return list(self.platform.pairs)
 

--- a/src/qibolab/backends.py
+++ b/src/qibolab/backends.py
@@ -63,7 +63,7 @@ class QibolabBackend(NumpyBackend):
     def natives(self) -> list[str]:
         native_gates = set()
         for _, q in self.platform.qubits.items():
-            native_gates |= {k for k, v in q.native_gates.__dict__.items() if v is not None}
+            native_gates |= {k for k, v in asdict(q.native_gates).items() if v is not None}
         
         for _, p in self.platform.pairs.items():
             native_gates |= {k for k, v in p.native_gates.__dict__.items() if v is not None}

--- a/src/qibolab/backends.py
+++ b/src/qibolab/backends.py
@@ -1,4 +1,5 @@
 from collections import deque
+from typing import Union
 
 import numpy as np
 from qibo import __version__ as qibo_version
@@ -51,11 +52,11 @@ class QibolabBackend(NumpyBackend):
         self.compiler = Compiler.default()
 
     @property
-    def qubits(self) -> list[str | int]:
+    def qubits(self) -> list[Union[str, int]]:
         return list(self.platform.qubits.keys())
 
     @property
-    def connectivity(self) -> list[tuple[str | int, str | int]]:
+    def connectivity(self) -> list[tuple[Union[str, int], Union[str, int]]]:
         return list(self.platform.pairs)
 
     @property

--- a/src/qibolab/backends.py
+++ b/src/qibolab/backends.py
@@ -1,5 +1,4 @@
 from collections import deque
-from typing import Union
 
 import numpy as np
 from qibo import __version__ as qibo_version
@@ -12,8 +11,8 @@ from qibolab.compilers import Compiler
 from qibolab.execution_parameters import ExecutionParameters
 from qibolab.platform import Platform, create_platform
 from qibolab.platform.load import available_platforms
-from qibolab.version import __version__ as qibolab_version
 from qibolab.qubits import QubitId, QubitPairId
+from qibolab.version import __version__ as qibolab_version
 
 
 def execute_qasm(circuit: str, platform, initial_state=None, nshots=1000):

--- a/src/qibolab/backends.py
+++ b/src/qibolab/backends.py
@@ -53,7 +53,7 @@ class QibolabBackend(NumpyBackend):
 
     @property
     def qubits(self) -> list[Union[str, int]]:
-        return list(self.platform.qubits.keys())
+        return list(self.platform.qubits)
 
     @property
     def connectivity(self) -> list[tuple[Union[str, int], Union[str, int]]]:

--- a/src/qibolab/backends.py
+++ b/src/qibolab/backends.py
@@ -76,7 +76,25 @@ class QibolabBackend(NumpyBackend):
                 for fld in fields(p.native_gates)
                 if getattr(p.native_gates, fld.name) is not None
             }
-        return list(native_gates)
+
+        return self._rename_gates(list(native_gates))
+
+    def _rename_gates(self, natives: list[str]):
+        gates = []
+        for native in natives:
+            if native == "RX12":
+                pass
+            elif native == "RX":
+                gates.append("RX")
+            elif native == "CZ":
+                gates.append("CZ")
+            elif native == "iSWAP":
+                gates.append("iSWAP")
+            elif native == "MZ":
+                gates.append("M")
+            elif native == "CNOT":
+                gates.append("CNOT")
+        return gates
 
     def apply_gate(self, gate, state, nqubits):  # pragma: no cover
         raise_error(NotImplementedError, "Qibolab cannot apply gates directly.")

--- a/src/qibolab/backends.py
+++ b/src/qibolab/backends.py
@@ -60,7 +60,7 @@ class QibolabBackend(NumpyBackend):
         return list(self.platform.pairs)
 
     @property
-    def natives(self) -> list[str]:    
+    def natives(self) -> list[str]:
         native_gates = set()
         for _, q in self.platform.qubits.items():
             native_gates |= {k for k, v in q.native_gates.__dict__.items() if v is not None}

--- a/src/qibolab/backends.py
+++ b/src/qibolab/backends.py
@@ -50,6 +50,25 @@ class QibolabBackend(NumpyBackend):
         }
         self.compiler = Compiler.default()
 
+    @property
+    def qubits(self) -> list[str | int]:
+        return list(self.platform.qubits.keys())
+
+    @property
+    def connectivity(self) -> list[tuple[str | int, str | int]]:
+        return list(self.platform.pairs)
+
+    @property
+    def natives(self) -> list[str]:    
+        native_gates = set()
+        for _, q in self.platform.qubits.items():
+            native_gates |= {k for k, v in q.native_gates.__dict__.items() if v is not None}
+        
+        for _, p in self.platform.pairs.items():
+            native_gates |= {k for k, v in p.native_gates.__dict__.items() if v is not None}
+
+        return list(native_gates)
+
     def apply_gate(self, gate, state, nqubits):  # pragma: no cover
         raise_error(NotImplementedError, "Qibolab cannot apply gates directly.")
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -22,6 +22,20 @@ def generate_circuit_with_gate(nqubits, gate, **kwargs):
 def connected_backend(connected_platform):
     yield QibolabBackend(connected_platform)
 
+def test_qubits():
+    backend = QibolabBackend("dummy")
+    assert isinstance(backend.qubits, list)
+    assert set(backend.qubits) == set([0, 1, 2, 3, 4])
+
+def test_connectivity():
+    backend = QibolabBackend("dummy")
+    assert isinstance(backend.connectivity, list)
+    assert set(backend.connectivity) == set([(0, 2), (2, 0), (1, 2), (2, 1), (2, 3), (3, 2), (2, 4), (4, 2)])
+
+def test_natives():
+    backend = QibolabBackend("dummy")
+    assert isinstance(backend.natives, list)
+    assert set(backend.natives) == set(['RX12', 'RX', 'CZ', 'iSWAP', 'MZ', 'CNOT'])
 
 def test_execute_circuit_initial_state():
     backend = QibolabBackend("dummy")

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -47,18 +47,16 @@ def test_connectivity():
 def test_natives():
     backend = QibolabBackend("dummy")
     assert isinstance(backend.natives, list)
-    assert set(backend.natives) == {"RX", "CZ", "iSWAP", "M", "CNOT"}
-
-
-def test_rename_gates():
-    backend = QibolabBackend("dummy")
-    assert backend._rename_gates(["RX12", "RX", "CZ", "iSWAP", "MZ", "CNOT"]) == [
-        "RX",
+    assert set(backend.natives) == {
+        "I",
+        "Z",
+        "RZ",
+        "U3",
         "CZ",
-        "iSWAP",
+        "GPI2",
+        "GPI",
         "M",
-        "CNOT",
-    ]
+    }
 
 
 def test_execute_circuit_initial_state():

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -22,20 +22,44 @@ def generate_circuit_with_gate(nqubits, gate, **kwargs):
 def connected_backend(connected_platform):
     yield QibolabBackend(connected_platform)
 
+
 def test_qubits():
     backend = QibolabBackend("dummy")
     assert isinstance(backend.qubits, list)
-    assert set(backend.qubits) == set([0, 1, 2, 3, 4])
+    assert set(backend.qubits) == {0, 1, 2, 3, 4}
+
 
 def test_connectivity():
     backend = QibolabBackend("dummy")
     assert isinstance(backend.connectivity, list)
-    assert set(backend.connectivity) == set([(0, 2), (2, 0), (1, 2), (2, 1), (2, 3), (3, 2), (2, 4), (4, 2)])
+    assert set(backend.connectivity) == {
+        (0, 2),
+        (2, 0),
+        (1, 2),
+        (2, 1),
+        (2, 3),
+        (3, 2),
+        (2, 4),
+        (4, 2),
+    }
+
 
 def test_natives():
     backend = QibolabBackend("dummy")
     assert isinstance(backend.natives, list)
-    assert set(backend.natives) == set(['RX12', 'RX', 'CZ', 'iSWAP', 'MZ', 'CNOT'])
+    assert set(backend.natives) == {"RX", "CZ", "iSWAP", "M", "CNOT"}
+
+
+def test_rename_gates():
+    backend = QibolabBackend("dummy")
+    assert backend._rename_gates(["RX12", "RX", "CZ", "iSWAP", "MZ", "CNOT"]) == [
+        "RX",
+        "CZ",
+        "iSWAP",
+        "M",
+        "CNOT",
+    ]
+
 
 def test_execute_circuit_initial_state():
     backend = QibolabBackend("dummy")

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -72,9 +72,9 @@ def test_natives_no_cz_cnot():
         "GPI",
         "M",
         "CZ",
-        "CNOT"
+        "CNOT",
     }
-    
+
     for gate in ["CZ", "CNOT"]:
         for p in platform.pairs:
             setattr(platform.pairs[p].native_gates, gate, None)

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -62,10 +62,6 @@ def test_natives():
 
 def test_natives_no_cz_cnot():
     platform = create_platform("dummy")
-    for p in platform.pairs:
-        platform.pairs[p].native_gates.CZ = None
-        platform.pairs[p].native_gates.CNOT = None
-
     backend = QibolabBackend(platform)
     assert set(backend.natives) == {
         "I",
@@ -75,7 +71,14 @@ def test_natives_no_cz_cnot():
         "GPI2",
         "GPI",
         "M",
+        "CZ",
+        "CNOT"
     }
+    
+    for gate in ["CZ", "CNOT"]:
+        for p in platform.pairs:
+            setattr(platform.pairs[p].native_gates, gate, None)
+        assert gate not in set(backend.natives)
 
 
 def test_execute_circuit_initial_state():

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -53,6 +53,7 @@ def test_natives():
         "RZ",
         "U3",
         "CZ",
+        "CNOT",
         "GPI2",
         "GPI",
         "M",

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -60,6 +60,24 @@ def test_natives():
     }
 
 
+def test_natives_no_cz_cnot():
+    platform = create_platform("dummy")
+    for p in platform.pairs:
+        platform.pairs[p].native_gates.CZ = None
+        platform.pairs[p].native_gates.CNOT = None
+
+    backend = QibolabBackend(platform)
+    assert set(backend.natives) == {
+        "I",
+        "Z",
+        "RZ",
+        "U3",
+        "GPI2",
+        "GPI",
+        "M",
+    }
+
+
 def test_execute_circuit_initial_state():
     backend = QibolabBackend("dummy")
     circuit = Circuit(1)


### PR DESCRIPTION
Qibo needs `qubits`, `connectivity`, and `natives` to create a default transpiler.

https://github.com/qiboteam/qibo/blob/65bdfee7f5d30eb1b18cb31e54a28bac5bfd2e1a/src/qibo/backends/abstract.py#L32-L50


For `native_gates`, I returned all the native gates that can be executed on at least one case... (couplers are excluded) Please let me know if there is a better approach.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
