### PR TITLE
Add support for OPX1000 MW-FEMs

### DIFF
--- a/src/qibolab/_core/instruments/qm/components/configs.py
+++ b/src/qibolab/_core/instruments/qm/components/configs.py
@@ -77,7 +77,7 @@ class MwFemOscillatorConfig(OscillatorConfig):
 
     kind: Literal["mw-fem-oscillator"] = "mw-fem-oscillator"
 
-    power: int = -10
+    power: int = -11
     """This corresponds to the ``full_scale_power_dbm`` setting."""
     upconverter: int = 1
     band: int = 2

--- a/src/qibolab/_core/instruments/qm/components/configs.py
+++ b/src/qibolab/_core/instruments/qm/components/configs.py
@@ -5,7 +5,6 @@ from pydantic import Field
 from qibolab._core.components import (
     AcquisitionConfig,
     DcConfig,
-    IqConfig,
     OscillatorConfig,
 )
 
@@ -14,7 +13,7 @@ __all__ = [
     "QmAcquisitionConfig",
     "QmConfigs",
     "OctaveOscillatorConfig",
-    "MwFemConfig",
+    "MwFemOscillatorConfig",
 ]
 
 OctaveOutputModes = Literal[
@@ -69,24 +68,24 @@ class QmAcquisitionConfig(AcquisitionConfig):
     """Constant voltage to be applied on the input."""
 
 
-class MwFemConfig(IqConfig):
+class MwFemOscillatorConfig(OscillatorConfig):
     """Output config for OPX1000 MW-FEM ports.
 
     For more information see
     https://docs.quantum-machines.co/latest/docs/Guides/opx1000_fems/?h=upsampl#microwave-fem-mw-fem
     """
 
-    kind: Literal["mw-fem-output"] = "mw-fem-output"
+    kind: Literal["mw-fem-oscillator"] = "mw-fem-oscillator"
 
+    power: int = -10
     upconverter: int = 1
     band: int = 2
     sampling_rate: float = DEFAULT_SAMPLING_RATE
-    full_scale_power_dbm: int = -10
 
 
 QmConfigs = Union[
     OpxOutputConfig,
     OctaveOscillatorConfig,
     QmAcquisitionConfig,
-    MwFemConfig,
+    MwFemOscillatorConfig,
 ]

--- a/src/qibolab/_core/instruments/qm/components/configs.py
+++ b/src/qibolab/_core/instruments/qm/components/configs.py
@@ -70,6 +70,12 @@ class QmAcquisitionConfig(AcquisitionConfig):
 
 
 class MwFemConfig(IqConfig):
+    """Output config for OPX1000 MW-FEM ports.
+
+    For more information see
+    https://docs.quantum-machines.co/latest/docs/Guides/opx1000_fems/?h=upsampl#microwave-fem-mw-fem
+    """
+
     kind: Literal["mw-fem-output"] = "mw-fem-output"
 
     upconverter: int = 1

--- a/src/qibolab/_core/instruments/qm/components/configs.py
+++ b/src/qibolab/_core/instruments/qm/components/configs.py
@@ -78,6 +78,7 @@ class MwFemOscillatorConfig(OscillatorConfig):
     kind: Literal["mw-fem-oscillator"] = "mw-fem-oscillator"
 
     power: int = -10
+    """This corresponds to the ``full_scale_power_dbm`` setting."""
     upconverter: int = 1
     band: int = 2
     sampling_rate: float = DEFAULT_SAMPLING_RATE

--- a/src/qibolab/_core/instruments/qm/components/configs.py
+++ b/src/qibolab/_core/instruments/qm/components/configs.py
@@ -2,18 +2,26 @@ from typing import Literal, Union
 
 from pydantic import Field
 
-from qibolab._core.components import AcquisitionConfig, DcConfig, OscillatorConfig
+from qibolab._core.components import (
+    AcquisitionConfig,
+    DcConfig,
+    IqConfig,
+    OscillatorConfig,
+)
 
 __all__ = [
     "OpxOutputConfig",
     "QmAcquisitionConfig",
     "QmConfigs",
     "OctaveOscillatorConfig",
+    "MwFemConfig",
 ]
 
 OctaveOutputModes = Literal[
     "always_on", "always_off", "triggered", "triggered_reversed"
 ]
+
+DEFAULT_SAMPLING_RATE = 1e9
 
 
 class OpxOutputConfig(DcConfig):
@@ -35,6 +43,8 @@ class OpxOutputConfig(DcConfig):
     Changing the filters affects the calibration of single shot discrimination (threshold and angle).
     """
     output_mode: Literal["direct", "amplified"] = "direct"
+    sampling_rate: float = DEFAULT_SAMPLING_RATE
+    upsampling_mode: Literal["mw", "pulsed"] = "mw"
 
 
 class OctaveOscillatorConfig(OscillatorConfig):
@@ -59,4 +69,18 @@ class QmAcquisitionConfig(AcquisitionConfig):
     """Constant voltage to be applied on the input."""
 
 
-QmConfigs = Union[OpxOutputConfig, OctaveOscillatorConfig, QmAcquisitionConfig]
+class MwFemConfig(IqConfig):
+    kind: Literal["mw-fem-output"] = "mw-fem-output"
+
+    upconverter: int = 1
+    band: int = 2
+    sampling_rate: float = DEFAULT_SAMPLING_RATE
+    full_scale_power_dbm: int = -10
+
+
+QmConfigs = Union[
+    OpxOutputConfig,
+    OctaveOscillatorConfig,
+    QmAcquisitionConfig,
+    MwFemConfig,
+]

--- a/src/qibolab/_core/instruments/qm/components/configs.py
+++ b/src/qibolab/_core/instruments/qm/components/configs.py
@@ -43,7 +43,7 @@ class OpxOutputConfig(DcConfig):
     """
     output_mode: Literal["direct", "amplified"] = "direct"
     sampling_rate: float = DEFAULT_SAMPLING_RATE
-    upsampling_mode: Literal["mw", "pulsed"] = "mw"
+    upsampling_mode: Literal["mw", "pulse"] = "mw"
 
 
 class OctaveOscillatorConfig(OscillatorConfig):

--- a/src/qibolab/_core/instruments/qm/config/config.py
+++ b/src/qibolab/_core/instruments/qm/config/config.py
@@ -107,7 +107,8 @@ class Configuration:
         else:
             output = MwFemOutput.from_config(config)
         controller.analog_outputs[channel.port] = asdict(output)
-        self.elements[id] = MwFemElement.from_channel(channel, config.upconverter)
+        if id is not None:
+            self.elements[id] = MwFemElement.from_channel(channel, config.upconverter)
 
     def configure_mw_fem_acquire_line(
         self,

--- a/src/qibolab/_core/instruments/qm/config/devices.py
+++ b/src/qibolab/_core/instruments/qm/config/devices.py
@@ -51,7 +51,7 @@ class MwFemOutput:
 
     @classmethod
     def from_config(cls, config: MwFemConfig):
-        upconverters = {config.upconverter: config.frequency}
+        upconverters = {config.upconverter: {"frequency": config.frequency}}
         return cls(
             upconverters=upconverters,
             band=config.band,
@@ -64,7 +64,7 @@ class MwFemOutput:
         assert self.sampling_rate == config.sampling_rate
         assert self.full_scale_power_dbm == config.full_scale_power_dbm
         assert config.upconverter not in self.upconverters
-        self.upconverters[config.upconverter] = config.frequency
+        self.upconverters[config.upconverter] = {"frequency": config.frequency}
 
 
 @dataclass(frozen=True)

--- a/src/qibolab/_core/instruments/qm/config/devices.py
+++ b/src/qibolab/_core/instruments/qm/config/devices.py
@@ -131,8 +131,8 @@ class Controller:
     def add_octave_output(self, port: int):
         # TODO: Add offset here?
         self._set_default_inputs()
-        self.analog_outputs[2 * port - 1] = {}
-        self.analog_outputs[2 * port] = {}
+        self.analog_outputs[2 * port - 1] = {"offset": 0}
+        self.analog_outputs[2 * port] = {"offset": 0}
 
         self.digital_outputs[2 * port - 1] = {}
 

--- a/src/qibolab/_core/instruments/qm/config/devices.py
+++ b/src/qibolab/_core/instruments/qm/config/devices.py
@@ -18,14 +18,6 @@ __all__ = [
     "Controllers",
 ]
 
-
-DEFAULT_INPUTS = {"1": {"offset": 0}, "2": {"offset": 0}}
-"""Default controller config section.
-
-Inputs are always registered to avoid issues with automatic mixer
-calibration when using Octaves.
-"""
-
 V = TypeVar("V")
 
 
@@ -123,17 +115,29 @@ class Controller:
     analog_outputs: PortDict[dict[str, dict]] = field(default_factory=PortDict)
     digital_outputs: PortDict[dict[str, dict]] = field(default_factory=PortDict)
     analog_inputs: PortDict[dict[str, Union[AnalogInput, MwFemInput]]] = field(
-        default_factory=lambda: PortDict(DEFAULT_INPUTS)
+        default_factory=PortDict
     )
+
+    def _set_default_inputs(self):
+        """Add default inputs in controller config section.
+
+        Inputs are always registered to avoid issues with automatic mixer
+        calibration when using Octaves.
+        """
+        for port in range(1, 3):
+            if port not in self.analog_inputs:
+                self.analog_inputs[port] = {"offset": 0}
 
     def add_octave_output(self, port: int):
         # TODO: Add offset here?
+        self._set_default_inputs()
         self.analog_outputs[2 * port - 1] = {}
         self.analog_outputs[2 * port] = {}
 
         self.digital_outputs[2 * port - 1] = {}
 
     def add_octave_input(self, port: int, config: QmAcquisitionConfig):
+        self._set_default_inputs()
         self.analog_inputs[2 * port - 1] = self.analog_inputs[2 * port] = (
             AnalogInput.from_config(config)
         )

--- a/src/qibolab/_core/instruments/qm/config/devices.py
+++ b/src/qibolab/_core/instruments/qm/config/devices.py
@@ -3,7 +3,11 @@ from typing import Generic, Literal, TypeVar, Union
 
 from qibolab._core.components import OscillatorConfig
 
-from ..components import MwFemConfig, OctaveOscillatorConfig, QmAcquisitionConfig
+from ..components import (
+    MwFemOscillatorConfig,
+    OctaveOscillatorConfig,
+    QmAcquisitionConfig,
+)
 from ..components.configs import OctaveOutputModes
 
 __all__ = [
@@ -50,19 +54,19 @@ class MwFemOutput:
     full_scale_power_dbm: int
 
     @classmethod
-    def from_config(cls, config: MwFemConfig):
+    def from_config(cls, config: MwFemOscillatorConfig):
         upconverters = {config.upconverter: {"frequency": config.frequency}}
         return cls(
             upconverters=upconverters,
             band=config.band,
             sampling_rate=config.sampling_rate,
-            full_scale_power_dbm=config.full_scale_power_dbm,
+            full_scale_power_dbm=config.power,
         )
 
-    def update(self, config: MwFemConfig):
+    def update(self, config: MwFemOscillatorConfig):
         assert self.band == config.band
         assert self.sampling_rate == config.sampling_rate
-        assert self.full_scale_power_dbm == config.full_scale_power_dbm
+        assert self.full_scale_power_dbm == config.power
         assert config.upconverter not in self.upconverters
         self.upconverters[config.upconverter] = {"frequency": config.frequency}
 
@@ -74,7 +78,7 @@ class MwFemInput:
     sampling_rate: float
 
     @classmethod
-    def from_config(cls, config: MwFemConfig):
+    def from_config(cls, config: MwFemOscillatorConfig):
         return cls(
             downconverter_frequency=config.frequency,
             band=config.band,

--- a/src/qibolab/_core/instruments/qm/config/elements.py
+++ b/src/qibolab/_core/instruments/qm/config/elements.py
@@ -145,7 +145,7 @@ class MwFemElement:
 @dataclass
 class AcquireMwFemElement:
     MWInput: MwInput
-    MwOutput: MwOutput
+    MWOutput: MwOutput
     digitalInputs: DigitalInputs = field(default_factory=dict)
     time_of_flight: int = 24
     smearing: int = 0

--- a/src/qibolab/_core/instruments/qm/config/elements.py
+++ b/src/qibolab/_core/instruments/qm/config/elements.py
@@ -134,18 +134,25 @@ def _to_mw_fem_input(channel: Channel, upconverter: int):
 @dataclass
 class MwFemElement:
     MWInput: MwInput
+    intermediate_frequency: int
     digitalInputs: DigitalInputs = field(default_factory=dict)
     operations: dict[str, str] = field(default_factory=dict)
 
     @classmethod
-    def from_channel(cls, channel: Channel, upconverter: int):
-        return cls(_to_mw_fem_input(channel, upconverter))
+    def from_channel(
+        cls, channel: Channel, upconverter: int, intermediate_frequency: int
+    ):
+        return cls(
+            _to_mw_fem_input(channel, upconverter),
+            intermediate_frequency=intermediate_frequency,
+        )
 
 
 @dataclass
 class AcquireMwFemElement:
     MWInput: MwInput
     MWOutput: MwOutput
+    intermediate_frequency: int
     digitalInputs: DigitalInputs = field(default_factory=dict)
     time_of_flight: int = 24
     smearing: int = 0
@@ -157,12 +164,14 @@ class AcquireMwFemElement:
         probe_channel: Channel,
         upconverter: int,
         acquire_channel: Channel,
+        intermediate_frequency: int,
         time_of_flight: int,
         smearing: int,
     ):
         return cls(
             _to_mw_fem_input(probe_channel, upconverter),
             _to_port(acquire_channel),
+            intermediate_frequency=intermediate_frequency,
             time_of_flight=time_of_flight,
             smearing=smearing,
         )

--- a/src/qibolab/_core/instruments/qm/config/pulses.py
+++ b/src/qibolab/_core/instruments/qm/config/pulses.py
@@ -63,8 +63,8 @@ class ArbitraryWaveform:
         pad_len = new_duration - int(pulse.duration)
         baked_waveforms = np.pad(rotated_waveforms, ((0, 0), (0, pad_len)))
         return {
-            "I": cls(baked_waveforms[0]),
-            "Q": cls(baked_waveforms[1]),
+            "I": cls(baked_waveforms[0].tolist()),
+            "Q": cls(baked_waveforms[1].tolist()),
         }
 
 

--- a/src/qibolab/_core/instruments/qm/controller.py
+++ b/src/qibolab/_core/instruments/qm/controller.py
@@ -281,7 +281,7 @@ class QmController(Controller):
             if isinstance(lo_config, MwFemOscillatorConfig):
                 self.config.configure_mw_fem_line(ch, config, lo_config, channel)
             else:
-                self.config.configure_iq_line(channel, ch, config, lo_config)
+                self.config.configure_iq_line(ch, config, lo_config, channel)
 
         elif isinstance(ch, AcquisitionChannel):
             assert ch.probe is not None
@@ -295,16 +295,21 @@ class QmController(Controller):
             assert isinstance(lo_config, OscillatorConfig)
             if isinstance(lo_config, MwFemOscillatorConfig):
                 self.config.configure_mw_fem_acquire_line(
-                    channel,
                     ch,
                     probe,
                     config,
                     probe_config,
                     lo_config,
+                    channel,
                 )
             else:
                 self.config.configure_acquire_line(
-                    channel, ch, probe, config, probe_config, lo_config
+                    ch,
+                    probe,
+                    config,
+                    probe_config,
+                    lo_config,
+                    channel,
                 )
             return ch.probe
 

--- a/src/qibolab/_core/instruments/qm/controller.py
+++ b/src/qibolab/_core/instruments/qm/controller.py
@@ -302,7 +302,6 @@ class QmController(Controller):
                 assert probe.lo is not None
                 lo_config = configs[probe.lo]
                 assert isinstance(lo_config, OscillatorConfig)
-                self.configure_device(ch.device)
                 self.config.configure_acquire_line(
                     channel, ch, probe, config, probe_config, lo_config
                 )

--- a/src/qibolab/_core/instruments/qm/controller.py
+++ b/src/qibolab/_core/instruments/qm/controller.py
@@ -536,10 +536,7 @@ class QmController(Controller):
         experiment = program(args, options, sweepers, offsets)
 
         if self.script_file_name is not None:
-            script_config = (
-                {"version": 1} if self.manager is None else asdict(self.config)
-            )
-            script = generate_qua_script(experiment, script_config)
+            script = generate_qua_script(experiment, asdict(self.config))
             with open(self.script_file_name, "w") as file:
                 file.write(script)
 


### PR DESCRIPTION
Adds support for [MW-FEMs](https://docs.quantum-machines.co/latest/docs/Guides/opx1000_fems/?h=upsampl#microwave-fem-mw-fem) in the QM driver. In TII lab we only have LF-FEMs so we I cannot fully test this. I am only relying on printing the generated `config` and checking whether it complies with the format presented in https://docs.quantum-machines.co/latest/docs/Introduction/config/?h=fem#configuration-components.

Here is an example platform with two flux tunable qubits on a single readout, controlled using MW-FEM for readout and drive and LF-FEM for flux:
<details>
<summary>platform.py</summary>

```py
import pathlib

from qibolab import (
    AcquisitionChannel,
    ConfigKinds,
    DcChannel,
    IqChannel,
    Platform,
    Qubit,
)
from qibolab.instruments.qm import Octave, QmConfigs, QmController

FOLDER = pathlib.Path(__file__).parent

# Register QM-specific configurations for parameters loading
ConfigKinds.extend([QmConfigs])


def create():
    qubits = {i: Qubit.default(i) for i in range(2)}

    # Create channels and connect to instrument ports
    # Readout
    channels = {}
    for q in qubits.values():
        channels[q.probe] = IqChannel(
            device="con1/1", path="1", mixer=None, lo=None
        )
    # Acquire
    for q in qubits.values():
        channels[q.acquisition] = AcquisitionChannel(
            device="con1/1", path="1", twpa_pump="twpa", probe=q.probe
        )
    # Drive
    channels[qubits[0].drive] = IqChannel(
        device="con1/1", path="2", mixer=None, lo=None
    )
    channels[qubits[1].drive] = IqChannel(
        device="con1/1", path="4", mixer=None, lo=None
    )

    # Flux
    channels[qubits[0].flux] = DcChannel(device="con1/2", path="1")
    channels[qubits[1].flux] = DcChannel(device="con1/2", path="2")

    fems = {"con1/1": "MW", "con1/2": "LF"}
    controller = QmController(
        address="192.168.0.105:80",
        fems=fems,
        channels=channels,
        calibration_path=FOLDER,
    )
    instruments = {"qm": controller}
    return Platform.load(path=FOLDER, instruments=instruments, qubits=qubits)
```

</details>

<details>
<summary>parameters.json</summary>

```json
{
    "settings": {
        "nshots": 2048,
        "relaxation_time": 100000
    },
    "configs": {
        "qm/bounds": {
            "waveforms": 40000,
            "readout": 30,
            "instructions": 1000000,
            "kind": "bounds"
        },
        "0/drive": {
            "kind": "mw-fem-output",
            "frequency": 4768135481,
            "upconverter": 1,
            "band": 1
        },
        "0/drive12": {
            "kind": "mw-fem-output",
            "frequency": 4482584846,
            "upconverter": 1,
            "band": 1
        },
        "0/probe": {
            "kind": "mw-fem-output",
            "frequency": 7203155906,
            "upconverter": 1,
            "band": 3
        },
        "1/drive": {
            "kind": "mw-fem-output",
            "frequency": 5517550116,
            "upconverter": 1,
            "band": 2
        },
        "1/drive12": {
            "kind": "mw-fem-output",
            "frequency": 5205873098,
            "upconverter": 1,
            "band": 2
        },
        "1/probe": {
            "kind": "mw-fem-output",
            "frequency": 7496149642,
            "upconverter": 1,
            "band": 3
        },
        "0/acquisition": {
            "kind": "qm-acquisition",
            "delay": 224,
            "smearing": 0.0,
            "threshold": 0.004192128608094518,
            "iq_angle": 1.0692526458388023,
            "kernel": null,
            "gain": 10
        },
        "1/acquisition": {
            "kind": "qm-acquisition",
            "delay": 224,
            "smearing": 0.0,
            "threshold": 0.005696653584116273,
            "iq_angle": 0.7070647945870343,
            "kernel": null,
            "gain": 10
        },
        "0/flux": {
            "kind": "opx-output",
            "offset": 0.36277712048456884,
            "filter": {},
            "output_mode": "amplified"
        },
        "1/flux": {
            "kind": "opx-output",
            "offset": 0.5479482811779897,
            "filter": {},
            "output_mode": "amplified"
        }
    },
    "native_gates": {
        "single_qubit": {
            "0": {
                "RX": [
                    [
                        "0/drive",
                        {
                            "kind": "pulse",
                            "duration": 40,
                            "amplitude": 0.17908866460553952,
                            "envelope": {
                                "kind": "gaussian",
                                "rel_sigma": 0.2
                            },
                            "relative_phase": 0
                        }
                    ]
                ],
                "RX12": [
                    [
                        "0/drive",
                        {
                            "kind": "pulse",
                            "duration": 40,
                            "amplitude": 0.36,
                            "envelope": {
                                "kind": "drag",
                                "rel_sigma": 0.2,
                                "beta": 0.0
                            },
                            "relative_phase": 0.0
                        }
                    ]
                ],
                "MZ": [
                    [
                        "0/acquisition",
                        {
                            "kind": "readout",
                            "acquisition": {
                                "kind": "acquisition",
                                "duration": 2000
                            },
                            "probe": {
                                "kind": "pulse",
                                "duration": 2000,
                                "amplitude": 0.01,
                                "envelope": {
                                    "kind": "rectangular"
                                },
                                "relative_phase": 0
                            }
                        }
                    ]
                ]
            },
            "1": {
                "RX": [
                    [
                        "1/drive",
                        {
                            "kind": "pulse",
                            "duration": 40,
                            "amplitude": 0.10210964519118683,
                            "envelope": {
                                "kind": "gaussian",
                                "rel_sigma": 0.2
                            },
                            "relative_phase": 0.0
                        }
                    ]
                ],
                "RX12": [
                    [
                        "1/drive",
                        {
                            "kind": "pulse",
                            "duration": 40,
                            "amplitude": 0.449,
                            "envelope": {
                                "kind": "drag",
                                "rel_sigma": 0.2,
                                "beta": 0.0
                            },
                            "relative_phase": 0.0
                        }
                    ]
                ],
                "MZ": [
                    [
                        "1/acquisition",
                        {
                            "kind": "readout",
                            "acquisition": {
                                "kind": "acquisition",
                                "duration": 2000
                            },
                            "probe": {
                                "kind": "pulse",
                                "duration": 2000,
                                "amplitude": 0.006,
                                "envelope": {
                                    "kind": "rectangular"
                                },
                                "relative_phase": 0.0
                            }
                        }
                    ]
                ]
            }
        },
        "coupler": {},
        "two_qubit": {
            "0-1": {
                "CZ": [
                    [
                        "1/flux",
                        {
                            "kind": "pulse",
                            "duration": 31,
                            "amplitude": 0.47,
                            "envelope": {
                                "kind": "rectangular"
                            },
                            "relative_phase": 0.0
                        }
                    ],
                    [
                        "0/drive",
                        {
                            "kind": "virtualz",
                            "phase": 0.10432916513703352
                        }
                    ],
                    [
                        "1/drive",
                        {
                            "kind": "virtualz",
                            "phase": 6.112548493656258
                        }
                    ]
                ]
            }
        }
    }
}
```

</details>