### PR TITLE
Use of `wire_names`

### DIFF
--- a/doc/source/tutorials/compiler.rst
+++ b/doc/source/tutorials/compiler.rst
@@ -80,11 +80,10 @@ The following example shows how to modify the compiler in order to execute a cir
 
 
     # define a compiler rule that translates X to the pi-pulse
-    def x_rule(gate, platform):
+    def x_rule(qubits_ids, platform, parameters=None):
         """X gate applied with a single pi-pulse."""
-        qubit = gate.target_qubits[0]
         sequence = PulseSequence()
-        sequence.add(platform.create_RX_pulse(qubit, start=0))
+        sequence.add(platform.create_RX_pulse(qubits_ids[1][0], start=0))
         return sequence, {}
 
 

--- a/src/qibolab/backends.py
+++ b/src/qibolab/backends.py
@@ -127,8 +127,8 @@ class QibolabBackend(NumpyBackend):
 
         # This should be done in qibo side
         # Temporary fix: overwrite the wire names
-        if not all(q in circuit.wire_names for q in self.qubits):
-            circuit._wire_names = self.qubits
+        if not all(q in self.qubits for q in circuit.wire_names):
+            circuit._wire_names = self.qubits[: circuit.nqubits]
 
         sequence, measurement_map = self.compiler.compile(circuit, self.platform)
 
@@ -175,8 +175,8 @@ class QibolabBackend(NumpyBackend):
         # This should be done in qibo side
         # Temporary fix: overwrite the wire names
         for circuit in circuits:
-            if not all(q in circuit.wire_names for q in self.qubits):
-                circuit._wire_names = self.qubits
+            if not all(q in self.qubits for q in circuit.wire_names):
+                circuit._wire_names = self.qubits[: circuit.nqubits]
 
         # TODO: Maybe these loops can be parallelized
         sequences, measurement_maps = zip(

--- a/src/qibolab/backends.py
+++ b/src/qibolab/backends.py
@@ -125,6 +125,18 @@ class QibolabBackend(NumpyBackend):
                 "Hardware backend only supports circuits as initial states.",
             )
 
+        if not all(q in circuit.wire_names for q in self.platform.qubits):
+            # This should be done in qibo side
+            # raise_error(
+            #     ValueError,
+            #     "Circuit qubits do not match the platform qubits.",
+            # )
+
+            # Temporary fix: overwrite the wire names
+            circuit._wire_names = self.qubits
+
+        self.platform.wire_names = circuit.wire_names
+
         sequence, measurement_map = self.compiler.compile(circuit, self.platform)
 
         if not self.platform.is_connected:

--- a/src/qibolab/backends.py
+++ b/src/qibolab/backends.py
@@ -125,14 +125,9 @@ class QibolabBackend(NumpyBackend):
                 "Hardware backend only supports circuits as initial states.",
             )
 
+        # This should be done in qibo side
+        # Temporary fix: overwrite the wire names
         if not all(q in circuit.wire_names for q in self.platform.qubits):
-            # This should be done in qibo side
-            # raise_error(
-            #     ValueError,
-            #     "Circuit qubits do not match the platform qubits.",
-            # )
-
-            # Temporary fix: overwrite the wire names
             circuit._wire_names = self.qubits
 
         self.platform.wire_names = circuit.wire_names
@@ -178,6 +173,12 @@ class QibolabBackend(NumpyBackend):
                 ValueError,
                 "Hardware backend only supports circuits as initial states.",
             )
