### PR TITLE
Apply phases using `frame_rotation` in QM

### DIFF
--- a/src/qibolab/_core/instruments/qm/config/pulses.py
+++ b/src/qibolab/_core/instruments/qm/config/pulses.py
@@ -42,12 +42,8 @@ class ConstantWaveform:
 
     @classmethod
     def from_pulse(cls, pulse: Pulse, max_voltage: float) -> dict[str, "Waveform"]:
-        phase = wrap_phase(pulse.relative_phase)
         voltage_amp = pulse.amplitude * max_voltage
-        return {
-            "I": cls(voltage_amp * np.cos(phase)),
-            "Q": cls(voltage_amp * np.sin(phase)),
-        }
+        return {"I": cls(voltage_amp), "Q": cls(0)}
 
 
 @dataclass(frozen=True)
@@ -58,10 +54,9 @@ class ArbitraryWaveform:
     @classmethod
     def from_pulse(cls, pulse: Pulse, max_voltage: float) -> dict[str, "Waveform"]:
         original_waveforms = pulse.envelopes(SAMPLING_RATE) * max_voltage
-        rotated_waveforms = rotate(original_waveforms, pulse.relative_phase)
         new_duration = baked_duration(pulse.duration)
         pad_len = new_duration - int(pulse.duration)
-        baked_waveforms = np.pad(rotated_waveforms, ((0, 0), (0, pad_len)))
+        baked_waveforms = np.pad(original_waveforms, ((0, 0), (0, pad_len)))
         return {
             "I": cls(baked_waveforms[0]),
             "Q": cls(baked_waveforms[1]),

--- a/src/qibolab/_core/instruments/qm/config/pulses.py
+++ b/src/qibolab/_core/instruments/qm/config/pulses.py
@@ -4,7 +4,6 @@ from typing import Union
 import numpy as np
 
 from qibolab._core.pulses import Pulse, Rectangular
-from qibolab._core.pulses.modulation import rotate, wrap_phase
 
 SAMPLING_RATE = 1
 """Sampling rate of Quantum Machines OPX+ in GSps."""

--- a/src/qibolab/_core/instruments/qm/program/instructions.py
+++ b/src/qibolab/_core/instruments/qm/program/instructions.py
@@ -101,6 +101,8 @@ def play(args: ExecutionArguments):
         if isinstance(pulse, Delay):
             _delay(pulse, element, params)
         elif isinstance(pulse, Pulse):
+            if pulse.relative_phase != 0 and params.phase is None:
+                params.phase = normalize_phase(pulse.relative_phase)
             _play(op, element, params)
         elif isinstance(pulse, Readout):
             acquisition = args.acquisitions.get((op, element))

--- a/src/qibolab/_core/instruments/qm/program/instructions.py
+++ b/src/qibolab/_core/instruments/qm/program/instructions.py
@@ -22,7 +22,7 @@ def _delay(pulse: Delay, element: str, parameters: Parameters):
         duration = max(int(pulse.duration) // 4 + 1, 4)
         qua.wait(duration, element)
     elif parameters.interpolated:
-        duration = parameters.duration + 1
+        duration = parameters.duration
         qua.wait(duration, element)
     else:
         duration = parameters.duration / 4
@@ -79,7 +79,7 @@ def _play(
         _play_single_waveform(op, element, parameters, acquisition)
 
     if parameters.phase is not None:
-        qua.reset_frame(element)
+        qua.frame_rotation_2pi(-parameters.phase, element)
 
 
 def play(args: ExecutionArguments):


### PR DESCRIPTION
In 0.2 pulse phases was applied in the uploaded waveform samples. Here I am switching this back to the approach used in 0.1, based on `frame_rotation`, because this is how I managed to make the CHSH routine work.

I am not sure which solution of the two is better. The one implemented here may suffer from the second note in https://docs.quantum-machines.co/latest/docs/API_references/qua/dsl_main/?h=frame_#qm.qua._dsl.frame_rotation_2pi, so I am leaving it as draft for now.