### PR TITLE
Make `Custom` envelope serializable

### DIFF
--- a/src/qibolab/_core/pulses/envelope.py
+++ b/src/qibolab/_core/pulses/envelope.py
@@ -337,8 +337,8 @@ class Custom(BaseEnvelope):
 
     kind: Literal["custom"] = "custom"
 
-    i_: npt.NDArray
-    q_: npt.NDArray
+    i_: NdArray
+    q_: NdArray
 
     def i(self, samples: int) -> Waveform:
         """I.


### PR DESCRIPTION
Now that `Custom` is all the rage, I noticed there was a leftover related to the type of its attributes, preventing its serialization.

(To be fair, I actually discovered it by chance in the context of https://github.com/qiboteam/qibolab_platforms_qrc/pull/201, only because it is used in the `iqm5q` parameters...)