### PR TITLE
Reproduce 0.1 snapshot

### DIFF
--- a/src/qibolab/_core/instruments/qblox/cluster.py
+++ b/src/qibolab/_core/instruments/qblox/cluster.py
@@ -242,6 +242,11 @@ class Cluster(Controller):
     ) -> SequencerMap:
         self.cluster.reference_source("internal")
         sequencers = defaultdict(dict)
+        for mod in self._modules.values():
+            config.module_default(mod)
+            for seq in mod.sequencers:
+                config.sequencer_default(seq)
+
         for slot, chs in self._channels_by_module.items():
             module = self._modules[slot]
             assert len(module.sequencers) >= len(chs)

--- a/src/qibolab/_core/instruments/qblox/cluster.py
+++ b/src/qibolab/_core/instruments/qblox/cluster.py
@@ -240,6 +240,7 @@ class Cluster(Controller):
         configs: Configs,
         acquisition: AcquisitionType,
     ) -> SequencerMap:
+        self.cluster.reference_source("internal")
         sequencers = defaultdict(dict)
         for slot, chs in self._channels_by_module.items():
             module = self._modules[slot]

--- a/src/qibolab/_core/instruments/qblox/cluster.py
+++ b/src/qibolab/_core/instruments/qblox/cluster.py
@@ -246,6 +246,10 @@ class Cluster(Controller):
             config.module_default(mod)
             for seq in mod.sequencers:
                 config.sequencer_default(seq)
+        for mod in self._modules.values():
+            config.module_default(mod)
+            for seq in mod.sequencers:
+                config.sequencer_default(seq)
 
         for slot, chs in self._channels_by_module.items():
             module = self._modules[slot]

--- a/src/qibolab/_core/instruments/qblox/config.py
+++ b/src/qibolab/_core/instruments/qblox/config.py
@@ -176,7 +176,7 @@ def sequencer_default(seq: Sequencer):
         seq.set("connect_out1", "off")
         if seq.seq_idx < 2:
             default = True
-            seq.set(f"connect_out{seq.seq_idx}", "off")
+            seq.set(f"connect_out{seq.seq_idx}", "IQ")
 
     if mod.is_qrm_type:
         seq.set("marker_ovr_en", False)
@@ -184,6 +184,8 @@ def sequencer_default(seq: Sequencer):
         seq.set("connect_out0", "off")
         if seq.seq_idx < 1:
             default = True
+            seq.set("demod_en_acq", True)
+            seq.set("connect_out0", "IQ")
 
     if default:
         seq.set("cont_mode_en_awg_path0", False)

--- a/src/qibolab/_core/instruments/qblox/config.py
+++ b/src/qibolab/_core/instruments/qblox/config.py
@@ -153,14 +153,8 @@ def _integration_length(sequence: Q1Sequence) -> Optional[int]:
 
 
 def sequencer_default(seq: Sequencer):
-    seq.set("cont_mode_en_awg_path0", False)
-    seq.set("cont_mode_en_awg_path1", False)
-    seq.set("cont_mode_waveform_idx_awg_path0", 0)
-    seq.set("cont_mode_waveform_idx_awg_path1", 0)
     seq.set("marker_ovr_en", True)
-    seq.set("mixer_corr_gain_ratio", 1)
-    seq.set("mixer_corr_phase_offset_degree", 0)
-    seq.set("nco_phase_offs", 0)
+    seq.set("marker_ovr_value", 0)
     seq.set("sync_en", False)
 
     mod = cast(Module, seq.ancestors[1])
@@ -189,6 +183,13 @@ def sequencer_default(seq: Sequencer):
             default = True
 
     if default:
+        seq.set("cont_mode_en_awg_path0", False)
+        seq.set("cont_mode_en_awg_path1", False)
+        seq.set("cont_mode_waveform_idx_awg_path0", 0)
+        seq.set("cont_mode_waveform_idx_awg_path1", 0)
+        seq.set("mixer_corr_gain_ratio", 1)
+        seq.set("mixer_corr_phase_offset_degree", 0)
+        seq.set("nco_phase_offs", 0)
         seq.set("upsample_rate_awg_path0", 0)
         seq.set("upsample_rate_awg_path1", 0)
 

--- a/src/qibolab/_core/instruments/qblox/config.py
+++ b/src/qibolab/_core/instruments/qblox/config.py
@@ -157,12 +157,32 @@ def sequencer_default(seq: Sequencer):
     seq.set("cont_mode_en_awg_path1", False)
     seq.set("cont_mode_waveform_idx_awg_path0", 0)
     seq.set("cont_mode_waveform_idx_awg_path1", 0)
