### PR TITLE
Disconnect platform when job is interrupted

### DIFF
--- a/src/qibolab/platform/platform.py
+++ b/src/qibolab/platform/platform.py
@@ -120,7 +120,6 @@ class Platform:
     def __post_init__(self):
         signal.signal(signal.SIGTERM, self.termination_handler)
         signal.signal(signal.SIGINT, self.termination_handler)
-        log.info("signals registered")
 
         log.info("Loading platform %s", self.name)
         if self.resonator_type is None:

--- a/src/qibolab/platform/platform.py
+++ b/src/qibolab/platform/platform.py
@@ -1,5 +1,6 @@
 """A platform for executing quantum algorithms."""
 
+import signal
 from collections import defaultdict
 from dataclasses import dataclass, field, replace
 from typing import Dict, List, Optional, Tuple
@@ -117,6 +118,10 @@ class Platform:
     """Graph representing the qubit connectivity in the quantum chip."""
 
     def __post_init__(self):
+        signal.signal(signal.SIGTERM, self.termination_handler)
+        signal.signal(signal.SIGINT, self.termination_handler)
+        log.info("signals registered")
+
         log.info("Loading platform %s", self.name)
         if self.resonator_type is None:
             self.resonator_type = "3D" if self.nqubits == 1 else "2D"
@@ -167,6 +172,12 @@ class Platform:
             for instrument in self.instruments.values():
                 instrument.disconnect()
         self.is_connected = False
+
+    def termination_handler(self, signum, frame):
+        self.disconnect()
+        raise RuntimeError(
+            f"Platform {self.name} disconnected because job was cancelled. Signal type: {signum}."
+        )
 
     def _execute(self, sequence, options, **kwargs):
         """Executes sequence on the controllers."""


### PR DESCRIPTION
Implements the suggestion of #1108 for 0.1, which is what was primarily causing the temperature issues. Note that it will only work when the `Platform` interface is used, not the instruments directly, but this should capture most cases in practice. It may be possible to lower it to the drivers. If you agree, I can also port it to 0.2.

I have tested and it seems that the handler is called successfully on qw11q when sbatch+scancel is used. It also works on dummy for both sbatch+scancel and srun+(Ctrl+C). However, srun+(Ctrl+C) does not seem to work on qw11q and the handler is skipped! I am not sure why.

I have also confirmed that the TWPA pump LO is turned off by the handler, which is not the case now (LO will remain on after job cancellation). I have not confirmed that QM jobs are properly cancelled, but I believe that https://github.com/qiboteam/qibolab/blob/cc64ee1cca9e8c9ec75b01b574089dd0e1051136/src/qibolab/instruments/qm/controller.py#L260
should be taking care of this (will confirm soon).