### PR TITLE
Handle integer pulse duration in QM

### DIFF
--- a/src/qibolab/_core/instruments/qm/controller.py
+++ b/src/qibolab/_core/instruments/qm/controller.py
@@ -331,7 +331,9 @@ class QmController(Controller):
             acquisitions (dict): Map from measurement instructions to acquisition objects.
         """
         for id, pulse in sequence:
-            if hasattr(pulse, "duration") and not pulse.duration.is_integer():
+            if hasattr(pulse, "duration") and not (
+                isinstance(pulse.duration, int) or pulse.duration.is_integer()
+            ):
                 raise ValueError(
                     f"Quantum Machines cannot play pulse with duration {pulse.duration}. "
                     "Only integer duration in ns is supported."


### PR DESCRIPTION
@alecandido I believe we had this discussion before releasing 0.2 and we were expecting that `int` (not `float`) durations will be captured by pydantic, however this does not seem to be the case. This issue appears in some qibocal routines that allow to change pulse durations (eg. qubit spectroscopy), so I am using
```py
pulse = pulse.model_copy(update={"duration": 1000})
```
in the routine and there it seems that I am able to pass `int`s, which then cause the driver to fail. In these cases, the duration is read from the qibocal action runcard, so another fix is to just use floats there (1000.0 instead of 1000). However that's a bit annoying and I wouldn't expect every user to do it, that's why the proposed fix here.