### PR TITLE
Fix compiler adding phases to flux pulses

### DIFF
--- a/src/qibolab/compilers/compiler.py
+++ b/src/qibolab/compilers/compiler.py
@@ -15,7 +15,7 @@ from qibolab.compilers.default import (
     u3_rule,
     z_rule,
 )
-from qibolab.pulses import PulseSequence, ReadoutPulse
+from qibolab.pulses import DrivePulse, PulseSequence
 
 
 @dataclass
@@ -131,7 +131,7 @@ class Compiler:
         # shift start time and phase according to the global sequence
         for pulse in gate_sequence:
             pulse.start += start
-            if not isinstance(pulse, ReadoutPulse):
+            if isinstance(pulse, DrivePulse):
                 pulse.relative_phase += virtual_z_phases[pulse.qubit]
             sequence.add(pulse)
 

--- a/src/qibolab/dummy/parameters.json
+++ b/src/qibolab/dummy/parameters.json
@@ -309,12 +309,12 @@
                     },
                     {
                         "type": "virtual_z",
-                        "phase": 0.0,
+                        "phase": 0.1,
                         "qubit": 1
                     },
                     {
                         "type": "virtual_z",
-                        "phase": 0.0,
+                        "phase": 0.2,
                         "qubit": 2
                     },
                     {

--- a/tests/test_compilers_default.py
+++ b/tests/test_compilers_default.py
@@ -185,6 +185,21 @@ def test_cz_to_sequence(platform):
     assert sequence == test_sequence
 
 
+def test_twocz_to_sequence(platform):
+    if (1, 2) not in platform.pairs:
+        pytest.skip(
+            f"Skipping CZ test for {platform} because pair (1, 2) is not available."
+        )
+
+    circuit = Circuit(3)
+    circuit.add(gates.CZ(1, 2))
+    circuit.add(gates.CZ(1, 2))
+
+    sequence = compile_circuit(circuit, platform)
+    assert sequence[0].relative_phase == 0
+    assert sequence[1].relative_phase == 0
+
+
 def test_cnot_to_sequence():
     platform = create_platform("dummy")
     circuit = Circuit(4)

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -88,7 +88,7 @@ def test_dummy_execute_pulse_sequence_couplers():
     result = platform.execute_pulse_sequence(sequence, options)
 
     test_pulses = "PulseSequence\nFluxPulse(0, 30, 0.05, GaussianSquare(5, 0.75), flux-2, 2)\nCouplerFluxPulse(0, 30, 0.05, GaussianSquare(5, 0.75), flux_coupler-1, 1)"
-    test_phases = {1: 0.0, 2: 0.0}
+    test_phases = {1: 0.1, 2: 0.2}
 
     assert test_pulses == cz.serial
     assert test_phases == cz_phases


### PR DESCRIPTION
Current compiler adds the virtual-z phases to flux pulses in addition to the drive ones. This should not have any effect since flux pulses are DC, but it is probably better to remove to be on the safe side.

@igres26 I have not tested on hardware, but this should remove the frame rotations of the flux channel from the qua script.