### PR TITLE
Parameters builder

### DIFF
--- a/src/qibolab/_core/components/__init__.py
+++ b/src/qibolab/_core/components/__init__.py
@@ -18,6 +18,7 @@ their name.
 from . import channels
 from .channels import *
 from .configs import *
+from .default import *
 
 __all__ = []
 __all__ += channels.__all__

--- a/src/qibolab/_core/components/default.py
+++ b/src/qibolab/_core/components/default.py
@@ -1,0 +1,19 @@
+from .channels import AcquisitionChannel, Channel, DcChannel, IqChannel
+from .configs import AcquisitionConfig, Config, DcConfig, IqConfig
+
+__all__ = ["channel_to_config"]
+
+CHANNEL_TO_CONFIG_MAP = {
+    Channel: Config,
+    DcChannel: lambda: DcConfig(offset=0),
+    IqChannel: lambda: IqConfig(frequency=0),
+    AcquisitionChannel: lambda: AcquisitionConfig(delay=0, smearing=0),
+}
+
+
+def channel_to_config(channel: Channel) -> Config:
+    """Create a default config for a given channel.
+
+    The config type depends on the channel type.
+    """
+    return CHANNEL_TO_CONFIG_MAP[type(channel)]()

--- a/src/qibolab/_core/platform/load.py
+++ b/src/qibolab/_core/platform/load.py
@@ -62,7 +62,7 @@ def locate_platform(name: str, paths: Optional[list[Path]] = None) -> Path:
     return _search(name, paths)
 
 
-def create_platform(name: str, params: Optional[dict] = None) -> Platform:
+def create_platform(name: str, parameters: Optional[Parameters] = None) -> Platform:
     """A platform for executing quantum algorithms.
 
     It consists of a quantum processor QPU and a set of controlling instruments.
@@ -83,10 +83,10 @@ def create_platform(name: str, params: Optional[dict] = None) -> Platform:
     if isinstance(hardware, Platform):
         return hardware
 
-    if params is None:
+    if parameters is None:
         return Platform.load(path, **hardware)
 
-    return Platform(**hardware, parameters=Parameters(**params))
+    return Platform(**hardware, parameters=parameters)
 
 
 def available_platforms() -> list[str]:

--- a/src/qibolab/_core/platform/load.py
+++ b/src/qibolab/_core/platform/load.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 from qibo.config import raise_error
 
+from ..parameters import Parameters
 from .platform import Platform
 
 __all__ = ["create_platform", "locate_platform"]
@@ -61,7 +62,7 @@ def locate_platform(name: str, paths: Optional[list[Path]] = None) -> Path:
     return _search(name, paths)
 
 
-def create_platform(name: str) -> Platform:
+def create_platform(name: str, params: Optional[dict] = None) -> Platform:
     """A platform for executing quantum algorithms.
 
     It consists of a quantum processor QPU and a set of controlling instruments.
@@ -77,7 +78,15 @@ def create_platform(name: str) -> Platform:
 
         return create_dummy()
 
-    return _load(_search(name, _platforms_paths()))
+    path = _search(name, _platforms_paths())
+    hardware = _load(path)
+    if isinstance(hardware, Platform):
+        return hardware
+
+    if params is None:
+        return Platform.load(path, **hardware)
+
+    return Platform(**hardware, parameters=Parameters(**params))
 
 
 def available_platforms() -> list[str]:

