### PR TITLE
Renaming `drive_qudits` to `drive_extra`

### DIFF
--- a/doc/source/main-documentation/qibolab.rst
+++ b/doc/source/main-documentation/qibolab.rst
@@ -168,7 +168,7 @@ These channels encompass distinct types, each serving a specific purpose:
 - acquisition (measurement acquisition from qubits to controller)
 - drive
 - flux
-- drive_qudits (additional drive channels at different frequencies used to probe higher-level transition)
+- drive_extra (additional drive channels at different frequencies used to probe higher-level transition)
 
 Some channel types are optional because not all hardware platforms require them.
 For example, flux channels are typically relevant only for flux tunable qubits.

--- a/src/qibolab/_core/dummy/platform.py
+++ b/src/qibolab/_core/dummy/platform.py
@@ -17,7 +17,7 @@ def create_dummy_hardware() -> Hardware:
     pump_name = "twpa_pump"
     for q in range(5):
         drive12 = f"{q}/drive12"
-        qubits[q] = qubit = Qubit.default(q, drive_qudits={(1, 2): drive12})
+        qubits[q] = qubit = Qubit.default(q, drive_extra={(1, 2): drive12})
         channels |= {
             qubit.probe: IqChannel(mixer=None, lo=None),
             qubit.acquisition: AcquisitionChannel(

--- a/src/qibolab/_core/parameters.py
+++ b/src/qibolab/_core/parameters.py
@@ -226,6 +226,7 @@ class Parameters(Model):
 
 
 QubitMap = dict[QubitId, Qubit]
+QubitPairMap = dict[QubitPairId, Qubit]
 InstrumentMap = dict[InstrumentId, Instrument]
 
 
@@ -235,6 +236,7 @@ class Hardware(Model):
     instruments: InstrumentMap
     qubits: QubitMap
     couplers: QubitMap = Field(default_factory=dict)
+    pairs: QubitPairMap = Field(default_factory=dict)
 
 
 def _gate_channel(qubit: Qubit, gate: str) -> str:

--- a/src/qibolab/_core/parameters.py
+++ b/src/qibolab/_core/parameters.py
@@ -226,7 +226,6 @@ class Parameters(Model):
 
 
 QubitMap = dict[QubitId, Qubit]
-QubitPairMap = dict[QubitPairId, Qubit]
 InstrumentMap = dict[InstrumentId, Instrument]
 
 
@@ -236,7 +235,6 @@ class Hardware(Model):
     instruments: InstrumentMap
     qubits: QubitMap
     couplers: QubitMap = Field(default_factory=dict)
-    qubit_pairs: QubitPairMap = Field(default_factory=dict)
 
 
 def _gate_channel(qubit: Qubit, gate: str) -> str:

--- a/src/qibolab/_core/parameters.py
+++ b/src/qibolab/_core/parameters.py
@@ -236,7 +236,7 @@ class Hardware(Model):
     instruments: InstrumentMap
     qubits: QubitMap
     couplers: QubitMap = Field(default_factory=dict)
-    pairs: QubitPairMap = Field(default_factory=dict)
+    qubit_pairs: QubitPairMap = Field(default_factory=dict)
 
 
 def _gate_channel(qubit: Qubit, gate: str) -> str:

--- a/src/qibolab/_core/parameters.py
+++ b/src/qibolab/_core/parameters.py
@@ -242,7 +242,7 @@ def _gate_channel(qubit: Qubit, gate: str) -> str:
     if gate in ("RX", "RX90", "CNOT"):
         return qubit.drive
     if gate == "RX12":
-        return qubit.drive_qudits[(1, 2)]
+        return qubit.drive_extra[(1, 2)]
     if gate == "MZ":
         return qubit.acquisition
     if gate in ("CP", "CZ", "iSWAP"):

--- a/src/qibolab/_core/platform/platform.py
+++ b/src/qibolab/_core/platform/platform.py
@@ -17,7 +17,6 @@ from ..parameters import (
     NativeGates,
     Parameters,
     QubitMap,
-    QubitPairMap,
     Settings,
     Update,
     update_configs,
@@ -96,11 +95,6 @@ class Platform:
 
     Fully analogue to :attr:`qubits`. Only the flux channel is expected to be populated
     in the mapped objects.
-    """
-    qubit_pairs: QubitPairMap = field(default_factory=dict)
-    """Pairs controllers.
-
-    Necessary to add drive for CR gate.
     """
     resonator_type: Literal["2D", "3D"] = "2D"
     """Type of resonator (2D or 3D) in the used QPU."""
@@ -308,7 +302,6 @@ class Platform:
         instruments: InstrumentMap,
         qubits: QubitMap,
         couplers: Optional[QubitMap] = None,
-        qubit_pairs: Optional[QubitPairMap] = None,
         name: Optional[str] = None,
     ) -> "Platform":
         """Dump platform."""
@@ -319,7 +312,6 @@ class Platform:
             instruments=instruments,
             qubits=qubits,
             couplers=couplers if couplers is not None else {},
-            qubit_pairs=qubit_pairs if qubit_pairs is not None else {},
         )
 
     def dump(self, path: Path):

--- a/src/qibolab/_core/platform/platform.py
+++ b/src/qibolab/_core/platform/platform.py
@@ -17,6 +17,7 @@ from ..parameters import (
     NativeGates,
     Parameters,
     QubitMap,
+    QubitPairMap,
     Settings,
     Update,
     update_configs,
@@ -95,6 +96,11 @@ class Platform:
 
     Fully analogue to :attr:`qubits`. Only the flux channel is expected to be populated
     in the mapped objects.
+    """
+    qubit_pairs: QubitPairMap = field(default_factory=dict)
+    """Pairs controllers.
+
+    Necessary to add drive for CR gate.
     """
     resonator_type: Literal["2D", "3D"] = "2D"
     """Type of resonator (2D or 3D) in the used QPU."""
@@ -302,6 +308,7 @@ class Platform:
         instruments: InstrumentMap,
         qubits: QubitMap,
         couplers: Optional[QubitMap] = None,
+        qubit_pairs: Optional[QubitPairMap] = None,
         name: Optional[str] = None,
     ) -> "Platform":
         """Dump platform."""
@@ -312,6 +319,7 @@ class Platform:
             instruments=instruments,
             qubits=qubits,
             couplers=couplers if couplers is not None else {},
+            qubit_pairs=qubit_pairs if qubit_pairs is not None else {},
         )
 
     def dump(self, path: Path):

--- a/src/qibolab/_core/qubits.py
+++ b/src/qibolab/_core/qubits.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Optional
+from typing import Annotated, Optional, Union
 
 from pydantic import ConfigDict, Field
 
@@ -23,8 +23,8 @@ class Qubit(Model):
 
     drive: DefaultChannelType = None
     """Ouput channel, to drive the qubit state."""
-    drive_qudits: Annotated[dict[TransitionId, ChannelId], False] = Field(
-        default_factory=dict
+    drive_extra: Annotated[dict[Union[TransitionId, QubitId], ChannelId], False] = (
+        Field(default_factory=dict)
     )
     """Output channels collection, to drive non-qubit transitions."""
     flux: DefaultChannelType = None

--- a/src/qibolab/_core/qubits.py
+++ b/src/qibolab/_core/qubits.py
@@ -61,10 +61,3 @@ class Qubit(Model):
         if channels is None:
             channels = [name for name, f in cls.model_fields.items() if f.metadata[0]]
         return cls(**{ch: f"{name}/{ch}" for ch in channels}, **kwargs)
-
-
-class QubitPair(Model):
-    """Represent a two-qubit interaction."""
-
-    drive: Optional[ChannelId] = None
-    """Output channel, for cross-resonance driving."""

--- a/src/qibolab/_core/qubits.py
+++ b/src/qibolab/_core/qubits.py
@@ -40,7 +40,7 @@ class Qubit(Model):
             x
             for x in (
                 [getattr(self, ch) for ch in ["probe", "acquisition", "drive", "flux"]]
-                + list(self.drive_qudits.values())
+                + list(self.drive_extra.values())
             )
             if x is not None
         ]


### PR DESCRIPTION
~~This PR introduces a `QubitPairMap` type which will be passed to `Platform`.
The motivation behind this is to have the possibility to add channels which are acting on a specific pair, which is the case for the CR gate which we will need at some point.~~

Renaming `drive_qudits` to `drive_extra` and modifying its type to allow to define also cross resonance channels.


