### PR TITLE
Generalize emulator to n-levels transmon

### DIFF
--- a/src/qibolab/_core/instruments/emulator/emulator.py
+++ b/src/qibolab/_core/instruments/emulator/emulator.py
@@ -23,8 +23,6 @@ from qibolab._core.sequence import PulseSequence
 from qibolab._core.sweeper import ParallelSweepers
 
 from .hamiltonians import HamiltonianConfig, waveform
-
-# from .operators import INITIAL_STATE, SIGMAZ
 from .utils import shots
 
 

--- a/src/qibolab/_core/instruments/emulator/hamiltonians.py
+++ b/src/qibolab/_core/instruments/emulator/hamiltonians.py
@@ -41,7 +41,7 @@ class Qubit(Config):
         quadratic_term = transmon_create(n) * transmon_destroy(n) * self.omega / giga
         quartic_term = (
             self.anharmonicity
-            / 2
+            * np.pi
             / giga
             * transmon_create(n)
             * transmon_create(n)

--- a/src/qibolab/_core/instruments/emulator/hamiltonians.py
+++ b/src/qibolab/_core/instruments/emulator/hamiltonians.py
@@ -7,8 +7,16 @@ from pydantic import Field
 from scipy.constants import giga
 
 from ...components import Config, IqConfig
+from ...identifier import QubitId, TransitionId
 from ...pulses import Delay, Pulse
-from .operators import L1, L2, QUBIT_DRIVE, SIGMAZ
+from .operators import (
+    dephasing,
+    probability,
+    relaxation,
+    state,
+    transmon_create,
+    transmon_destroy,
+)
 
 
 class Qubit(Config):
@@ -16,26 +24,51 @@ class Qubit(Config):
 
     frequency: float = 0
     """Qubit frequency for 0->1."""
-    t1: float = 0
-    """Relaxation time."""
-    t2: float = 0
-    """Coherence time."""
+    anharmonicity: float = 0
+    """Qubit anharmonicity."""
+    t1: dict[TransitionId, float] = Field(default_factory=dict)
+    """Dictionary with relaxation times per transition."""
+    t2: dict[TransitionId, float] = Field(default_factory=dict)
+    """Dictionary with dephasing time per transition."""
 
     @property
-    def operator(self):
+    def omega(self) -> float:
+        """Angular velocity."""
+        return 2 * np.pi * self.frequency
+
+    def operator(self, n: int):
         """Time independent operator."""
-        return -np.pi * (self.frequency / giga) * SIGMAZ
+        quadratic_term = transmon_create(n) * transmon_destroy(n) * self.omega / giga
+        quartic_term = (
+            self.anharmonicity
+            / 2
+            / giga
+            * transmon_create(n)
+            * transmon_create(n)
+            * transmon_destroy(n)
+            * transmon_destroy(n)
+        )
+        return quadratic_term + quartic_term
 
-    @property
-    def t_phi(self):
-        """T_phi computed from T1 and T2."""
-        return 1 / (1 / self.t2 - 1 / self.t1 / 2)
+    def t_phi(self, transition: TransitionId) -> float:
+        """T_phi computed from T1 and T2 per transition."""
+        return 1 / (1 / self.t2[transition] - 1 / self.t1[transition] / 2)
 
-    @property
-    def decoherence(self):
+    def relaxation(self, n: int):
+        return sum(
+            np.sqrt(1 / t1) * relaxation(pair[0], pair[1], n)
+            for pair, t1 in self.t1.items()
+        )
+
+    def dephasing(self, n: int):
+        return sum(
+            np.sqrt(1 / self.t_phi(pair) / 2) * dephasing(pair[0], pair[1], n)
+            for pair in self.t2
+        )
+
+    def dissipation(self, n: int):
         """Decoherence operator."""
-        assert self.t1 > 0 and self.t2 > 0
-        return np.sqrt(1 / self.t1) * L1 + np.sqrt(1 / self.t_phi / 2) * L2
+        return self.relaxation(n) + self.dephasing(n)
 
 
 @dataclass
@@ -46,6 +79,8 @@ class QubitDrive:
     """Drive pulse."""
     frequency: float
     """Drive frequency."""
+    n: int
+    """Transmon levels."""
     sampling_rate: float = 1
     """Sampling rate."""
 
@@ -58,7 +93,7 @@ class QubitDrive:
     @cached_property
     def operator(self):
         """Time independent operator."""
-        return QUBIT_DRIVE
+        return -1.0j * (transmon_destroy(self.n) - transmon_create(self.n))
 
     def __len__(self):
         return int(self.pulse.duration * self.sampling_rate)
@@ -77,16 +112,26 @@ class HamiltonianConfig(Config):
     """Hamiltonian configuration."""
 
     kind: Literal["hamiltonian"] = "hamiltonian"
-    single_qubit: dict[str, Qubit] = Field(default_factory=dict)
+    transmon_levels: int = 2
+    single_qubit: dict[QubitId, Qubit] = Field(default_factory=dict)
+
+    @property
+    def initial_state(self):
+        return state(0, self.transmon_levels)
+
+    def probability(self, state: int):
+        return probability(state=state, n=self.transmon_levels)
 
     @property
     def hamiltonian(self):
-        return [qubit.operator for qubit in self.single_qubit.values()]
+        return [
+            qubit.operator(self.transmon_levels) for qubit in self.single_qubit.values()
+        ]
 
     @property
-    def decoherence(self):
+    def dissipation(self):
         return [
-            qubit.decoherence
+            qubit.dissipation(self.transmon_levels)
             for qubit in self.single_qubit.values()
             if not isinstance(qubit, list)
         ]
@@ -104,4 +149,8 @@ def waveform(pulse, channel, configs, updates=None) -> Optional[QubitDrive]:
     config = configs[channel].model_copy(update=updates.get(channel, {}))
     frequency = config.frequency
     pulse = pulse.model_copy(update=updates.get(pulse.id, {}))
-    return QubitDrive(pulse=pulse, frequency=frequency / giga)
+    return QubitDrive(
+        pulse=pulse,
+        frequency=frequency / giga,
+        n=configs["hamiltonian"].transmon_levels,
+    )

--- a/src/qibolab/_core/instruments/emulator/operators.py
+++ b/src/qibolab/_core/instruments/emulator/operators.py
@@ -1,23 +1,39 @@
-from qutip import basis, sigmap, sigmax, sigmaz, tensor
+"""Useful operators in qutip for n levels transmon."""
 
-N_LEVELS = 2
-"""Levels for transmon system."""
+from qutip import Qobj, basis, create, destroy, tensor
 
-STATE_0 = basis(N_LEVELS, 0)
-"""State 0."""
-STATE_1 = basis(N_LEVELS, 1)
-"""State 1."""
 
-INITIAL_STATE = tensor(STATE_0)
-"""System initial state."""
+def transmon_create(n: int) -> Qobj:
+    """Creation operator for n levels system."""
+    return create(n)
 
-SIGMAZ = sigmaz()
-"""Qubit destruction operator."""
-QUBIT_DRIVE = sigmax()
-"""Qubit drive term."""
 
-# TODO: check these operators
-L1 = sigmap()
-"""Time relaxation operator."""
-L2 = sigmaz()
-"""Dephasing operator."""
+def transmon_destroy(n: int) -> Qobj:
+    """Destruction operator for n levels system."""
+    return destroy(n)
+
+
+def relaxation(final_state: int, initial_state: int, n: int) -> Qobj:
+    """Relaxation operator.
+
+    Matrix element for initial_state -> final_state decay.
+    """
+    return basis(n, final_state) * basis(n, initial_state).dag()
+
+
+def dephasing(state0: int, state1: int, n: int) -> Qobj:
+    """Dephasing operator between two states."""
+    return (
+        basis(n, state0) * basis(n, state0).dag()
+        - basis(n, state1) * basis(n, state1).dag()
+    )
+
+
+def probability(state: int, n: int) -> Qobj:
+    """Probability of measuring state."""
+    return basis(n, state) * basis(n, state).dag()
+
+
+def state(state, n) -> Qobj:
+    """State as tensor for qutip."""
+    return tensor(basis(n, state))

--- a/src/qibolab/_core/instruments/emulator/utils.py
+++ b/src/qibolab/_core/instruments/emulator/utils.py
@@ -28,14 +28,11 @@ def ndchoice(probabilities: NDArray, samples: int) -> NDArray:
 
 
 def shots(probabilities: NDArray, nshots: int) -> NDArray:
-    """Extract shots from state |1> probabilities.
+    """Extract shots from state |0> ... |n> probabilities.
 
     This function just wraps :func:`ndchoice`, taking care of creating the n-D array of
     binomial distributions, and extracting shots as the outermost dimension.
     """
-    # discrete distributions of [|0>, |1>] states, over the innermost dimension
-    dists = np.stack([1 - probabilities, probabilities], axis=-1)
-    # shots, in the innermost dimension, replacing the distribution dimension
-    shots = ndchoice(dists, nshots)
+    shots = ndchoice(probabilities, nshots)
     # move shots from innermost to outermost dimension
     return np.moveaxis(shots, -1, 0)


### PR DESCRIPTION
In this PR I generalized the emulator to a $n$-levels transmon system with a driving term

```math
H = \omega_q b^\dagger b + \frac{\alpha}{2} b^\dagger  b^\dagger  b b - i V(t) \epsilon(t)(b - b^\dagger) 
```
I was able to run a qubit spectroscopy between to find the frequency for the $1\rightarrow 2$ transition, assuming a $\omega_q^{01} = 5.0 \ \text{GHz}$ and $\frac{\alpha}{2 \pi} = - 200 \ \text{MHz}$ I was able to correctly measure the transition frequency between $\ket{1} \rightarrow \ket{2}$.

![Screenshot 2025-03-17 at 12 22 45](https://github.com/user-attachments/assets/6d00f464-9270-40c1-a2ec-9ecfb7a421c1)
Here on the y axis I am measuring the population of the excited state.
I was able to run a Rabi experiments between state $\ket{1}$ and $\ket{2}.$

![Screenshot 2025-03-17 at 12 27 40](https://github.com/user-attachments/assets/bd910ff7-3bb0-4b3f-9632-ae00eeded26a)

Here the y axis is again the population of $\ket{1}$ while the x axis is the drive power.
I've also added dissipation (see Qibocal related PR https://github.com/qiboteam/qibocal/pull/1113).