--- a/src/qibolab/_core/platform/platform.py
+++ b/src/qibolab/_core/platform/platform.py
@@ -16,6 +16,7 @@ from ..parameters import (
     InstrumentMap,
     NativeGates,
     Parameters,
+    ParametersBuilder,
     QubitMap,
     Settings,
     Update,
@@ -310,13 +311,13 @@ class Platform:
         if couplers is None:
             couplers = {}
 
-        return cls(
-            name=name,
-            parameters=Parameters.model_validate_json((path / PARAMETERS).read_text()),
-            instruments=instruments,
-            qubits=qubits,
-            couplers=couplers,
-        )
+        hardware = {"instruments": instruments, "qubits": qubits, "couplers": couplers}
+        try:
+            parameters = Parameters.model_validate_json((path / PARAMETERS).read_text())
+        except FileNotFoundError:
+            parameters = ParametersBuilder(hardware=hardware).build()
+
+        return cls(name=name, parameters=parameters, **hardware)
 
     def dump(self, path: Path):
         """Dump platform."""

--- a/src/qibolab/_core/platform/platform.py
+++ b/src/qibolab/_core/platform/platform.py
@@ -11,8 +11,16 @@ from ..components import Config
 from ..components.channels import Channel
 from ..execution_parameters import ExecutionParameters
 from ..identifier import ChannelId, QubitId, QubitPairId, Result
-from ..instruments.abstract import Controller, Instrument, InstrumentId
-from ..parameters import NativeGates, Parameters, Settings, Update, update_configs
+from ..instruments.abstract import Controller
+from ..parameters import (
+    InstrumentMap,
+    NativeGates,
+    Parameters,
+    QubitMap,
+    Settings,
+    Update,
+    update_configs,
+)
 from ..pulses import PulseId
 from ..qubits import Qubit
 from ..sequence import PulseSequence
@@ -20,10 +28,6 @@ from ..sweeper import ParallelSweepers
 from ..unrolling import Bounds, batch
 
 __all__ = ["Platform"]
-
-QubitMap = dict[QubitId, Qubit]
-QubitPairMap = list[QubitPairId]
-InstrumentMap = dict[InstrumentId, Instrument]
 
 NS_TO_SEC = 1e-9
 PARAMETERS = "parameters.json"

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -11,7 +11,7 @@ from qibolab._core.parameters import (
     TwoQubitContainer,
 )
 from qibolab._core.platform.load import create_platform
-from qibolab._core.pulses.pulse import Pulse
+from qibolab._core.pulses.pulse import Pulse, Readout
 
 
 def test_two_qubit_container():
@@ -119,7 +119,9 @@ def test_builder():
         "qubits": dummy.qubits,
         "couplers": dummy.couplers,
     }
-    builder = ParametersBuilder(hardware=hardware, pairs=["0-2"])
+    builder = ParametersBuilder(
+        hardware=hardware, natives=["RX", "MZ", "CZ"], pairs=["0-2"]
+    )
     parameters = builder.build()
 
     for q in dummy.qubits:
@@ -133,3 +135,12 @@ def test_builder():
         assert c in parameters.native_gates.coupler
 
     assert list(parameters.native_gates.two_qubit) == [(0, 2)]
+    sequence = parameters.native_gates.two_qubit[(0, 2)].CZ
+    assert sequence[0][0] == "0/flux"
+    assert isinstance(sequence[0][1], Pulse)
+    sequence = parameters.native_gates.single_qubit[0].RX
+    assert sequence[0][0] == "0/drive"
+    assert isinstance(sequence[0][1], Pulse)
+    sequence = parameters.native_gates.single_qubit[2].MZ
+    assert sequence[0][0] == "2/acquisition"
+    assert isinstance(sequence[0][1], Readout)


### PR DESCRIPTION
Implements the `ParametersBuilder` discussed with @alecandido last week. The main change, from a usability point of view, is that `Platform`s can now be defined without writing the corresponding `parameters.json`. In that case, a default parameter configuration will be autogenerated, using the new `ParametersBuilder` object.

The generated `Parameters` will have configs with zero values for all channels defined within the `create_method`. They will also have default native gates (also with zeros) for all gates specified as `natives` in the `ParametersBuilder`. Note that `ParametersBuilder` makes some assumptions about the config kinds and channels that native gates play on, which the user may need to change in practice for things to work properly on hardware. The updates can be done either directly in Python using `Parameter.replace` API or dumping to JSON and updating manually.

@alecandido let me know if this is what you also had in mind, because I am not sure. Then we can add some examples in the documentation of how this can be used to simplify platform creation (avoid copy-pasting, etc.).