+    seq.set("marker_ovr_en", False)
+    seq.set("marker_ovr_value", 0)
     seq.set("mixer_corr_gain_ratio", 1)
     seq.set("mixer_corr_phase_offset_degree", 0)
     seq.set("nco_phase_offs", 0)
     seq.set("sync_en", False)
     seq.set("upsample_rate_awg_path0", 0)
     seq.set("upsample_rate_awg_path1", 0)
+
+    mod = cast(Module, seq.ancestors[1])
+
+    if not mod.is_qrm_type and not mod.is_rf_type:
+        if seq.seq_idx <= 3:
+            seq.set(f"connect_out{seq.seq_idx}", "I" if seq.seq_idx % 2 == 0 else "Q")
+        else:
+            seq.set("connect_out0", "off")
+            seq.set("connect_out1", "off")
+            seq.set("connect_out2", "off")
+            seq.set("connect_out3", "off")
+
+    if not mod.is_qrm_type and mod.is_rf_type:
+        pass
+
+    if mod.is_qrm_type:
+        seq.set("connect_acq", "in0")
+        seq.set("connect_out0", "off")
 
 
 def sequencer(

--- a/src/qibolab/_core/instruments/qblox/config.py
+++ b/src/qibolab/_core/instruments/qblox/config.py
@@ -160,6 +160,7 @@ def sequencer_default(seq: Sequencer):
     seq.set("mixer_corr_gain_ratio", 1)
     seq.set("mixer_corr_phase_offset_degree", 0)
     seq.set("nco_phase_offs", 0)
+    seq.set("sync_en", False)
     seq.set("upsample_rate_awg_path0", 0)
     seq.set("upsample_rate_awg_path1", 0)
 

--- a/src/qibolab/_core/instruments/qblox/config.py
+++ b/src/qibolab/_core/instruments/qblox/config.py
@@ -157,19 +157,19 @@ def sequencer_default(seq: Sequencer):
     seq.set("cont_mode_en_awg_path1", False)
     seq.set("cont_mode_waveform_idx_awg_path0", 0)
     seq.set("cont_mode_waveform_idx_awg_path1", 0)
-    seq.set("marker_ovr_en", False)
-    seq.set("marker_ovr_value", 0)
+    seq.set("marker_ovr_en", True)
     seq.set("mixer_corr_gain_ratio", 1)
     seq.set("mixer_corr_phase_offset_degree", 0)
     seq.set("nco_phase_offs", 0)
     seq.set("sync_en", False)
-    seq.set("upsample_rate_awg_path0", 0)
-    seq.set("upsample_rate_awg_path1", 0)
 
     mod = cast(Module, seq.ancestors[1])
 
+    default = False
     if not mod.is_qrm_type and not mod.is_rf_type:
-        if seq.seq_idx <= 3:
+        seq.set("marker_ovr_value", 15)
+        if seq.seq_idx < 4:
+            default = True
             seq.set(f"connect_out{seq.seq_idx}", "I" if seq.seq_idx % 2 == 0 else "Q")
         else:
             seq.set("connect_out0", "off")
@@ -178,11 +178,19 @@ def sequencer_default(seq: Sequencer):
             seq.set("connect_out3", "off")
 
     if not mod.is_qrm_type and mod.is_rf_type:
-        pass
+        if seq.seq_idx < 2:
+            default = True
 
     if mod.is_qrm_type:
+        seq.set("marker_ovr_en", False)
         seq.set("connect_acq", "in0")
         seq.set("connect_out0", "off")
+        if seq.seq_idx < 2:
+            default = True
+
+    if default:
+        seq.set("upsample_rate_awg_path0", 0)
+        seq.set("upsample_rate_awg_path1", 0)
 
 
 def sequencer(

--- a/src/qibolab/_core/instruments/qblox/config.py
+++ b/src/qibolab/_core/instruments/qblox/config.py
@@ -186,7 +186,7 @@ def sequencer_default(seq: Sequencer):
         seq.set("marker_ovr_en", False)
         seq.set("connect_acq", "in0")
         seq.set("connect_out0", "off")
-        if seq.seq_idx < 2:
+        if seq.seq_idx < 1:
             default = True
 
     if default:

--- a/src/qibolab/_core/instruments/qblox/config.py
+++ b/src/qibolab/_core/instruments/qblox/config.py
@@ -165,10 +165,6 @@ def sequencer_default(seq: Sequencer):
         if seq.seq_idx < 4:
             default = True
             seq.set(f"connect_out{seq.seq_idx}", "I" if seq.seq_idx % 2 == 0 else "Q")
-            seq.set("mod_en_awg", True)
-            seq.set("nco_freq", 0)
-            seq.set("offset_awg_path0", 0)
-            seq.set("offset_awg_path1", 0)
         else:
             seq.set("connect_out0", "off")
             seq.set("connect_out1", "off")
@@ -194,9 +190,13 @@ def sequencer_default(seq: Sequencer):
         seq.set("cont_mode_en_awg_path1", False)
         seq.set("cont_mode_waveform_idx_awg_path0", 0)
         seq.set("cont_mode_waveform_idx_awg_path1", 0)
+        seq.set("mod_en_awg", True)
         seq.set("mixer_corr_gain_ratio", 1)
         seq.set("mixer_corr_phase_offset_degree", 0)
+        seq.set("nco_freq", 0)
         seq.set("nco_phase_offs", 0)
+        seq.set("offset_awg_path0", 0)
+        seq.set("offset_awg_path1", 0)
         seq.set("upsample_rate_awg_path0", 0)
         seq.set("upsample_rate_awg_path1", 0)
 

--- a/src/qibolab/_core/instruments/qblox/config.py
+++ b/src/qibolab/_core/instruments/qblox/config.py
@@ -191,11 +191,8 @@ def sequencer_default(seq: Sequencer):
         seq.set("cont_mode_en_awg_path1", False)
         seq.set("cont_mode_waveform_idx_awg_path0", 0)
         seq.set("cont_mode_waveform_idx_awg_path1", 0)
-        seq.set("mod_en_awg", True)
         seq.set("mixer_corr_gain_ratio", 1)
         seq.set("mixer_corr_phase_offset_degree", 0)
-        seq.set("nco_freq", 0)
-        seq.set("nco_phase_offs", 0)
         seq.set("offset_awg_path0", 0)
         seq.set("offset_awg_path1", 0)
         seq.set("upsample_rate_awg_path0", 0)
@@ -230,8 +227,11 @@ def sequencer(
     seq.offset_awg_path1(0.0)
 
     # modulation, only disable for QCM - always used for flux pulses
-    mod = cast(Module, seq.ancestors[1])
-    seq.mod_en_awg(mod.is_qrm_type or mod.is_rf_type)
+    # mod = cast(Module, seq.ancestors[1])
+    # seq.mod_en_awg(mod.is_qrm_type or mod.is_rf_type)
+    seq.mod_en_awg(True)
+    seq.nco_freq(0)
+    seq.nco_phase_offs(0)
 
     # FIX: for no apparent reason other than experimental evidence, the marker has to be
     # enabled and set to a certain value

--- a/src/qibolab/_core/instruments/qblox/config.py
+++ b/src/qibolab/_core/instruments/qblox/config.py
@@ -172,8 +172,11 @@ def sequencer_default(seq: Sequencer):
             seq.set("connect_out3", "off")
 
     if not mod.is_qrm_type and mod.is_rf_type:
+        seq.set("connect_out0", "off")
+        seq.set("connect_out1", "off")
         if seq.seq_idx < 2:
             default = True
+            seq.set(f"connect_out{seq.seq_idx}", "off")
 
     if mod.is_qrm_type:
         seq.set("marker_ovr_en", False)
@@ -248,8 +251,10 @@ def sequencer(
 
     # avoid sequence operations for inactive sequencers, including synchronization
     if sequence.is_empty:
-        seq.sync_en(False)
         return
+
+    if address.input:
+        seq.connect_out0("IQ")
 
     # upload sequence
     # - ensure JSON compatibility of the sent dictionary

--- a/src/qibolab/_core/instruments/qblox/config.py
+++ b/src/qibolab/_core/instruments/qblox/config.py
@@ -216,6 +216,7 @@ def sequencer(
 
     # avoid sequence operations for inactive sequencers, including synchronization
     if sequence.is_empty:
+        seq.sync_en(False)
         return
 
     # upload sequence

--- a/src/qibolab/_core/instruments/qblox/config.py
+++ b/src/qibolab/_core/instruments/qblox/config.py
@@ -110,7 +110,9 @@ def module_default(mod: Module):
         mod.scope_acq_sequencer_select(0)
         mod.scope_acq_trigger_level_path0(0)
         mod.scope_acq_trigger_level_path1(0)
-    # ---
+        if mod.slot_idx == 20:
+            mod.out0_offset_path0(-8.1)
+            mod.out0_offset_path1(-3.8)
 
 
 def module(
@@ -191,6 +193,7 @@ def sequencer_default(seq: Sequencer):
             seq.set("mod_en_awg", True)
             seq.set("nco_freq", 0)
             seq.set("nco_phase_offs", 0)
+            seq.set("integration_length_acq", 480)
 
     if default:
         seq.set("cont_mode_en_awg_path0", False)
@@ -247,14 +250,15 @@ def sequencer(
     # acquisition
     if address.input:
         assert isinstance(config, AcquisitionConfig)
-        length = _integration_length(sequence)
-        if length is not None:
-            seq.integration_length_acq(length)
+        # length = _integration_length(sequence)
+        # if length is not None:
+        #     seq.integration_length_acq(length)
         # discrimination
         if config.iq_angle is not None:
             seq.thresholded_acq_rotation(np.degrees(config.iq_angle % (2 * np.pi)))
         if config.threshold is not None:
-            seq.thresholded_acq_threshold(config.threshold)
+            # seq.thresholded_acq_threshold(config.threshold * length)
+            seq.thresholded_acq_threshold(config.threshold * 480)
         # demodulation
         seq.demod_en_acq(acquisition is not AcquisitionType.RAW)
 

--- a/src/qibolab/_core/instruments/qblox/config.py
+++ b/src/qibolab/_core/instruments/qblox/config.py
@@ -176,6 +176,9 @@ def sequencer_default(seq: Sequencer):
         if seq.seq_idx < 2:
             default = True
             seq.set(f"connect_out{seq.seq_idx}", "IQ")
+            seq.set("mod_en_awg", True)
+            seq.set("nco_freq", 0)
+            seq.set("nco_phase_offs", 0)
 
     if mod.is_qrm_type:
         seq.set("marker_ovr_en", False)

--- a/src/qibolab/_core/instruments/qblox/config.py
+++ b/src/qibolab/_core/instruments/qblox/config.py
@@ -188,6 +188,9 @@ def sequencer_default(seq: Sequencer):
             default = True
             seq.set("demod_en_acq", True)
             seq.set("connect_out0", "IQ")
+            seq.set("mod_en_awg", True)
+            seq.set("nco_freq", 0)
+            seq.set("nco_phase_offs", 0)
 
     if default:
         seq.set("cont_mode_en_awg_path0", False)

--- a/src/qibolab/_core/instruments/qblox/config.py
+++ b/src/qibolab/_core/instruments/qblox/config.py
@@ -165,6 +165,10 @@ def sequencer_default(seq: Sequencer):
         if seq.seq_idx < 4:
             default = True
             seq.set(f"connect_out{seq.seq_idx}", "I" if seq.seq_idx % 2 == 0 else "Q")
+            seq.set("mod_en_awg", True)
+            seq.set("nco_freq", 0)
+            seq.set("offset_awg_path0", 0)
+            seq.set("offset_awg_path1", 0)
         else:
             seq.set("connect_out0", "off")
             seq.set("connect_out1", "off")

--- a/src/qibolab/_core/instruments/qblox/config.py
+++ b/src/qibolab/_core/instruments/qblox/config.py
@@ -104,6 +104,30 @@ def module(
         mod.scope_acq_trigger_mode_path0("sequencer")
         mod.scope_acq_trigger_mode_path1("sequencer")
 
+    # apply defaults
+    # ---
+    if not mod.is_qrm_type and not mod.is_rf_type:
+        mod.out0_offset(0)
+        mod.out1_offset(0)
+        mod.out2_offset(0)
+        mod.out3_offset(0)
+
+    if not mod.is_qrm_type and mod.is_rf_type:
+        mod.out0_offset_path0(0)
+        mod.out0_offset_path1(0)
+        mod.out1_offset_path0(0)
+        mod.out1_offset_path1(0)
+
+    if mod.is_qrm_type:
+        mod.out0_offset_path0(0)
+        mod.out0_offset_path1(0)
+        mod.scope_acq_avg_mode_en_path0(True)
+        mod.scope_acq_avg_mode_en_path1(True)
+        mod.scope_acq_sequencer_select(0)
+        mod.scope_acq_trigger_level_path0(0)
+        mod.scope_acq_trigger_level_path1(0)
+    # ---
+
     # set lo frequencies
     for iq, lo in los.items():
         n = PortAddress.from_path(channels[iq].path).ports[0] - 1

--- a/src/qibolab/_core/instruments/qblox/config.py
+++ b/src/qibolab/_core/instruments/qblox/config.py
@@ -161,7 +161,6 @@ def sequencer_default(seq: Sequencer):
 
     default = False
     if not mod.is_qrm_type and not mod.is_rf_type:
-        seq.set("marker_ovr_value", 15)
         if seq.seq_idx < 4:
             default = True
             seq.set(f"connect_out{seq.seq_idx}", "I" if seq.seq_idx % 2 == 0 else "Q")

--- a/src/qibolab/_core/instruments/qblox/config.py
+++ b/src/qibolab/_core/instruments/qblox/config.py
@@ -155,6 +155,16 @@ def sequencer(
     seq.marker_ovr_en(not (sequence.is_empty and address.input))
     seq.marker_ovr_value(0 if sequence.is_empty else 15)
 
+    seq.set("cont_mode_en_awg_path0", False)
+    seq.set("cont_mode_en_awg_path1", False)
+    seq.set("cont_mode_waveform_idx_awg_path0", 0)
+    seq.set("cont_mode_waveform_idx_awg_path1", 0)
+    seq.set("mixer_corr_gain_ratio", 1)
+    seq.set("mixer_corr_phase_offset_degree", 0)
+    seq.set("nco_phase_offs", 0)
+    seq.set("upsample_rate_awg_path0", 0)
+    seq.set("upsample_rate_awg_path1", 0)
+
     # acquisition
     if address.input:
         assert isinstance(config, AcquisitionConfig)

--- a/src/qibolab/_core/instruments/qblox/results.py
+++ b/src/qibolab/_core/instruments/qblox/results.py
@@ -37,7 +37,7 @@ def integration_lenghts(
     return _fill_empty_lenghts(
         reduce(or_, (seq.integration_lengths for seq in sequences.values())),
         {
-            (mod_id, i): 1  # seq.integration_length_acq()
+            (mod_id, i): 480  # seq.integration_length_acq()
             for mod_id, mod in modules.items()
             for i, seq in enumerate(mod.sequencers)
             if hasattr(seq, "integration_length_acq")

--- a/src/qibolab/_core/instruments/qblox/results.py
+++ b/src/qibolab/_core/instruments/qblox/results.py
@@ -37,7 +37,7 @@ def integration_lenghts(
     return _fill_empty_lenghts(
         reduce(or_, (seq.integration_lengths for seq in sequences.values())),
         {
-            (mod_id, i): seq.integration_length_acq()
+            (mod_id, i): 1  # seq.integration_length_acq()
             for mod_id, mod in modules.items()
             for i, seq in enumerate(mod.sequencers)
             if hasattr(seq, "integration_length_acq")


### PR DESCRIPTION
With the last modifications in #1088, I'm pretty sure that the sequence uploaded is fully equivalent to the 0.1 (exact same waveforms' samples, the only differences in instructions are loops of length 1, or `set_ph 0` right after a `reset_ph`).

So, I'm now attempting to reproduce the exact same cluster snapshot (obtainable with `cluster.print_readable_snapshot()`, to avoid parsing manually all the Qcodes structures).

Here are the current snapshots being compared, before this PR.
[0.1-snapshot.txt](https://github.com/user-attachments/files/18967562/snapshot.txt)
[0.2-snapshot.txt](https://github.com/user-attachments/files/18967571/snapshot.txt)

The plan is to include all the differences, to make the 0.2 snapshot identical. The patches will be applied:
- directly in #1088, for those acknowledged to be required (i.e. whose role is explicitly understood) - and I will keep rebasing this branch
- or in here, if it is not clear how/why the change is affecting

## Known differences

### Cluster level
- [x] `reference_source`, reference clock

### Module level
- [x] `outX_offset`, to replace what is currently `Sequencer.offset_awg_path0`
    - I know the second can be affected in real time, but I'm not sure how the value set via Qcodes acts differently from the module level one
- [x] apply default values for `_path`, `_offset`, and `scope_`

#### Unused modules

They are not being configured in any way currently.

### Sequencer level
- [x] `connect_outX`, sometimes unset instead of `I`/`Q`/`IQ`/`off`
- [x] `marker_ovr_en`, sometimes `None` instead of `True`
- [x] `marker_ovr_value`, sometimes 0 instead of 15
- [x] `mod_en_awg`, sometimes `False` instead of `True`
- [x] `nco_freq`, sometimes `None` instead of `0`
- [x] `sync_en`, sometimes `None` instead of `True`
- [x] `thresholded_acq_threshold` for the used `qrm_rf` sequencer disagrees (`0.0060097` instead of `2.8846`)
- [x] `thresholded_acq_rotation` and `thresholded_acq_threshold` set for unused module (`270.14 (Degrees)` and `-7.3504e-05`)


#### Unused sequencers

They are not being configured in any way currently.

- [ ] default for all sequencers (`cont_mode_...`, `mixer_...`, ...) not applied

## Updated snapshot

[0.2-updated.txt](https://github.com/user-attachments/files/18968938/snapshot.txt)
