### PR TITLE
Fix compiler pushing /measurement/ pulses to later time

### DIFF
--- a/src/qibolab/compilers/compiler.py
+++ b/src/qibolab/compilers/compiler.py
@@ -104,7 +104,6 @@ class Compiler:
         platform,
         sequence,
         virtual_z_phases,
-        moment_start,
         delays,
         wire_names,
     ):
@@ -120,13 +119,12 @@ class Compiler:
 
         # update global pulse sequence
         # determine the right start time based on the availability of the qubits involved
-        all_qubits = {*gate_sequence.qubits, *gate.qubits}
+        all_qubits = {*gate_sequence.qubits, *gate.qubits, *gate_phases.keys()}
         start = max(
-            *[
+            [
                 sequence.get_qubit_pulses(qubit).finish + delays[qubit]
                 for qubit in all_qubits
-            ],
-            moment_start,
+            ]
         )
         # shift start time and phase according to the global sequence
         for pulse in gate_sequence:
@@ -159,7 +157,6 @@ class Compiler:
         # process circuit gates
         delays = defaultdict(int)
         for moment in circuit.queue.moments:
-            moment_start = sequence.finish
             for gate in set(filter(lambda x: x is not None, moment)):
                 if isinstance(gate, gates.Align):
                     for qubit in gate.qubits:
@@ -170,7 +167,6 @@ class Compiler:
                     platform,
                     sequence,
                     virtual_z_phases,
-                    moment_start,
                     delays,
                     circuit.wire_names,
                 )

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -1,0 +1,59 @@
+import numpy as np
+import pytest
+from qibo import Circuit, gates
+
+from qibolab import create_platform
+from qibolab.compilers.compiler import Compiler
+
+
+@pytest.fixture
+def dummy():
+    return create_platform("dummy")
+
+
+@pytest.fixture
+def dummy_couplers():
+    return create_platform("dummy_couplers")
+
+
+@pytest.fixture
+def compiler():
+    return Compiler.default()
+
+
+def test_measurement_timings(dummy, compiler):
+    q0, q1 = 0, 1
+    circ = Circuit(2)
+    circ.add(gates.GPI2(q0, phi=0.0))
+    circ.add(gates.GPI2(q1, phi=np.pi / 2))
+    circ.add(gates.GPI2(q1, phi=np.pi))
+    
+    # put measurement in different moments
+    circ.add(gates.M(q0))
+    circ.add(gates.M(q1))
+    
+    # make sure they are in different moments before proceeding
+    assert not any([len([gate for gate in m if isinstance(gate, gates.M)]) == 2 for m in circ.queue.moments])
+    
+    circ._wire_names = [q0, q1]
+    sequence, _ = compiler.compile(circ, dummy)
+    
+    MEASUREMENT_DURATION = 2000
+    for pulse in sequence.ro_pulses:
+        # assert that measurements don't happen one after another
+        assert not pulse.start >= MEASUREMENT_DURATION
+    
+
+def test_coupler_pulse_timing(dummy_couplers, compiler):
+    q0, q1, q2 = 0, 1, 2
+    circ = Circuit(3)
+    circ.add(gates.GPI2(q0, phi=0.0))
+    circ.add(gates.GPI2(q0, phi=np.pi))
+    circ.add(gates.GPI2(q1, phi=0.0))
+    circ.add(gates.CZ(q1, q2))
+    
+    circ._wire_names = [q0, q1, q2]
+    sequence, _ = compiler.compile(circ, dummy_couplers)
+    
+    coupler_pulse = sequence.cf_pulses[0]
+    assert coupler_pulse.start == 40


### PR DESCRIPTION
Consider the following circuit:

```
q0: ─GPI2─M──────
q1: ─GPI2─GPI2─M─
```

The current compiler will compile this to:

```
DrivePulse(0, 40, 0.05, 4_000_000_000.0, 0, Gaussian(5), drive-0, 0)
DrivePulse(0, 40, 0.15, 4_200_000_000.0, 1.570796, Drag(5, -0.02), drive-1, 1)
DrivePulse(40, 40, 0.15, 4_200_000_000.0, 3.141593, Drag(5, -0.02), drive-1, 1)
ReadoutPulse(40, 2000, 0.1, 5_200_000_000.0, 0, GaussianSquare(5, 0.75), readout, 0)
ReadoutPulse(2040, 2000, 0.1, 4_900_000_000.0, 0, GaussianSquare(5, 0.75), readout, 1)
```

Notice how the measurement on qubit 1 starts after the measurement of 0 (start time is 2040). Since measurement pulses are usually long (in this example 2000ns), this results into significant qubit state deterioration before the measurement of qubit 1 starts, hence poor results.

With the fix in this PR the circuit is compiled into the following sequence instead:
```
DrivePulse(0, 40, 0.05, 4_000_000_000.0, 0, Gaussian(5), drive-0, 0)
DrivePulse(0, 40, 0.15, 4_200_000_000.0, 1.570796, Drag(5, -0.02), drive-1, 1)
DrivePulse(40, 40, 0.15, 4_200_000_000.0, 3.141593, Drag(5, -0.02), drive-1, 1)
ReadoutPulse(40, 2000, 0.1, 5_200_000_000.0, 0, GaussianSquare(5, 0.75), readout, 0)
ReadoutPulse(80, 2000, 0.1, 4_900_000_000.0, 0, GaussianSquare(5, 0.75), readout, 1)
```

P.S. with measurement this issue is most apparent because of the typical long durations of the measurement pulses, however in principle pulses start times could be messed up in specific situations for other gates as well.