### PR TITLE
Fix alternative platform loading

### DIFF
--- a/src/qibolab/_core/parameters.py
+++ b/src/qibolab/_core/parameters.py
@@ -236,6 +236,13 @@ class Hardware(Model):
     qubits: QubitMap
     couplers: QubitMap = Field(default_factory=dict)
 
+    @property
+    def elements(self) -> dict:
+        """Extract connected elements."""
+        d = self.model_dump()
+        del d["instruments"]
+        return d
+
 
 def _gate_channel(qubit: Qubit, gate: str) -> str:
     """Default channel that a native gate plays on."""

--- a/src/qibolab/_core/platform/load.py
+++ b/src/qibolab/_core/platform/load.py
@@ -83,7 +83,7 @@ def create_platform(name: str) -> Platform:
     if isinstance(hardware, Platform):
         return hardware
 
-    return Platform.load(path, **hardware.model_dump())
+    return Platform.load(path, instruments=hardware.instruments, **hardware.elements)
 
 
 def available_platforms() -> list[str]:


### PR DESCRIPTION
The loading mechanism provided in #1123 is convenient for the future. But, unfortunately, to implement it as intended, we should make some more magic to make it work.

Indeed, since we rely on Pydantic for (de)serialization, we need to be pretty specific with the possible types.
However, this is not the case for the `InstrumentMap`, where we are specifying the parent class, rather than the union of its children.

We already faced this problem for configuration, leading to `ConfigKinds`, which is not the simplest object.

For the time being, I decided to bypass the problem, since we do not have any actual need to serialize the `Hardware` object, because our persistence layer for hardware just consists of the `platform.py` files (which we are *reading*, but aiming to *write* automatically).