### PR TITLE
Generalize acquisitions handling in emulator

### DIFF
--- a/src/qibolab/_core/instruments/emulator/emulator.py
+++ b/src/qibolab/_core/instruments/emulator/emulator.py
@@ -40,11 +40,16 @@ def update_configs(configs: dict[str, Config], updates: dict) -> dict[str, Confi
     return {k: c.model_copy(update=updates.get(k, {})) for k, c in configs.items()}
 
 
-def tlist(sequence: PulseSequence, sampling_rate: float) -> NDArray:
+def tlist(
+    sequence: PulseSequence, sampling_rate: float, per_sample: float = 2
+) -> NDArray:
     """Compute times for evolution.
 
     The frequency of times is double the sampling rate, to make sure
     that all pulses features are resolved by the evolution.
+
+    This can be customized using the `per_sample` rate, e.g. to retrieve times at the
+    sampling rate itself, for pulses evaluation.
 
     .. note::
 
@@ -62,7 +67,8 @@ def tlist(sequence: PulseSequence, sampling_rate: float) -> NDArray:
         else sequence
     )
     end = max(seq.duration, 1)
-    return np.arange(0, end, 1 / sampling_rate / 2)
+    rate = sampling_rate * per_sample
+    return np.arange(0, end, 1 / rate)
 
 
 def wrapped_time(waveforms):

--- a/src/qibolab/_core/instruments/emulator/emulator.py
+++ b/src/qibolab/_core/instruments/emulator/emulator.py
@@ -81,7 +81,7 @@ def wrapped_time(waveforms):
 
 
 def extract_probabilities(
-    expectations: NDArray, acquisitions: Iterable[float], times: NDArray
+    expectations: list[NDArray], acquisitions: Iterable[float], times: NDArray
 ) -> NDArray:
     """Extract probabilities from expectations.
 
@@ -93,7 +93,7 @@ def extract_probabilities(
     """
     acq = np.array(list(acquisitions))
     samples = np.minimum(np.searchsorted(times, acq), times.size - 1)
-    return (1 - expectations[samples]) / 2
+    return np.stack(expectations, axis=-1)[samples]
 
 
 class EmulatorController(Controller):
@@ -136,9 +136,7 @@ class EmulatorController(Controller):
         )
 
         return extract_probabilities(
-            np.stack(results.expect, axis=-1),
-            self._acquisitions(sequence_).values(),
-            tlist_,
+            results.expect, self._acquisitions(sequence_).values(), tlist_
         )
 
     def _sweep(

--- a/src/qibolab/_core/instruments/emulator/emulator.py
+++ b/src/qibolab/_core/instruments/emulator/emulator.py
@@ -66,10 +66,10 @@ class EmulatorController(Controller):
         config = cast(HamiltonianConfig, configs["hamiltonian"])
         sequence_ = update_sequence(sequence, updates)
         hamiltonian = config.hamiltonian
-        hamiltonian += self._pulse_sequence_to_hamiltonian(sequence_, configs)
-        tlist = measurements(sequence_)
-        # return probability of 1 for generic system
-        # TODO: add option to retrieve probability of 0 or 2
+        hamiltonian += self._pulse_sequence_to_hamiltonian(sequence_, configs, updates)
+        tlist = np.arange(
+            0, max(measurements(sequence_).values()), 1 / self.sampling_rate / 2
+        )
         results = mesolve(
             hamiltonian,
             config.initial_state,
@@ -77,7 +77,7 @@ class EmulatorController(Controller):
             config.dissipation,
             e_ops=[config.probability(state=i) for i in range(config.transmon_levels)],
         )
-        acq = np.array(list(self._acquisitions(sequence_).values())) - 1
+        acq = np.array(list(self._acquisitions(sequence_).values()))
         return np.stack(
             [results.expect[i][acq] for i in range(config.transmon_levels)], axis=-1
         )

--- a/src/qibolab/_core/instruments/emulator/hamiltonians.py
+++ b/src/qibolab/_core/instruments/emulator/hamiltonians.py
@@ -1,11 +1,13 @@
 from dataclasses import dataclass
 from functools import cache, cached_property
-from typing import Literal, Optional
+from typing import Literal, Optional, Union
 
 import numpy as np
 from pydantic import Field
 from qutip import Qobj
 from scipy.constants import giga
+
+from qibolab._core.serialize import Model
 
 from ...components import Config, IqConfig
 from ...identifier import QubitId, TransitionId
@@ -87,16 +89,13 @@ class QubitDrive:
 
     @cached_property
     def envelopes(self):
-        if isinstance(self.pulse, Delay):
-            return [np.zeros(len(self)), np.zeros(len(self))]
         return self.pulse.envelopes(self.sampling_rate)
 
-    def __len__(self):
-        return int(self.pulse.duration * self.sampling_rate)
+    @property
+    def duration(self):
+        return self.pulse.duration
 
     def __call__(self, t, sample):
-        if isinstance(self.pulse, Delay):
-            return 0
         i, q = self.envelopes
         omega = 2 * np.pi * self.frequency * t + self.pulse.relative_phase
         return self.pulse.amplitude * (
@@ -109,6 +108,16 @@ def channel_operator(n: int) -> Qobj:
     """Time independent operator for channel coupling."""
     # TODO: add distinct operators for distinct channel types
     return -1.0j * (transmon_destroy(n) - transmon_create(n))
+
+
+class ModulatedDelay(Model):
+    duration: float
+
+    def __call__(self, t: float, sample: int) -> float:
+        return 0
+
+
+Modulated = Union[QubitDrive, ModulatedDelay]
 
 
 class HamiltonianConfig(Config):
@@ -140,11 +149,15 @@ class HamiltonianConfig(Config):
         ]
 
 
-def waveform(pulse: Pulse, channel: Config, level: int) -> Optional[QubitDrive]:
+def waveform(
+    pulse: Union[Pulse, Delay], channel: Config, level: int
+) -> Optional[Modulated]:
     """Convert pulse to hamiltonian."""
     # mapping IqConfig -> QubitDrive
     if not isinstance(channel, IqConfig):
         return None
 
-    frequency = channel.frequency
-    return QubitDrive(pulse=pulse, frequency=frequency / giga, n=level)
+    if isinstance(pulse, Pulse):
+        frequency = channel.frequency
+        return QubitDrive(pulse=pulse, frequency=frequency / giga, n=level)
+    return ModulatedDelay(duration=pulse.duration)

--- a/src/qibolab/_core/instruments/emulator/hamiltonians.py
+++ b/src/qibolab/_core/instruments/emulator/hamiltonians.py
@@ -137,18 +137,15 @@ class HamiltonianConfig(Config):
         ]
 
 
-def waveform(pulse, channel, configs, updates=None) -> Optional[QubitDrive]:
+def waveform(pulse, channel, configs) -> Optional[QubitDrive]:
     """Convert pulse to hamiltonian."""
-    if updates is None:
-        updates = {}
     # mapping IqConfig -> QubitDrive
-
     if not isinstance(configs[channel], IqConfig):
         return None
 
-    config = configs[channel].model_copy(update=updates.get(channel, {}))
+    frequency = configs[channel].frequency
     return QubitDrive(
         pulse=pulse,
-        frequency=config.frequency / giga,
+        frequency=frequency / giga,
         n=configs["hamiltonian"].transmon_levels,
     )

--- a/src/qibolab/_core/instruments/emulator/hamiltonians.py
+++ b/src/qibolab/_core/instruments/emulator/hamiltonians.py
@@ -147,9 +147,8 @@ def waveform(pulse, channel, configs, updates=None) -> Optional[QubitDrive]:
         return None
 
     config = configs[channel].model_copy(update=updates.get(channel, {}))
-    frequency = config.frequency
     return QubitDrive(
         pulse=pulse,
-        frequency=frequency / giga,
+        frequency=config.frequency / giga,
         n=configs["hamiltonian"].transmon_levels,
     )

--- a/src/qibolab/_core/instruments/emulator/hamiltonians.py
+++ b/src/qibolab/_core/instruments/emulator/hamiltonians.py
@@ -148,7 +148,6 @@ def waveform(pulse, channel, configs, updates=None) -> Optional[QubitDrive]:
 
     config = configs[channel].model_copy(update=updates.get(channel, {}))
     frequency = config.frequency
-    pulse = pulse.model_copy(update=updates.get(pulse.id, {}))
     return QubitDrive(
         pulse=pulse,
         frequency=frequency / giga,


### PR DESCRIPTION
### Acquisitions' times computation

In the emulator, the acquisitions were isolated from the various expectation values returned, by computing the times at which they were supposed to happen.
This computation was not taking into account the presence of multiple channels, and a single duration was used for all of them
https://github.com/qiboteam/qibolab/blob/599db8a0fcd79d5d9698fb20b9670cbf0a17180d/src/qibolab/_core/instruments/emulator/emulator.py#L167-L175

In practice, it was already working, because the acquisition channels were isolated (checking for the `AcquisitionConfig`) and a single qubit was present. So, in this specific case, a single channel was isolated.

By reworking, such that it acts on each channel separately, the computation is easier (since no access to configs is required) and more general (taking into account arbitrarily many acquisitions channels).

### Integer samples with floating point times

Moreover, the sampling rate and times were all treated as integers, using integer numbers of nanoseconds. This is not required at all, and now the computation is performed for general sampling rates, with `tlist` having double frequency than the specified sampling rate.

https://github.com/qiboteam/qibolab/blob/599db8a0fcd79d5d9698fb20b9670cbf0a17180d/src/qibolab/_core/instruments/emulator/emulator.py#L180

### Bulk apply updates

Sweep updates are now applied to the sequence, rather than propagating them till the waveform computation.