### PR TITLE
Fix for running QM mixer calibration

### DIFF
--- a/src/qibolab/instruments/qm/config.py
+++ b/src/qibolab/instruments/qm/config.py
@@ -11,7 +11,7 @@ from .ports import OPXIQ, FEMInput, FEMOutput, OctaveInput, OctaveOutput, OPXOut
 SAMPLING_RATE = 1
 """Sampling rate of Quantum Machines OPX in GSps."""
 
-DEFAULT_INPUTS = {1: {}, 2: {}}
+DEFAULT_INPUTS = {1: {"offset": 0}, 2: {"offset": 0}}
 """Default controller config section.
 
 Inputs are always registered to avoid issues with automatic mixer
@@ -57,7 +57,7 @@ class QMConfig:
                     controllers[port.device] = {"type": "opx1000", "fems": {}}
                 else:
                     controllers[port.device] = {
-                        "analog_inputs": DEFAULT_INPUTS,
+                        "analog_inputs": DEFAULT_INPUTS.copy(),
                         "digital_outputs": {},
                     }
 
@@ -66,7 +66,7 @@ class QMConfig:
                 if port.fem_number not in fems:
                     fems[port.fem_number] = {
                         "type": port.fem_type,
-                        "analog_inputs": DEFAULT_INPUTS,
+                        "analog_inputs": DEFAULT_INPUTS.copy(),
                         "digital_outputs": {},
                     }
                 device = fems[port.fem_number]

--- a/tests/test_instruments_qm.py
+++ b/tests/test_instruments_qm.py
@@ -158,7 +158,7 @@ def test_qm_register_port(qmcontroller, offset):
     controllers = qmcontroller.config.controllers
     assert controllers == {
         "con1": {
-            "analog_inputs": {1: {}, 2: {}},
+            "analog_inputs": {1: {"offset": 0}, 2: {"offset": 0}},
             "analog_outputs": {1: {"offset": offset, "filter": {}}},
             "digital_outputs": {},
         }
@@ -173,7 +173,7 @@ def test_qm_register_port_filter(qmcontroller):
     controllers = qmcontroller.config.controllers
     assert controllers == {
         "con1": {
-            "analog_inputs": {1: {}, 2: {}},
+            "analog_inputs": {1: {"offset": 0}, 2: {"offset": 0}},
             "analog_outputs": {
                 2: {
                     "filter": {"feedback": [0.95], "feedforward": [1, -1]},


### PR DESCRIPTION
Fix required for the following script to work and perform mixer calibration (related issue #1125):

<details>
<summary>Mixer calibration script</summary>

```py
import warnings

from qibolab import create_platform
from qibolab.instruments.qm.controller import controllers_config


def _calibrate_readout_mixer(platform, controller, config, qubit_names):
    lo_frequency = None
    if_frequencies = []
    for q in qubit_names:
        qubit = platform.qubits[q]
        element = f"readout{qubit.name}"
        if lo_frequency is None:
            lo_frequency = qubit.readout.lo_frequency
        else:
            assert (
                lo_frequency == qubit.readout.lo_frequency
            ), "Qubits on same probe line must have the same LO frequency."
        if_frequencies.append(qubit.native_gates.MZ.frequency - lo_frequency)

    qmachine = controller.manager.open_qm(config.__dict__)
    qmachine.calibrate_element(element, {lo_frequency: tuple(if_frequencies)})
    qmachine.close()

def _calibrate_drive_mixers(platform, controller, config, qubit_names):
    for q in qubit_names:
        qubit = platform.qubits[q]
        element = f"drive{qubit.name}"
        lo_frequency = qubit.drive.lo_frequency
        if_frequency = qubit.native_gates.RX.frequency - lo_frequency

        qmachine = controller.manager.open_qm(config.__dict__)
        qmachine.calibrate_element(element, {lo_frequency: (if_frequency,)})
        qmachine.close()


def _run_until_success(fn, *args, label):
    while True:
        try:
            fn(*args)
            print(f"Mixer calibration for {label} finished successfully")
            break
        except RuntimeWarning as w:
            print(
                f"Issue encountered while running mixer calibration for {label} mixer. Retrying..."
            )


if __name__ == "__main__":
    warnings.filterwarnings("error", category=RuntimeWarning, message="invalid value")

    platform = create_platform("qw5q_platinum")
    controller = platform.instruments["qm"]
    controller.write_calibration = True
    controller.connect()

    config = controllers_config(
        list(platform.qubits.values()), controller.time_of_flight, controller.smearing
    )

    import json
    with open("mixers_config.json", "w") as file:
        json.dump(config.__dict__, file, indent=4)

    _run_until_success(
        _calibrate_readout_mixer,
        platform,
        controller,
        config,
        [0,1,2,3,4],
        label="readout",
    )
    _run_until_success(
        _calibrate_drive_mixers,
        platform,
        controller,
        config,
        [0,1,2,3,4],
        label="drive",
    )

    controller.disconnect()
```

</details>

I believe the issue was also discovered by @hay-k before, but never made it to PR/merged.