### PR TITLE
Introduce integration acquisition mode for emulator

### DIFF
--- a/src/qibolab/_core/instruments/emulator/hamiltonians.py
+++ b/src/qibolab/_core/instruments/emulator/hamiltonians.py
@@ -4,11 +4,11 @@ from typing import Literal, Optional
 
 import numpy as np
 from pydantic import Field
+from scipy.constants import giga
 
 from ...components import Config, IqConfig
 from ...pulses import Delay, Pulse
 from .operators import L1, L2, QUBIT_DRIVE, SIGMAZ
-from .utils import HZ_TO_GHZ
 
 
 class Qubit(Config):
@@ -24,7 +24,7 @@ class Qubit(Config):
     @property
     def operator(self):
         """Time independent operator."""
-        return -np.pi * self.frequency * HZ_TO_GHZ * SIGMAZ
+        return -np.pi * (self.frequency / giga) * SIGMAZ
 
     @property
     def t_phi(self):
@@ -104,4 +104,4 @@ def waveform(pulse, channel, configs, updates=None) -> Optional[QubitDrive]:
     config = configs[channel].model_copy(update=updates.get(channel, {}))
     frequency = config.frequency
     pulse = pulse.model_copy(update=updates.get(pulse.id, {}))
-    return QubitDrive(pulse=pulse, frequency=frequency * HZ_TO_GHZ)
+    return QubitDrive(pulse=pulse, frequency=frequency / giga)

--- a/src/qibolab/_core/instruments/emulator/utils.py
+++ b/src/qibolab/_core/instruments/emulator/utils.py
@@ -1,11 +1,6 @@
 import numpy as np
 from numpy.typing import NDArray
 
-GHZ_TO_HZ = 1e9
-"""Converting GHz to Hz."""
-HZ_TO_GHZ = 1e-9
-"""Converting Hz to GHz."""
-
 
 def ndchoice(probabilities: NDArray, samples: int) -> NDArray:
     """Sample elements with n-dimensional probabilities.


### PR DESCRIPTION
Closes #1170

@andrea-pasquale I'm not sure whether I should aim to do anything more in here.

Just to summarize what it may be possible about integration: currently, I'm just putting the content of discrimination on the I component, supplying a null Q one, and adding some fixed Gaussian noise.
We could add some configurations (alongside channels configs), to perform the following operations:
- scale the noise by a custom $\sigma$
- scale the noise with an array of $\sigma_{\ket{i}}$, according to the discriminated $\ket{i}$ state (it would only apply in single-shot, and averaged for cyclic/sequential averages)
- introduce an angle and threshold, to rotate and translate the entire plane
- introduce an amplification, to scale the whole plane

All of these are just trivial arrays manipulation, but they require handling some more configurations. Which is also pretty straightforward, but pure overhead if not needed.