### PR TITLE
Really disconnect QM (0.1)

### DIFF
--- a/src/qibolab/instruments/qm/controller.py
+++ b/src/qibolab/instruments/qm/controller.py
@@ -288,6 +288,10 @@ class QMController(Controller):
         Args:
             program: QUA program.
         """
+        if self.manager is None:
+            raise RuntimeError(
+                "Quantum Machines are not connected. Please use ``platform.connect()``."
+            )
         machine = self.manager.open_qm(self.config.__dict__)
         return machine.execute(program)
 

--- a/src/qibolab/instruments/qm/controller.py
+++ b/src/qibolab/instruments/qm/controller.py
@@ -258,6 +258,7 @@ class QMController(Controller):
         self._reset_temporary_calibration()
         if self.manager is not None:
             self.manager.close_all_quantum_machines()
+            self.manager = None
             self.is_connected = False
 
     def calibrate_mixers(self, qubits):


### PR DESCRIPTION
Removes the `self.manager` reference, so that QM is not available after calling `platform.disconnect()`.

Note that in 0.2 this is already fixed: https://github.com/qiboteam/qibolab/blob/13c94d493daf9c5938c44b21589672d6da2dc307/src/qibolab/_core/instruments/qm/controller.py#L239