### PR TITLE
Fix duration interpolated sweeper for QM

### DIFF
--- a/src/qibolab/_core/instruments/qm/controller.py
+++ b/src/qibolab/_core/instruments/qm/controller.py
@@ -348,7 +348,8 @@ class QmController(Controller):
     ):
         """Register pulse with many different durations.
 
-        Needed when sweeping duration.
+        Needed when sweeping duration. When interpolation is used, only
+        a single pulse with the minimum duration is used.
         """
         for pulse in sweeper.pulses:
             if isinstance(pulse, (Align, Delay)):
@@ -359,10 +360,19 @@ class QmController(Controller):
             original_pulse = (
                 pulse if params.amplitude_pulse is None else params.amplitude_pulse
             )
-            for value in sweeper.values.astype(int):
-                sweep_pulse = original_pulse.model_copy(update={"duration": value})
-                sweep_op = self.register_pulse(ids[0], configs[ids[0]], sweep_pulse)
-                params.duration_ops.append((value, sweep_op))
+            values = sweeper.values.astype(int)
+            if sweeper.parameter is Parameter.duration_interpolated:
+                sweep_pulse = original_pulse.model_copy(
+                    update={"duration": min(values)}
+                )
+                params.interpolated_op = self.register_pulse(
+                    ids[0], configs[ids[0]], sweep_pulse
+                )
+            else:
+                for value in values:
+                    sweep_pulse = original_pulse.model_copy(update={"duration": value})
+                    sweep_op = self.register_pulse(ids[0], configs[ids[0]], sweep_pulse)
+                    params.duration_ops.append((value, sweep_op))
 
     def register_amplitude_sweeper_pulses(
         self, args: ExecutionArguments, configs: dict[str, Config], sweeper: Sweeper
@@ -447,6 +457,8 @@ class QmController(Controller):
         for sweeper in find_sweepers(sweepers, Parameter.amplitude):
             self.register_amplitude_sweeper_pulses(args, configs, sweeper)
         for sweeper in find_sweepers(sweepers, Parameter.duration):
+            self.register_duration_sweeper_pulses(args, configs, sweeper)
+        for sweeper in find_sweepers(sweepers, Parameter.duration_interpolated):
             self.register_duration_sweeper_pulses(args, configs, sweeper)
 
     def execute_program(self, program):

--- a/src/qibolab/_core/instruments/qm/controller.py
+++ b/src/qibolab/_core/instruments/qm/controller.py
@@ -346,10 +346,16 @@ class QmController(Controller):
     def register_duration_sweeper_pulses(
         self, args: ExecutionArguments, configs: dict[str, Config], sweeper: Sweeper
     ):
-        """Register pulse with many different durations.
+        """Register pulses needed to implement a duration sweep.
 
-        Needed when sweeping duration. When interpolation is used, only
-        a single pulse with the minimum duration is used.
+        For standard (non-interpolated) duration sweeps, we need to
+        upload distinct waveforms for every different duration.
+
+        When interpolation is used, we need to upload a single pulse
+        with the minimum duration of the sweeper, because the QM real-
+        time interpolation can only stretch and not compress arbitrary
+        waveforms, as documented in
+        https://docs.quantum-machines.co/latest/docs/Guides/features/?h=interpo#dynamic-pulse-duration
         """
         for pulse in sweeper.pulses:
             if isinstance(pulse, (Align, Delay)):
@@ -369,6 +375,7 @@ class QmController(Controller):
                     ids[0], configs[ids[0]], sweep_pulse
                 )
             else:
+                assert sweeper.parameter is Parameter.duration
                 for value in values:
                     sweep_pulse = original_pulse.model_copy(update={"duration": value})
                     sweep_op = self.register_pulse(ids[0], configs[ids[0]], sweep_pulse)

--- a/src/qibolab/_core/instruments/qm/program/arguments.py
+++ b/src/qibolab/_core/instruments/qm/program/arguments.py
@@ -24,6 +24,7 @@ class Parameters:
     duration: Optional[_Variable] = None
     duration_ops: list[tuple[float, str]] = field(default_factory=list)
     interpolated: bool = False
+    interpolated_op: Optional[str] = None
 
     element: Optional[str] = None
     lo_frequency: Optional[int] = None

--- a/src/qibolab/_core/instruments/qm/program/instructions.py
+++ b/src/qibolab/_core/instruments/qm/program/instructions.py
@@ -52,7 +52,10 @@ def _play_single_waveform(
     if acquisition is not None:
         acquisition.measure(op)
     else:
-        qua.play(op, element, duration=parameters.duration)
+        if parameters.duration is not None:
+            qua.play(parameters.interpolated_op, element, duration=parameters.duration)
+        else:
+            qua.play(op, element)
 
 
 def _play(

--- a/src/qibolab/_core/instruments/qm/program/instructions.py
+++ b/src/qibolab/_core/instruments/qm/program/instructions.py
@@ -33,6 +33,8 @@ def _delay(pulse: Delay, element: str, parameters: Parameters):
 
 def _play_multiple_waveforms(element: str, parameters: Parameters):
     """Sweeping pulse duration using distinctly uploaded waveforms."""
+    assert not parameters.interpolated
+    assert parameters.interpolated_op is None
     with qua.switch_(parameters.duration, unsafe=True):
         for value, sweep_op in parameters.duration_ops:
             if parameters.amplitude is not None:
@@ -53,6 +55,9 @@ def _play_single_waveform(
         acquisition.measure(op)
     else:
         if parameters.duration is not None:
+            # sweeping duration using interpolation
+            # distinctly uploaded waveforms are handled by ``_play_multiple_waveforms``
+            assert len(parameters.duration_ops) == 0
             qua.play(parameters.interpolated_op, element, duration=parameters.duration)
         else:
             qua.play(op, element)


### PR DESCRIPTION
Using the Rabi length routine, we noticed that this sweeper works best when we upload the pulse with the minimum duration among the swept values. This is probably due to the inability to compress arbitrary waveforms in real time (see https://docs.quantum-machines.co/latest/docs/Guides/features/?h=interpo#dynamic-pulse-duration).

Using this branch, the Rabi length behaves consistently between 0.1 (http://login.qrccluster.com:9000/MutpaUWhRPa9XlYyhD8mYA==) and 0.2 (http://login.qrccluster.com:9000/xKil3FR_Qv-4El7gQHd3vQ==).

Note that the standard (non-interpolated) sweeper still behaves differently for this experiment, however for that case there is no 0.1 counterpart that we can compare to.