+
+        # This should be done in qibo side
+        # Temporary fix: overwrite the wire names
+        for circuit in circuits:
+            if not all(q in circuit.wire_names for q in self.platform.qubits):
+                circuit._wire_names = self.qubits
 
         # TODO: Maybe these loops can be parallelized
         sequences, measurement_maps = zip(

--- a/src/qibolab/backends.py
+++ b/src/qibolab/backends.py
@@ -127,7 +127,7 @@ class QibolabBackend(NumpyBackend):
 
         # This should be done in qibo side
         # Temporary fix: overwrite the wire names
-        if not all(q in circuit.wire_names for q in self.platform.qubits):
+        if not all(q in circuit.wire_names for q in self.qubits):
             circuit._wire_names = self.qubits
 
         sequence, measurement_map = self.compiler.compile(circuit, self.platform)
@@ -175,7 +175,7 @@ class QibolabBackend(NumpyBackend):
         # This should be done in qibo side
         # Temporary fix: overwrite the wire names
         for circuit in circuits:
-            if not all(q in circuit.wire_names for q in self.platform.qubits):
+            if not all(q in circuit.wire_names for q in self.qubits):
                 circuit._wire_names = self.qubits
 
         # TODO: Maybe these loops can be parallelized

--- a/src/qibolab/backends.py
+++ b/src/qibolab/backends.py
@@ -130,8 +130,6 @@ class QibolabBackend(NumpyBackend):
         if not all(q in circuit.wire_names for q in self.platform.qubits):
             circuit._wire_names = self.qubits
 
-        self.platform.wire_names = circuit.wire_names
-
         sequence, measurement_map = self.compiler.compile(circuit, self.platform)
 
         if not self.platform.is_connected:

--- a/src/qibolab/compilers/compiler.py
+++ b/src/qibolab/compilers/compiler.py
@@ -99,12 +99,24 @@ class Compiler:
         return inner
 
     def _compile_gate(
-        self, gate, platform, sequence, virtual_z_phases, moment_start, delays
+        self,
+        gate,
+        platform,
+        sequence,
+        virtual_z_phases,
+        moment_start,
+        delays,
+        wire_names,
     ):
         """Adds a single gate to the pulse sequence."""
         rule = self[gate.__class__]
+
         # get local sequence and phases for the current gate
-        gate_sequence, gate_phases = rule(gate, platform)
+        qubits_ids = (
+            [wire_names[qubit] for qubit in gate.control_qubits],
+            [wire_names[qubit] for qubit in gate.target_qubits],
+        )
+        gate_sequence, gate_phases = rule(qubits_ids, platform, gate.parameters)
 
         # update global pulse sequence
         # determine the right start time based on the availability of the qubits involved
@@ -154,7 +166,13 @@ class Compiler:
                         delays[qubit] += gate.delay
                     continue
                 gate_sequence, gate_phases = self._compile_gate(
-                    gate, platform, sequence, virtual_z_phases, moment_start, delays
+                    gate,
+                    platform,
+                    sequence,
+                    virtual_z_phases,
+                    moment_start,
+                    delays,
+                    circuit.wire_names,
                 )
                 for qubit in gate.qubits:
                     delays[qubit] = 0

--- a/src/qibolab/compilers/default.py
+++ b/src/qibolab/compilers/default.py
@@ -85,21 +85,18 @@ def cz_rule(gate, platform):
     Applying the CZ gate may involve sending pulses on qubits that the
     gate is not directly acting on.
     """
-    qubits = tuple(platform.get_qubit(q) for q in gate.qubits)
-    return platform.create_CZ_pulse_sequence(qubits)
+    return platform.create_CZ_pulse_sequence(gate.qubits)
 
 
 def cnot_rule(gate, platform):
     """CNOT applied as defined in the platform runcard."""
-    qubits = tuple(platform.get_qubit(q) for q in gate.qubits)
-    return platform.create_CNOT_pulse_sequence(qubits)
+    return platform.create_CNOT_pulse_sequence(gate.qubits)
 
 
 def measurement_rule(gate, platform):
     """Measurement gate applied using the platform readout pulse."""
     sequence = PulseSequence()
     for qubit in gate.target_qubits:
-        qubit = platform.get_qubit(qubit)
         MZ_pulse = platform.create_MZ_pulse(qubit, start=0)
         sequence.add(MZ_pulse)
     return sequence, {}

--- a/src/qibolab/compilers/default.py
+++ b/src/qibolab/compilers/default.py
@@ -8,52 +8,48 @@ import math
 from qibolab.pulses import PulseSequence
 
 
-def identity_rule(gate, platform):
+def identity_rule(qubits_ids, platform, parameters=None):
     """Identity gate skipped."""
     return PulseSequence(), {}
 
 
-def z_rule(gate, platform):
+def z_rule(qubits_ids, platform, parameters=None):
     """Z gate applied virtually."""
-    qubit = platform.get_qubit(gate.target_qubits[0])
-    return PulseSequence(), {qubit: math.pi}
+    return PulseSequence(), {qubits_ids[1][0]: math.pi}
 
 
-def rz_rule(gate, platform):
+def rz_rule(qubits_ids, platform, parameters=None):
     """RZ gate applied virtually."""
-    qubit = platform.get_qubit(gate.target_qubits[0])
-    return PulseSequence(), {qubit: -gate.parameters[0]}
+    return PulseSequence(), {qubits_ids[1][0]: -parameters[0]}
 
 
-def gpi2_rule(gate, platform):
+def gpi2_rule(qubits_ids, platform, parameters=None):
     """Rule for GPI2."""
-    qubit = platform.get_qubit(gate.target_qubits[0])
-    theta = gate.parameters[0]
+    theta = parameters[0]
     sequence = PulseSequence()
-    pulse = platform.create_RX90_pulse(qubit, start=0, relative_phase=theta)
+    pulse = platform.create_RX90_pulse(qubits_ids[1][0], start=0, relative_phase=theta)
     sequence.add(pulse)
     return sequence, {}
 
 
-def gpi_rule(gate, platform):
+def gpi_rule(qubits_ids, platform, parameters=None):
     """Rule for GPI."""
-    qubit = platform.get_qubit(gate.target_qubits[0])
-    theta = gate.parameters[0]
+    theta = parameters[0]
     sequence = PulseSequence()
     # the following definition has a global phase difference compare to
     # to the matrix representation. See
     # https://github.com/qiboteam/qibolab/pull/804#pullrequestreview-1890205509
     # for more detail.
-    pulse = platform.create_RX_pulse(qubit, start=0, relative_phase=theta)
+    pulse = platform.create_RX_pulse(qubits_ids[1][0], start=0, relative_phase=theta)
     sequence.add(pulse)
     return sequence, {}
 
 
-def u3_rule(gate, platform):
+def u3_rule(qubits_ids, platform, parameters=None):
     """U3 applied as RZ-RX90-RZ-RX90-RZ."""
-    qubit = platform.get_qubit(gate.target_qubits[0])
+    qubit = qubits_ids[1][0]
     # Transform gate to U3 and add pi/2-pulses
-    theta, phi, lam = gate.parameters
+    theta, phi, lam = parameters
     # apply RZ(lam)
     virtual_z_phases = {qubit: lam}
     sequence = PulseSequence()
@@ -79,24 +75,26 @@ def u3_rule(gate, platform):
     return sequence, virtual_z_phases
 
 
-def cz_rule(gate, platform):
+def cz_rule(qubits_ids, platform, parameters=None):
     """CZ applied as defined in the platform runcard.
 
     Applying the CZ gate may involve sending pulses on qubits that the
     gate is not directly acting on.
     """
-    return platform.create_CZ_pulse_sequence(gate.qubits)
+    qubits = qubits_ids[0] + qubits_ids[1]
+    return platform.create_CZ_pulse_sequence(qubits)
 
 
-def cnot_rule(gate, platform):
+def cnot_rule(qubits_ids, platform, parameters=None):
     """CNOT applied as defined in the platform runcard."""
-    return platform.create_CNOT_pulse_sequence(gate.qubits)
+    qubits = qubits_ids[0] + qubits_ids[1]
+    return platform.create_CNOT_pulse_sequence(qubits)
 
 
-def measurement_rule(gate, platform):
+def measurement_rule(qubits_ids, platform, parameters=None):
     """Measurement gate applied using the platform readout pulse."""
     sequence = PulseSequence()
-    for qubit in gate.target_qubits:
+    for qubit in qubits_ids[1]:
         MZ_pulse = platform.create_MZ_pulse(qubit, start=0)
         sequence.add(MZ_pulse)
     return sequence, {}

--- a/src/qibolab/compilers/default.py
+++ b/src/qibolab/compilers/default.py
@@ -15,19 +15,19 @@ def identity_rule(gate, platform):
 
 def z_rule(gate, platform):
     """Z gate applied virtually."""
-    qubit = list(platform.qubits)[gate.target_qubits[0]]
+    qubit = platform.get_qubit(gate.target_qubits[0])
     return PulseSequence(), {qubit: math.pi}
 
 
 def rz_rule(gate, platform):
     """RZ gate applied virtually."""
-    qubit = list(platform.qubits)[gate.target_qubits[0]]
+    qubit = platform.get_qubit(gate.target_qubits[0])
     return PulseSequence(), {qubit: -gate.parameters[0]}
 
 
 def gpi2_rule(gate, platform):
     """Rule for GPI2."""
-    qubit = list(platform.qubits)[gate.target_qubits[0]]
+    qubit = platform.get_qubit(gate.target_qubits[0])
     theta = gate.parameters[0]
     sequence = PulseSequence()
     pulse = platform.create_RX90_pulse(qubit, start=0, relative_phase=theta)
@@ -37,7 +37,7 @@ def gpi2_rule(gate, platform):
 
 def gpi_rule(gate, platform):
     """Rule for GPI."""
-    qubit = list(platform.qubits)[gate.target_qubits[0]]
+    qubit = platform.get_qubit(gate.target_qubits[0])
     theta = gate.parameters[0]
     sequence = PulseSequence()
     # the following definition has a global phase difference compare to
@@ -51,7 +51,7 @@ def gpi_rule(gate, platform):
 
 def u3_rule(gate, platform):
     """U3 applied as RZ-RX90-RZ-RX90-RZ."""
-    qubit = list(platform.qubits)[gate.target_qubits[0]]
+    qubit = platform.get_qubit(gate.target_qubits[0])
     # Transform gate to U3 and add pi/2-pulses
     theta, phi, lam = gate.parameters
     # apply RZ(lam)
@@ -85,18 +85,21 @@ def cz_rule(gate, platform):
     Applying the CZ gate may involve sending pulses on qubits that the
     gate is not directly acting on.
     """
-    return platform.create_CZ_pulse_sequence(gate.qubits)
+    qubits = tuple(platform.get_qubit(q) for q in gate.qubits)
+    return platform.create_CZ_pulse_sequence(qubits)
 
 
 def cnot_rule(gate, platform):
     """CNOT applied as defined in the platform runcard."""
-    return platform.create_CNOT_pulse_sequence(gate.qubits)
+    qubits = tuple(platform.get_qubit(q) for q in gate.qubits)
+    return platform.create_CNOT_pulse_sequence(qubits)
 
 
 def measurement_rule(gate, platform):
     """Measurement gate applied using the platform readout pulse."""
     sequence = PulseSequence()
     for qubit in gate.target_qubits:
+        qubit = platform.get_qubit(qubit)
         MZ_pulse = platform.create_MZ_pulse(qubit, start=0)
         sequence.add(MZ_pulse)
     return sequence, {}

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -63,10 +63,6 @@ def test_natives():
 
 def test_natives_no_cz_cnot():
     platform = create_platform("dummy")
-    for p in platform.pairs:
-        platform.pairs[p].native_gates.CZ = None
-        platform.pairs[p].native_gates.CNOT = None
-
     backend = QibolabBackend(platform)
     assert set(backend.natives) == {
         "I",
@@ -76,7 +72,14 @@ def test_natives_no_cz_cnot():
         "GPI2",
         "GPI",
         "M",
+        "CZ",
+        "CNOT",
     }
+
+    for gate in ["CZ", "CNOT"]:
+        for p in platform.pairs:
+            setattr(platform.pairs[p].native_gates, gate, None)
+        assert gate not in set(backend.natives)
 
 
 def test_execute_circuit_initial_state():

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -63,6 +63,10 @@ def test_natives():
 
 def test_natives_no_cz_cnot():
     platform = create_platform("dummy")
+    for p in platform.pairs:
+        platform.pairs[p].native_gates.CZ = None
+        platform.pairs[p].native_gates.CNOT = None
+
     backend = QibolabBackend(platform)
     assert set(backend.natives) == {
         "I",
@@ -72,14 +76,7 @@ def test_natives_no_cz_cnot():
         "GPI2",
         "GPI",
         "M",
-        "CZ",
-        "CNOT",
     }
-
-    for gate in ["CZ", "CNOT"]:
-        for p in platform.pairs:
-            setattr(platform.pairs[p].native_gates, gate, None)
-        assert gate not in set(backend.natives)
 
 
 def test_execute_circuit_initial_state():

--- a/tests/test_compilers_default.py
+++ b/tests/test_compilers_default.py
@@ -32,6 +32,8 @@ def test_u3_sim_agreement():
 def compile_circuit(circuit, platform):
     """Compile a circuit to a pulse sequence."""
     compiler = Compiler.default()
+    # Temporary fix: overwrite the wire names
+    circuit._wire_names = list(platform.qubits)
     sequence, _ = compiler.compile(circuit, platform)
     return sequence
 


### PR DESCRIPTION
This covers issue #1073.

### Updates

- `circuit.wire_names` is copied to `Platform.wire_names` each time `execute_circuit(circuit, ...)` is run.
- In `get_qubit(qubit)`, when `qubit` is an integer, it returns the corresponding physical qubit name from `wire_names`.
- In some rules, `get_qubit()` is used to retrieve `QubitId`.
- Test files is updated.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
