### PR TITLE
Adding flux-tunability in emulator

### DIFF
--- a/doc/source/main-documentation/qibolab.rst
+++ b/doc/source/main-documentation/qibolab.rst
@@ -645,7 +645,7 @@ It is possible to switch extractor when instantiating the :class:`qibolab.instru
 
 .. _main_doc_emulator:
 
-Simulation of QPU platforms
+Emulation of QPU platforms
 ---------------------------
 
 Although Qibolab is mostly dedicated to providing hardware drivers for self-hosted quantum computing setups,
@@ -653,15 +653,26 @@ it is also possible to simulate the outcome of a pulse sequence with an emulator
 The emulator currently available is based on `QuTiP <https://qutip.org/>`_, the simulation is performed
 by solving the master equation for a given Hamiltonian including dissipation using `mesolve <https://qutip.readthedocs.io/en/qutip-5.1.x/apidoc/solver.html#qutip.solver.mesolve.mesolve>`_.
 
-Qibolab currently support a model consisting of a single transmon with a drive term whose Hamiltonian is the following
+Qibolab currently support up to 2 split-transmon capacively coupled qubit
 
 .. math::
 
-    \frac{H}{\hbar} =  a^\dagger a \omega_q + \frac{\alpha}{2} a^\dagger a^\dagger a a - i \Omega(t) (a - a^\dagger)
+    \frac{H}{\hbar} =  \sum_{i=1}^2 \Big[ a^\dagger_i a_i \omega_i (\Phi_i) + \frac{\alpha_i}{2} a_i^\dagger a_i^\dagger a_i a_i - i \Omega_i(t) (a_i - a_i^\dagger) \Big] + g (a_1^\dagger a_2 + a_1 a_2^\dagger)
 
-where :math:`a (a^\dagger)` are the destruction (creation) operators for the transmon,
-:math:`\omega_q` is the transmon frequency, :math:`\alpha / 2 \pi` is the anharmonicity of the transmon and :math:`\Omega(t)` is a time-dependent
-term for driving the transmon.
+where :math:`a_i (a_i^\dagger)` are the destruction (creation) operators for the transmon  :math:`i`,
+:math:`\omega_i` and :math:`\alpha_i / 2 \pi` are the frequency and the anharmoncity of the transmon  :math:`i`.
+Each transmon is controlled with a drive term with a Rabi frequency :math:`\Omega_i(t)` and it is flux-tunable, meaning
+that the frequency of the transmon can be changed by applying flux :math:`\Phi_i`
+
+.. math::
+
+    \omega_i(\Phi_i) = (\omega_i^{\text{max}} - \alpha_i)
+    \sqrt[4]{d_i^2 + (1 - d_i^2)\cos^2\left( \pi (\Phi - \Phi^{\text{sweetspot}}) \right)} + \alpha_i
+
+where :math:`\omega_i^{\text{max}}` is the maximum frequency of the transmon, :math:`d_i` is the junctions asymmetry
+and :math:`\Phi^{\text{sweetspot}}` is the flux value at which the transmon frequency is maximum.
+Currently neither drive or crosstalk effects are considered.
+The coupling strength between the two transmons :math:`g` .
 
 The readout pulses parameters are ignored, given that the Hamiltonian doesn't include a resonator. The only information
 used when the readout pulse is placed in the sequence which is necessary to determine for how long the system should be evolved.

--- a/doc/source/tutorials/emulator.rst
+++ b/doc/source/tutorials/emulator.rst
@@ -148,9 +148,7 @@ We are now going to give an example on how to setup the `platform.py` file.
     # emulator / platform.py
 
 
-    import pathlib
-
-    from qibolab import ConfigKinds, DcChannel, IqChannel, Platform, Qubit
+    from qibolab import ConfigKinds, DcChannel, IqChannel, Platform, Qubit, Hardware
     from qibolab.instruments.emulator import (
         DriveEmulatorConfig,
         EmulatorController,
@@ -158,13 +156,11 @@ We are now going to give an example on how to setup the `platform.py` file.
         HamiltonianConfig,
     )
 
-    FOLDER = pathlib.Path(__file__).parent
-
     ConfigKinds.extend([HamiltonianConfig, DriveEmulatorConfig, FluxEmulatorConfig])
 
 
-    def create() -> Platform:
-        """Create a dummy platform using the dummy instrument."""
+    def create() -> Hardware:
+        """Create emulator platform with flux-tunable qubit."""
         qubits = {}
         channels = {}
 
@@ -177,11 +173,10 @@ We are now going to give an example on how to setup the `platform.py` file.
 
         # register the instruments
         instruments = {
-            "dummy": EmulatorController(address="0.0.0.0", channels=channels),
+            "emulator": EmulatorController(address="0.0.0.0", channels=channels),
         }
 
-        return Platform.load(
-            path=FOLDER,
+        return Hardware(
             instruments=instruments,
             qubits=qubits,
         )

--- a/doc/source/tutorials/emulator.rst
+++ b/doc/source/tutorials/emulator.rst
@@ -9,123 +9,134 @@ We are now going to explain a few distinctive features of an emulation
 platform. All parameters related to the Hamiltonian to be simulated are coded directly in the JSON file under
 the section ``configs``. Here is an example
 
-.. code-block::  json
+.. code-block:: json
 
     {
-        "settings": {
-            "nshots": 1024,
-            "relaxation_time": 0
-            },
-        "configs": {
-            "emulator/bounds": {
-            "kind": "bounds",
-            "waveforms": 1000000,
-            "readout": 50,
-            "instructions": 200
-            },
-        "hamiltonian":{
-            "transmon_levels": 2,
-            "single_qubit": {
-                "0": {
-                    "frequency": 5e9,
-                    "anharmonicity": -200e6,
-                    "t1": {
-                        "0-1": 1000
-                        },
-                    "t2": {
-                        "0-1": 1900
-                        }
-                    }
-                },
-            "kind": "hamiltonian"
-            },
-            "0/drive": {
-                "kind": "iq",
-                "frequency": 5e9
-                },
-            "0/drive12": {
-                "kind": "iq",
-                "frequency": 4.8e9
-                },
-            "0/probe": {
-                "kind": "iq",
-                "frequency": 5200000000.0
-                },
-            "0/acquisition": {
-                "kind": "acquisition",
-                "delay": 0.0,
-                "smearing": 0.0,
-                "threshold": 0.0,
-                "iq_angle": 0.0,
-                "kernel": null
-                }
-            },
-        "native_gates": {
-            "single_qubit": {
-                "0": {
-                    "RX": [
-                    [
-                        "0/drive",
-                        {
-                            "duration": 40,
-                            "amplitude": 0.1594,
-                            "envelope": {
-                                "kind": "gaussian",
-                                "rel_sigma": 0.2
-                            },
-                            "relative_phase": 0.0,
-                            "kind": "pulse"
-                        }
-                    ]
-                    ],
-                    "RX90": [
-                    [
-                        "0/drive",
-                        {
-                            "duration": 40,
-                            "amplitude": 0.07975,
-                            "envelope": {
-                                "kind": "gaussian",
-                                "rel_sigma": 0.2
-                            },
-                            "relative_phase": 0.0,
-                            "kind": "pulse"
-                        }
-                    ]
-                    ],
-                    "MZ": [
-                    [
-                        "0/acquisition",
-                        {
-                            "kind": "readout",
-                            "acquisition": {
-                                "kind": "acquisition",
-                                "duration": 100.0
-                            },
-                        "probe": {
-                            "duration": 100.0,
-                            "amplitude": 0.1,
-                            "envelope": {
-                                "kind": "gaussian_square",
-                                "rel_sigma": 0.2,
-                                "width": 0.75
-                                },
-                            "relative_phase": 0.0,
-                            "kind": "pulse"
-                        }
-                        }
-                    ]
-                    ],
-                    "CP": null
-                }
-                }
-                }
+      "settings": {
+        "nshots": 1024,
+        "relaxation_time": 0
+      },
+      "configs": {
+        "emulator/bounds": {
+          "kind": "bounds",
+          "waveforms": 1000000,
+          "readout": 50,
+          "instructions": 200
+        },
+        "hamiltonian": {
+          "transmon_levels": 2,
+          "single_qubit": {
+            "0": {
+              "frequency": 5e9,
+              "sweetspot": 0.02,
+              "anharmonicity": -200e6,
+              "asymmetry": 0.0,
+              "t1": {
+                "0-1": 1000
+              },
+              "t2": {
+                "0-1": 1900
+              }
             }
+          },
+          "kind": "hamiltonian"
+        },
+        "0/drive": {
+          "kind": "drive-emulator",
+          "frequency": 5e9,
+          "scale_factor": 0.1591549
+        },
+        "0/drive12": {
+          "kind": "drive-emulator",
+          "frequency": 4.8e9,
+          "scale_factor": 0.1591549
+        },
+        "0/flux": {
+          "kind": "flux-emulator",
+          "offset": 0.02
+        },
+        "0/probe": {
+          "kind": "iq",
+          "frequency": 5200000000.0
+        },
+        "0/acquisition": {
+          "kind": "acquisition",
+          "delay": 0.0,
+          "smearing": 0.0,
+          "threshold": 0.0,
+          "iq_angle": 0.0,
+          "kernel": null
+        }
+      },
+      "native_gates": {
+        "single_qubit": {
+          "0": {
+            "RX": [
+              [
+                "0/drive",
+                {
+                  "duration": 40,
+                  "amplitude": 0.1594,
+                  "envelope": {
+                    "kind": "gaussian",
+                    "rel_sigma": 0.2
+                  },
+                  "relative_phase": 0.0,
+                  "kind": "pulse"
+                }
+              ]
+            ],
+            "RX90": [
+              [
+                "0/drive",
+                {
+                  "duration": 40,
+                  "amplitude": 0.07975,
+                  "envelope": {
+                    "kind": "gaussian",
+                    "rel_sigma": 0.2
+                  },
+                  "relative_phase": 0.0,
+                  "kind": "pulse"
+                }
+              ]
+            ],
+            "MZ": [
+              [
+                "0/acquisition",
+                {
+                  "kind": "readout",
+                  "acquisition": {
+                    "kind": "acquisition",
+                    "duration": 100.0
+                  },
+                  "probe": {
+                    "duration": 100.0,
+                    "amplitude": 0.1,
+                    "envelope": {
+                      "kind": "gaussian_square",
+                      "rel_sigma": 0.2,
+                      "width": 0.75
+                    },
+                    "relative_phase": 0.0,
+                    "kind": "pulse"
+                  }
+                }
+              ]
+            ],
+            "CP": null
+          }
+        }
+      }
+    }
+
 
 
 We are defining an Hamiltonian with a transmon with two-levels, with a frequency of :math:`\omega_q / 2 \pi = 5 \ \text{GHz}` and
 anharmoncity :math:`\alpha/2 \pi = - 200 \ \text{MHz}`,
 with :math:`T_1 = 1 \  \mu s` and :math:`T_2 = 1.9 \ \mu s`.
+Currently the transmon is flux-tunable since we provided both the sweetspot and the asymmetry parameters in the qubit section and we have also introduce
+a flux channel. By removing them the simulation can be performed with a fixed-frequency transmon.
 Everything else follows the usual Qibolab conventions. Keep in mind that you still need to define also a readout pulse even if all
 parameters ignored in the current emulator except when the readout pulse is played.
 
@@ -137,29 +148,47 @@ We are now going to give an example on how to setup the `platform.py` file.
     # emulator / platform.py
 
 
-    from qibolab import ConfigKinds, IqChannel, Hardware, Qubit
-    from qibolab.instruments.emulator import EmulatorController, HamiltonianConfig
+    import pathlib
 
-    ConfigKinds.extend([HamiltonianConfig])
+    from qibolab import ConfigKinds, DcChannel, IqChannel, Platform, Qubit
+    from qibolab.instruments.emulator import (
+        DriveEmulatorConfig,
+        EmulatorController,
+        FluxEmulatorConfig,
+        HamiltonianConfig,
+    )
+
+    FOLDER = pathlib.Path(__file__).parent
+
+    ConfigKinds.extend([HamiltonianConfig, DriveEmulatorConfig, FluxEmulatorConfig])
 
 
-    def create() -> Hardware:
-        """Create an emulator hardware."""
-        qubits = {Qubit.default(q) for q in range(1)}
-        channels = {
-            qubit.drive: IqChannel(mixer=None, lo=None) for qubit in qubits.values()
-        }
+    def create() -> Platform:
+        """Create a dummy platform using the dummy instrument."""
+        qubits = {}
+        channels = {}
+
+        for q in range(1):
+            qubits[q] = qubit = Qubit.default(q)
+            channels |= {
+                qubit.drive: IqChannel(mixer=None, lo=None),
+                qubit.flux: DcChannel(),
+            }
 
         # register the instruments
         instruments = {
             "dummy": EmulatorController(address="0.0.0.0", channels=channels),
         }
 
-        return Hardware(
+        return Platform.load(
+            path=FOLDER,
             instruments=instruments,
             qubits=qubits,
         )
 
+
 We can observe that we need to allocate an object of type ``EmulatorController`` where we load the channels.
-Note that in order to enables the config to support the Hamiltonian configuration we are adding it explicitly
-in the statement ``ConfigKinds.extend([HamiltonianConfig])``.
+Note that in order to enables the config to support the Hamiltonian configuration as well as drive and flux channels for the emualtor
+we are adding it explicitly
+in the statement ``ConfigKinds.extend([HamiltonianConfig, DriveEmulatorConfig, FluxEmulatorConfig)``.
+By removing the lines referring to the flux channel we can also simulate a fixed-frequency transmon.

--- a/src/qibolab/_core/instruments/emulator/emulator.py
+++ b/src/qibolab/_core/instruments/emulator/emulator.py
@@ -135,7 +135,10 @@ class EmulatorController(Controller):
                     {
                         f"single_qubit.{qubit}.dynamical_frequency": config.single_qubit[
                             qubit
-                        ].detuned_frequency(configs_[f"{qubit}/flux"].offset)
+                        ].detuned_frequency(
+                            configs_[f"{qubit}/flux"].offset
+                            * configs_[f"{qubit}/flux"].voltage_to_flux
+                        )
                     }
                 )
             except KeyError:

--- a/src/qibolab/_core/instruments/emulator/emulator.py
+++ b/src/qibolab/_core/instruments/emulator/emulator.py
@@ -32,8 +32,12 @@ from .hamiltonians import (
     Operator,
     waveform,
 )
+<<<<<<< HEAD
 from .operators import TimeDependentOperator, evolve, expand
 from .results import acquisitions, results, select_acquisitions
+=======
+from .utils import apply_to_last_two_axes, calculate_probabilities_density_matrix, shots
+>>>>>>> 38b956b7 (refactor: Re-organize results)
 
 __all__ = ["EmulatorController"]
 
@@ -259,3 +263,24 @@ def channel_time(waveforms: Iterable[Modulated]) -> Callable[[float], float]:
         return 0
 
     return time
+<<<<<<< HEAD
+=======
+
+
+def extract_probabilities(
+    expectations: list[Qobj], acquisitions: Iterable[float], times: NDArray
+) -> NDArray:
+    """Extract probabilities from expectations.
+
+    First, retrieve acquisitions, and locate them in the tlist, to
+    isolate the expectations related to measurements.
+
+    Then, it computes probabilities, based on the identified
+    expectations.
+    """
+    expectations = [x.full() for x in expectations]
+    acq = np.array(list(acquisitions))
+    samples = np.minimum(np.searchsorted(times, acq), times.size - 1)
+
+    return np.stack(expectations, axis=0)[samples]
+>>>>>>> 38b956b7 (refactor: Re-organize results)

--- a/src/qibolab/_core/instruments/emulator/emulator.py
+++ b/src/qibolab/_core/instruments/emulator/emulator.py
@@ -204,9 +204,15 @@ def hamiltonian(
     config: Config,
     hamiltonian: HamiltonianConfig,
     qubit: int,
+<<<<<<< HEAD
 ) -> tuple[Operator, list[Modulated]]:
     n = hamiltonian.transmon_levels
     op = expand(config.operator(n), hamiltonian.dims, qubit)
+=======
+) -> tuple[Qobj, list[Modulated]]:
+    n = hamiltonian.transmon_levels
+    op = hamiltonian._embed_operator(channel_operator(n), qubit)
+>>>>>>> 842adb55 (feat: Uncoupled transmons prototype)
     waveforms = (
         waveform(pulse, config)
         for pulse in pulses

--- a/src/qibolab/_core/instruments/emulator/emulator.py
+++ b/src/qibolab/_core/instruments/emulator/emulator.py
@@ -204,15 +204,9 @@ def hamiltonian(
     config: Config,
     hamiltonian: HamiltonianConfig,
     qubit: int,
-<<<<<<< HEAD
 ) -> tuple[Operator, list[Modulated]]:
     n = hamiltonian.transmon_levels
     op = expand(config.operator(n), hamiltonian.dims, qubit)
-=======
-) -> tuple[Qobj, list[Modulated]]:
-    n = hamiltonian.transmon_levels
-    op = hamiltonian._embed_operator(channel_operator(n), qubit)
->>>>>>> 842adb55 (feat: Uncoupled transmons prototype)
     waveforms = (
         waveform(pulse, config)
         for pulse in pulses

--- a/src/qibolab/_core/instruments/emulator/emulator.py
+++ b/src/qibolab/_core/instruments/emulator/emulator.py
@@ -26,6 +26,7 @@ from qibolab._core.sequence import PulseSequence
 from qibolab._core.sweeper import ParallelSweepers
 
 from .hamiltonians import (
+    DriveConfig,
     HamiltonianConfig,
     Modulated,
     Operator,

--- a/src/qibolab/_core/instruments/emulator/emulator.py
+++ b/src/qibolab/_core/instruments/emulator/emulator.py
@@ -32,12 +32,8 @@ from .hamiltonians import (
     Operator,
     waveform,
 )
-<<<<<<< HEAD
 from .operators import TimeDependentOperator, evolve, expand
 from .results import acquisitions, results, select_acquisitions
-=======
-from .utils import apply_to_last_two_axes, calculate_probabilities_density_matrix, shots
->>>>>>> 38b956b7 (refactor: Re-organize results)
 
 __all__ = ["EmulatorController"]
 
@@ -263,24 +259,3 @@ def channel_time(waveforms: Iterable[Modulated]) -> Callable[[float], float]:
         return 0
 
     return time
-<<<<<<< HEAD
-=======
-
-
-def extract_probabilities(
-    expectations: list[Qobj], acquisitions: Iterable[float], times: NDArray
-) -> NDArray:
-    """Extract probabilities from expectations.
-
-    First, retrieve acquisitions, and locate them in the tlist, to
-    isolate the expectations related to measurements.
-
-    Then, it computes probabilities, based on the identified
-    expectations.
-    """
-    expectations = [x.full() for x in expectations]
-    acq = np.array(list(acquisitions))
-    samples = np.minimum(np.searchsorted(times, acq), times.size - 1)
-
-    return np.stack(expectations, axis=0)[samples]
->>>>>>> 38b956b7 (refactor: Re-organize results)

--- a/src/qibolab/_core/instruments/emulator/emulator.py
+++ b/src/qibolab/_core/instruments/emulator/emulator.py
@@ -127,21 +127,8 @@ class EmulatorController(Controller):
         tlist_ = tlist(sequence_, self.sampling_rate)
         configs_ = update_configs(configs, updates)
         config = cast(HamiltonianConfig, configs_["hamiltonian"])
+        config = config.update_from_configs(configs_)
 
-        config_update = {}
-        for qubit in config.single_qubit:
-            flux = configs_.get(f"{qubit}/flux")
-            config_update.update(
-                {
-                    f"single_qubit.{qubit}.dynamical_frequency": config.single_qubit[
-                        qubit
-                    ].detuned_frequency(
-                        flux.offset * flux.voltage_to_flux if flux is not None else 0
-                    )
-                }
-            )
-
-        config = config.replace(update=config_update)
         hamiltonian = config.hamiltonian
         time_hamiltonian = self._pulse_hamiltonian(sequence_, configs_)
         if time_hamiltonian is not None:

--- a/src/qibolab/_core/instruments/emulator/emulator.py
+++ b/src/qibolab/_core/instruments/emulator/emulator.py
@@ -137,10 +137,6 @@ class EmulatorController(Controller):
             config.initial_state,
             tlist_,
             config.dissipation,
-<<<<<<< HEAD
-=======
-            e_ops=config.observable,
->>>>>>> 89eb31b9 (refactor: Simplify code by introducing observable)
         )
         return select_acquisitions(
             results.states,

--- a/src/qibolab/_core/instruments/emulator/emulator.py
+++ b/src/qibolab/_core/instruments/emulator/emulator.py
@@ -137,6 +137,10 @@ class EmulatorController(Controller):
             config.initial_state,
             tlist_,
             config.dissipation,
+<<<<<<< HEAD
+=======
+            e_ops=config.observable,
+>>>>>>> 89eb31b9 (refactor: Simplify code by introducing observable)
         )
         return select_acquisitions(
             results.states,

--- a/src/qibolab/_core/instruments/emulator/hamiltonians.py
+++ b/src/qibolab/_core/instruments/emulator/hamiltonians.py
@@ -6,7 +6,7 @@ from pydantic import Field
 from qibo.config import raise_error
 from scipy.constants import giga
 
-from ...components import Config, DcConfig
+from ...components import Config
 from ...identifier import QubitId, QubitPairId, TransitionId
 from ...parameters import Update, _setvalue
 from ...pulses import Delay, Pulse, PulseLike, VirtualZ
@@ -312,7 +312,7 @@ def waveform(
     flux_dependence: Optional[callable] = None,
 ) -> Optional[ControlLine]:
     """Convert pulse to hamiltonian."""
-    if not isinstance(config, (DriveEmulatorConfig, DcConfig)):
+    if not isinstance(config, (DriveEmulatorConfig, FluxEmulatorConfig)):
         return None
 
     if isinstance(pulse, Pulse):

--- a/src/qibolab/_core/instruments/emulator/hamiltonians.py
+++ b/src/qibolab/_core/instruments/emulator/hamiltonians.py
@@ -49,6 +49,8 @@ class FluxEmulatorConfig(Config):
 
     offset: float
     """DC offset of the channel."""
+    voltage_to_flux: float = 1
+    """Convert voltarget to flux."""
 
     @staticmethod
     def operator(n: int) -> Operator:
@@ -173,8 +175,12 @@ class FluxPulse(Model):
             2
             * np.pi
             * (
-                self.flux_freq_dependence(i[sample] + self.config.offset)
-                - self.flux_freq_dependence(self.config.offset)
+                self.flux_freq_dependence(
+                    self.config.voltage_to_flux * (i[sample] + self.config.offset)
+                )
+                - self.flux_freq_dependence(
+                    self.config.voltage_to_flux * self.config.offset
+                )
             )
             / giga
         )

--- a/src/qibolab/_core/instruments/emulator/hamiltonians.py
+++ b/src/qibolab/_core/instruments/emulator/hamiltonians.py
@@ -147,9 +147,10 @@ class FluxPulse(Model):
     """Flux pulse to be played."""
     config: FluxEmulatorConfig
     """Flux emulator configuration."""
+    qubit: Qubit
+    """Qubit affected by the flux pulse."""
     sampling_rate: float = 1
     """Sampling rate."""
-    flux_freq_dependence: Optional[callable] = None
 
     @cached_property
     def envelopes(self):
@@ -175,10 +176,10 @@ class FluxPulse(Model):
             2
             * np.pi
             * (
-                self.flux_freq_dependence(
+                self.qubit.detuned_frequency(
                     self.config.voltage_to_flux * (i[sample] + self.config.offset)
                 )
-                - self.flux_freq_dependence(
+                - self.qubit.detuned_frequency(
                     self.config.voltage_to_flux * self.config.offset
                 )
             )
@@ -316,7 +317,7 @@ class HamiltonianConfig(Config):
 def waveform(
     pulse: PulseLike,
     config: Config,
-    flux_dependence: Optional[callable] = None,
+    qubit: Qubit,
 ) -> Optional[ControlLine]:
     """Convert pulse to hamiltonian."""
     if not isinstance(config, (DriveEmulatorConfig, FluxEmulatorConfig)):
@@ -329,7 +330,7 @@ def waveform(
             return FluxPulse(
                 pulse=pulse,
                 config=config,
-                flux_freq_dependence=flux_dependence,
+                qubit=qubit,
             )
     if isinstance(pulse, Delay):
         return ModulatedDelay(duration=pulse.duration)

--- a/src/qibolab/_core/instruments/emulator/hamiltonians.py
+++ b/src/qibolab/_core/instruments/emulator/hamiltonians.py
@@ -1,4 +1,9 @@
+<<<<<<< HEAD
 from functools import cached_property
+=======
+from dataclasses import dataclass
+from functools import cache, cached_property
+>>>>>>> ce09d263 (doc: Adding comments and docstrings)
 from typing import Literal, Optional, Union
 
 import numpy as np
@@ -235,7 +240,11 @@ class HamiltonianConfig(Config):
         return single_qubit_terms + two_qubit_terms
 
     @property
+<<<<<<< HEAD
     def dissipation(self) -> Operator:
+=======
+    def dissipation(self) -> Qobj:
+>>>>>>> ce09d263 (doc: Adding comments and docstrings)
         """Dissipation operators for the hamiltonian.
 
         They are going to be passed to mesolve as collapse operators."""

--- a/src/qibolab/_core/instruments/emulator/hamiltonians.py
+++ b/src/qibolab/_core/instruments/emulator/hamiltonians.py
@@ -41,6 +41,19 @@ class DriveEmulatorConfig(Config):
         return -1j * (transmon_destroy(n) - transmon_create(n))
 
 
+class DriveConfig(Config):
+    """Configuration for an IQ channel."""
+
+    kind: Literal["drive"] = "drive"
+
+    frequency: float
+    """Frequency of drive."""
+    rabi_frequency: float = 1
+    """Rabi frequency [GHz]"""
+    scale_factor: float = 10
+    """Scaling factor."""
+
+
 class Qubit(Config):
     """Hamiltonian parameters for single qubit."""
 
@@ -140,6 +153,10 @@ class ModulatedDrive(Model):
     @property
     def rabi_omega(self):
         return 2 * np.pi * self.config.rabi_frequency / giga
+
+    @property
+    def omega(self):
+        return 2 * np.pi * self.rabi_frequency
 
     def __call__(self, t, sample, phase):
         i, q = self.envelopes

--- a/src/qibolab/_core/instruments/emulator/hamiltonians.py
+++ b/src/qibolab/_core/instruments/emulator/hamiltonians.py
@@ -1,4 +1,8 @@
+<<<<<<< HEAD
 from functools import cached_property
+=======
+from functools import cache, cached_property
+>>>>>>> 038c4b41 (refactor: Address first comments)
 from typing import Literal, Optional, Union
 
 import numpy as np
@@ -46,16 +50,16 @@ class DriveEmulatorConfig(Config):
         return -1j * (transmon_destroy(n) - transmon_create(n))
 
 
-class DriveConfig(Config):
+class DriveEmulatorConfig(Config):
     """Configuration for an IQ channel."""
 
-    kind: Literal["drive"] = "drive"
+    kind: Literal["drive-emulator"] = "drive-emulator"
 
     frequency: float
     """Frequency of drive."""
     rabi_frequency: float = 1
     """Rabi frequency [GHz]"""
-    scale_factor: float = 10
+    scale_factor: float = 1
     """Scaling factor."""
 
 
@@ -142,6 +146,7 @@ class QubitPair(Config):
         return 2 * np.pi * self.coupling / giga * op
 
 
+<<<<<<< HEAD
 @dataclass
 class FluxPulse:
     pulse: Pulse
@@ -150,6 +155,17 @@ class FluxPulse:
     """Static bias offset."""
     flux_freq_dependence: callable
     """Flux frequency dep."""
+=======
+class QubitDrive(Model):
+    """Hamiltonian parameters for qubit drive."""
+
+    pulse: Pulse
+    """Drive pulse."""
+    config: DriveEmulatorConfig
+    """Drive emulator configuration."""
+    n: int
+    """Transmon levels."""
+>>>>>>> 038c4b41 (refactor: Address first comments)
     sampling_rate: float = 1
     """Sampling rate."""
 
@@ -217,13 +233,21 @@ class QubitDrive:
 
     @property
     def omega(self):
-        return 2 * np.pi * self.rabi_frequency
+        return 2 * np.pi * self.config.frequency / giga
+
+    @property
+    def rabi_omega(self):
+        return 2 * np.pi * self.config.rabi_frequency / giga
 
     def __call__(self, t, sample, phase):
         i, q = self.envelopes
         phi = self.omega * t + self.pulse.relative_phase + phase
         return (
+<<<<<<< HEAD
             self.rabi_omega
+=======
+            self.omega
+>>>>>>> 038c4b41 (refactor: Address first comments)
             * self.config.scale_factor
             * (np.cos(phi) * i[sample] + np.sin(phi) * q[sample])
         )
@@ -319,10 +343,15 @@ def waveform(
     pulse: Union[Pulse, Delay], channel: Config, level: int, flux_dependence: callable
 ) -> Optional[Modulated]:
     """Convert pulse to hamiltonian."""
+<<<<<<< HEAD
     if not isinstance(config, DriveEmulatorConfig):
+=======
+    if not isinstance(channel, DriveEmulatorConfig):
+>>>>>>> 038c4b41 (refactor: Address first comments)
         return None
 
     if isinstance(pulse, Pulse):
+<<<<<<< HEAD
         if isinstance(channel, DriveConfig):
             return QubitDrive(
                 pulse=pulse,
@@ -337,6 +366,13 @@ def waveform(
                 offset=channel.offset,
                 flux_freq_dependence=flux_dependence,
             )
+=======
+        return QubitDrive(
+            pulse=pulse,
+            config=channel,
+            n=level,
+        )
+>>>>>>> 038c4b41 (refactor: Address first comments)
     if isinstance(pulse, Delay):
         return ModulatedDelay(duration=pulse.duration)
     if isinstance(pulse, VirtualZ):

--- a/src/qibolab/_core/instruments/emulator/hamiltonians.py
+++ b/src/qibolab/_core/instruments/emulator/hamiltonians.py
@@ -273,6 +273,24 @@ class HamiltonianConfig(Config):
 
         return self.model_validate(d)
 
+    def update_from_configs(self, config: dict[str, Config]) -> "HamiltonianConfig":
+        """Update hamiltonian parameters from configs."""
+
+        config_update = {}
+        for qubit in self.single_qubit:
+            # setting static bias
+            flux = config.get(f"{qubit}/flux")
+            config_update.update(
+                {
+                    f"single_qubit.{qubit}.dynamical_frequency": self.single_qubit[
+                        qubit
+                    ].detuned_frequency(
+                        flux.offset * flux.voltage_to_flux if flux is not None else 0
+                    )
+                }
+            )
+        return self.replace(update=config_update)
+
     @property
     def initial_state(self):
         """Initial state as ground state of the system."""

--- a/src/qibolab/_core/instruments/emulator/hamiltonians.py
+++ b/src/qibolab/_core/instruments/emulator/hamiltonians.py
@@ -281,6 +281,10 @@ class HamiltonianConfig(Config):
         )
 
     @property
+    def qubits(self):
+        return list(self.single_qubit)
+
+    @property
     def nqubits(self):
         return len(self.single_qubit)
 

--- a/src/qibolab/_core/instruments/emulator/hamiltonians.py
+++ b/src/qibolab/_core/instruments/emulator/hamiltonians.py
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
 from functools import cached_property
-=======
-from functools import cache, cached_property
->>>>>>> 038c4b41 (refactor: Address first comments)
 from typing import Literal, Optional, Union
 
 import numpy as np
@@ -12,13 +8,8 @@ from scipy.constants import giga
 
 from ...components import Config
 from ...identifier import QubitId, QubitPairId, TransitionId
-<<<<<<< HEAD
 from ...pulses import Delay, Pulse, PulseLike, VirtualZ
 from ...serialize import Model
-=======
-from ...parameters import Update, _setvalue
-from ...pulses import Delay, Pulse, VirtualZ
->>>>>>> b30529ae (feat: Dummy prototype for offset sweeper)
 from .operators import (
     Operator,
     dephasing,
@@ -146,7 +137,6 @@ class QubitPair(Config):
         return 2 * np.pi * self.coupling / giga * op
 
 
-<<<<<<< HEAD
 @dataclass
 class FluxPulse:
     pulse: Pulse
@@ -155,17 +145,6 @@ class FluxPulse:
     """Static bias offset."""
     flux_freq_dependence: callable
     """Flux frequency dep."""
-=======
-class QubitDrive(Model):
-    """Hamiltonian parameters for qubit drive."""
-
-    pulse: Pulse
-    """Drive pulse."""
-    config: DriveEmulatorConfig
-    """Drive emulator configuration."""
-    n: int
-    """Transmon levels."""
->>>>>>> 038c4b41 (refactor: Address first comments)
     sampling_rate: float = 1
     """Sampling rate."""
 
@@ -244,10 +223,14 @@ class QubitDrive:
         phi = self.omega * t + self.pulse.relative_phase + phase
         return (
 <<<<<<< HEAD
+<<<<<<< HEAD
             self.rabi_omega
 =======
             self.omega
 >>>>>>> 038c4b41 (refactor: Address first comments)
+=======
+            self.rabi_omega
+>>>>>>> 79511a5b (fix: Missing rabi_)
             * self.config.scale_factor
             * (np.cos(phi) * i[sample] + np.sin(phi) * q[sample])
         )

--- a/src/qibolab/_core/instruments/emulator/hamiltonians.py
+++ b/src/qibolab/_core/instruments/emulator/hamiltonians.py
@@ -286,6 +286,31 @@ class HamiltonianConfig(Config):
         return len(self.single_qubit)
 
     @property
+<<<<<<< HEAD
+=======
+    def identity(self) -> list[Qobj]:
+        """Identiy as list of identity for each qubit."""
+        return self.nqubits * [qeye(self.transmon_levels)]
+
+    def _embed_operator(self, operator: Qobj, index: int) -> Qobj:
+        """Embed operator in the tensor product space."""
+        space = self.identity
+        space[index] = operator
+        return tensor(space)
+
+    def _qubit_qubit_coupling(self, pair: QubitPairId) -> Qobj:
+        """Qubit-qubit coupling operator."""
+        q0, q1 = pair
+        return self._embed_operator(
+            transmon_destroy(self.transmon_levels), q0
+        ) * self._embed_operator(
+            transmon_create(self.transmon_levels), q1
+        ) + self._embed_operator(
+            transmon_create(self.transmon_levels), q0
+        ) * self._embed_operator(transmon_destroy(self.transmon_levels), q1)
+
+    @property
+>>>>>>> 149b658d (refactor: Hardcode qubit-qubit coupling)
     def initial_state(self):
         """Initial state as ground state of the system."""
         return tensor_product(
@@ -305,7 +330,11 @@ class HamiltonianConfig(Config):
             for i, qubit in self.single_qubit.items()
         )
         two_qubit_terms = sum(
+<<<<<<< HEAD
             expand(pair.operator(self.transmon_levels), self.dims, list(pair_id))
+=======
+            pair.operator(self._qubit_qubit_coupling(pair_id))
+>>>>>>> 149b658d (refactor: Hardcode qubit-qubit coupling)
             for pair_id, pair in self.pairs.items()
         )
         return single_qubit_terms + two_qubit_terms

--- a/src/qibolab/_core/instruments/emulator/hamiltonians.py
+++ b/src/qibolab/_core/instruments/emulator/hamiltonians.py
@@ -1,9 +1,4 @@
-<<<<<<< HEAD
 from functools import cached_property
-=======
-from dataclasses import dataclass
-from functools import cache, cached_property
->>>>>>> ce09d263 (doc: Adding comments and docstrings)
 from typing import Literal, Optional, Union
 
 import numpy as np
@@ -240,11 +235,7 @@ class HamiltonianConfig(Config):
         return single_qubit_terms + two_qubit_terms
 
     @property
-<<<<<<< HEAD
     def dissipation(self) -> Operator:
-=======
-    def dissipation(self) -> Qobj:
->>>>>>> ce09d263 (doc: Adding comments and docstrings)
         """Dissipation operators for the hamiltonian.
 
         They are going to be passed to mesolve as collapse operators."""

--- a/src/qibolab/_core/instruments/emulator/hamiltonians.py
+++ b/src/qibolab/_core/instruments/emulator/hamiltonians.py
@@ -147,6 +147,7 @@ class FluxPulse(Model):
     """Flux emulator configuration."""
     sampling_rate: float = 1
     """Sampling rate."""
+    flux_freq_dependence: Optional[callable] = None
 
     @cached_property
     def envelopes(self):
@@ -172,8 +173,8 @@ class FluxPulse(Model):
             2
             * np.pi
             * (
-                self.flux_freq_dependence(i[sample] + self.offset)
-                - self.flux_freq_dependence(self.offset)
+                self.flux_freq_dependence(i[sample] + self.config.offset)
+                - self.flux_freq_dependence(self.config.offset)
             )
             / giga
         )

--- a/src/qibolab/_core/instruments/emulator/hamiltonians.py
+++ b/src/qibolab/_core/instruments/emulator/hamiltonians.py
@@ -48,8 +48,8 @@ class DriveEmulatorConfig(Config):
 
     frequency: float
     """Frequency of drive."""
-    rabi_frequency: float = 1
-    """Rabi frequency [GHz]"""
+    rabi_frequency: float = 1e9
+    """Rabi frequency [Hz]"""
     scale_factor: float = 1
     """Scaling factor."""
 

--- a/tests/instruments/emulator/platforms/fixed-frequency-qutrits/parameters.json
+++ b/tests/instruments/emulator/platforms/fixed-frequency-qutrits/parameters.json
@@ -1,0 +1,357 @@
+{
+    "settings": {
+        "nshots": 1024,
+        "relaxation_time": 0
+    },
+    "configs": {
+        "emulator/bounds": {
+            "kind": "bounds",
+            "waveforms": 1000000.0,
+            "readout": 50,
+            "instructions": 200
+        },
+        "hamiltonian": {
+            "kind": "hamiltonian",
+            "transmon_levels": 3,
+            "single_qubit": {
+                "0": {
+                    "frequency": 5114000000.0,
+                    "anharmonicity": -330000000.0,
+                    "t1": {
+                        "0-1": 38000.0,
+                        "1-2": 19000.0
+                    },
+                    "t2": {
+                        "0-1": 50000.0
+                    }
+                },
+                "1": {
+                    "frequency": 4914000000.0,
+                    "anharmonicity": -330000000.0,
+                    "t1": {
+                        "0-1": 42000.0,
+                        "1-2": 21000.0
+                    },
+                    "t2": {
+                        "0-1": 61000.0
+                    }
+                }
+            },
+            "pairs": {
+                "0-1": {
+                    "coupling": 3800000.0
+                }
+            }
+        },
+        "0/drive": {
+            "kind": "drive-emulator",
+            "frequency": 5114000000.0,
+            "rabi_frequency": 50000000.0,
+            "scale_factor": 10.0
+        },
+        "01/drive": {
+            "kind": "drive-emulator",
+            "frequency": 4914000000.0,
+            "rabi_frequency": 50000000.0,
+            "scale_factor": 10.0
+        },
+        "0/drive12": {
+            "kind": "drive-emulator",
+            "frequency": 4784000000.0,
+            "rabi_frequency": 50000000.0,
+            "scale_factor": 10.0
+        },
+        "1/drive": {
+            "kind": "drive-emulator",
+            "frequency": 4914000000.0,
+            "rabi_frequency": 50000000.0,
+            "scale_factor": 10.0
+        },
+        "1/drive12": {
+            "kind": "drive-emulator",
+            "frequency": 4584000000.0,
+            "rabi_frequency": 50000000.0,
+            "scale_factor": 10.0
+        },
+        "0/probe": {
+            "kind": "iq",
+            "frequency": 5500000000.0
+        },
+        "0/acquisition": {
+            "kind": "acquisition",
+            "delay": 0.0,
+            "smearing": 0.0,
+            "threshold": 0.0,
+            "iq_angle": 0.0,
+            "kernel": null
+        },
+        "1/probe": {
+            "kind": "iq",
+            "frequency": 5500000000.0
+        },
+        "1/acquisition": {
+            "kind": "acquisition",
+            "delay": 0.0,
+            "smearing": 0.0,
+            "threshold": 0.0,
+            "iq_angle": 0.0,
+            "kernel": null
+        }
+    },
+    "native_gates": {
+        "single_qubit": {
+            "0": {
+                "RX": [
+                    [
+                        "0/drive",
+                        {
+                            "kind": "pulse",
+                            "duration": 20.0,
+                            "amplitude": 0.200449,
+                            "envelope": {
+                                "kind": "drag",
+                                "rel_sigma": 0.1,
+                                "beta": 0.25
+                            },
+                            "relative_phase": 0.0
+                        }
+                    ]
+                ],
+                "RX90": [
+                    [
+                        "0/drive",
+                        {
+                            "kind": "pulse",
+                            "duration": 20.0,
+                            "amplitude": 0.1002245,
+                            "envelope": {
+                                "kind": "drag",
+                                "rel_sigma": 0.1,
+                                "beta": 0.25
+                            },
+                            "relative_phase": 0.0
+                        }
+                    ]
+                ],
+                "RX12": [
+                    [
+                        "0/drive12",
+                        {
+                            "kind": "pulse",
+                            "duration": 20.0,
+                            "amplitude": 0.1426586,
+                            "envelope": {
+                                "kind": "gaussian",
+                                "rel_sigma": 0.1
+                            },
+                            "relative_phase": 0.0
+                        }
+                    ]
+                ],
+                "MZ": [
+                    [
+                        "0/acquisition",
+                        {
+                            "kind": "readout",
+                            "acquisition": {
+                                "kind": "acquisition",
+                                "duration": 10.0
+                            },
+                            "probe": {
+                                "kind": "pulse",
+                                "duration": 10.0,
+                                "amplitude": 0.1,
+                                "envelope": {
+                                    "kind": "rectangular"
+                                },
+                                "relative_phase": 0.0
+                            }
+                        }
+                    ]
+                ],
+                "CP": null
+            },
+            "1": {
+                "RX": [
+                    [
+                        "1/drive",
+                        {
+                            "kind": "pulse",
+                            "duration": 20.0,
+                            "amplitude": 0.200792,
+                            "envelope": {
+                                "kind": "drag",
+                                "rel_sigma": 0.1,
+                                "beta": 0.25
+                            },
+                            "relative_phase": 0.0
+                        }
+                    ]
+                ],
+                "RX90": [
+                    [
+                        "1/drive",
+                        {
+                            "kind": "pulse",
+                            "duration": 20.0,
+                            "amplitude": 0.100396,
+                            "envelope": {
+                                "kind": "drag",
+                                "rel_sigma": 0.1,
+                                "beta": 0.25
+                            },
+                            "relative_phase": 0.0
+                        }
+                    ]
+                ],
+                "RX12": [
+                    [
+                        "1/drive12",
+                        {
+                            "kind": "pulse",
+                            "duration": 20.0,
+                            "amplitude": 0.138545,
+                            "envelope": {
+                                "kind": "gaussian",
+                                "rel_sigma": 0.1
+                            },
+                            "relative_phase": 0.0
+                        }
+                    ]
+                ],
+                "MZ": [
+                    [
+                        "1/acquisition",
+                        {
+                            "kind": "readout",
+                            "acquisition": {
+                                "kind": "acquisition",
+                                "duration": 10.0
+                            },
+                            "probe": {
+                                "kind": "pulse",
+                                "duration": 10.0,
+                                "amplitude": 0.1,
+                                "envelope": {
+                                    "kind": "rectangular"
+                                },
+                                "relative_phase": 0.0
+                            }
+                        }
+                    ]
+                ],
+                "CP": null
+            }
+        },
+        "coupler": {},
+        "two_qubit": {
+            "0-1": {
+                "CZ": null,
+                "CNOT": [
+                    [
+                        "01/drive",
+                        {
+                            "kind": "pulse",
+                            "duration": 50.0,
+                            "amplitude": 0.1,
+                            "envelope": {
+                                "kind": "rectangular"
+                            },
+                            "relative_phase": 0.0
+                        }
+                    ],
+                    [
+                        "0/drive",
+                        {
+                            "kind": "delay",
+                            "duration": 50.0
+                        }
+                    ],
+                    [
+                        "0/drive",
+                        {
+                            "kind": "pulse",
+                            "duration": 20.0,
+                            "amplitude": 0.200449,
+                            "envelope": {
+                                "kind": "drag",
+                                "rel_sigma": 0.1,
+                                "beta": 0.25
+                            },
+                            "relative_phase": 0.0
+                        }
+                    ],
+                    [
+                        "01/drive",
+                        {
+                            "kind": "delay",
+                            "duration": 20.0
+                        }
+                    ],
+                    [
+                        "01/drive",
+                        {
+                            "kind": "pulse",
+                            "duration": 50.0,
+                            "amplitude": -0.1,
+                            "envelope": {
+                                "kind": "rectangular"
+                            },
+                            "relative_phase": 0.0
+                        }
+                    ],
+                    [
+                        "0/drive",
+                        {
+                            "kind": "delay",
+                            "duration": 50.0
+                        }
+                    ],
+                    [
+                        "0/drive",
+                        {
+                            "kind": "pulse",
+                            "duration": 20.0,
+                            "amplitude": 0.200449,
+                            "envelope": {
+                                "kind": "drag",
+                                "rel_sigma": 0.1,
+                                "beta": 0.25
+                            },
+                            "relative_phase": 0.0
+                        }
+                    ],
+                    [
+                        "1/drive",
+                        {
+                            "kind": "delay",
+                            "duration": 140.0
+                        }
+                    ],
+                    [
+                        "1/drive",
+                        {
+                            "kind": "pulse",
+                            "duration": 20.0,
+                            "amplitude": 0.100396,
+                            "envelope": {
+                                "kind": "drag",
+                                "rel_sigma": 0.1,
+                                "beta": 0.25
+                            },
+                            "relative_phase": 0.0
+                        }
+                    ],
+                    [
+                        "0/drive",
+                        {
+                            "kind": "virtualz",
+                            "phase": -1.5707963267948966
+                        }
+                    ]
+                ],
+                "iSWAP": null
+            }
+        }
+    }
+}

--- a/tests/instruments/emulator/platforms/fixed-frequency-qutrits/platform.py
+++ b/tests/instruments/emulator/platforms/fixed-frequency-qutrits/platform.py
@@ -1,0 +1,37 @@
+from qibolab import ConfigKinds, Hardware, IqChannel, Platform, Qubit
+from qibolab.instruments.emulator import (
+    DriveEmulatorConfig,
+    EmulatorController,
+    HamiltonianConfig,
+)
+
+ConfigKinds.extend([HamiltonianConfig, DriveEmulatorConfig])
+
+
+def create() -> Platform:
+    """Create a dummy platform using the dummy instrument."""
+    qubits = {}
+    channels = {}
+
+    qubits[0] = qubit = Qubit.default(
+        0, drive_extra={(1, 2): "0/drive12", 1: "01/drive"}
+    )
+    channels |= {
+        qubit.drive: IqChannel(mixer=None, lo=None),
+        qubits[0].drive_extra[1, 2]: IqChannel(mixer=None, lo=None),
+        qubits[0].drive_extra[1]: IqChannel(mixer=None, lo=None),
+    }
+    qubits[1] = qubit = Qubit.default(1, drive_extra={(1, 2): "1/drive12"})
+    channels |= {
+        qubit.drive: IqChannel(mixer=None, lo=None),
+        qubits[1].drive_extra[1, 2]: IqChannel(mixer=None, lo=None),
+    }
+    # register the instruments
+    instruments = {
+        "dummy": EmulatorController(address="0.0.0.0", channels=channels),
+    }
+
+    return Hardware(
+        instruments=instruments,
+        qubits=qubits,
+    )

--- a/tests/instruments/emulator/platforms/fixed-frequency-qutrits/platform.py
+++ b/tests/instruments/emulator/platforms/fixed-frequency-qutrits/platform.py
@@ -1,4 +1,4 @@
-from qibolab import ConfigKinds, Hardware, IqChannel, Platform, Qubit
+from qibolab import ConfigKinds, Hardware, IqChannel, Qubit
 from qibolab.instruments.emulator import (
     DriveEmulatorConfig,
     EmulatorController,
@@ -8,8 +8,8 @@ from qibolab.instruments.emulator import (
 ConfigKinds.extend([HamiltonianConfig, DriveEmulatorConfig])
 
 
-def create() -> Platform:
-    """Create a dummy platform using the dummy instrument."""
+def create() -> Hardware:
+    """Create emulator platform with fixed-frequency coupled qutrits."""
     qubits = {}
     channels = {}
 
@@ -28,7 +28,7 @@ def create() -> Platform:
     }
     # register the instruments
     instruments = {
-        "dummy": EmulatorController(address="0.0.0.0", channels=channels),
+        "emulator": EmulatorController(address="0.0.0.0", channels=channels),
     }
 
     return Hardware(

--- a/tests/instruments/emulator/platforms/qubit/parameters.json
+++ b/tests/instruments/emulator/platforms/qubit/parameters.json
@@ -15,7 +15,9 @@
     "single_qubit": {
       "0": {
         "frequency": 5e9,
+        "sweetspot": 0.02,
         "anharmonicity": -200e6,
+        "asymmetry": 0.0,
         "t1": {
           "0-1": 1000
         },
@@ -36,6 +38,10 @@
       "frequency": 4.8e9,
       "scale_factor": 0.1591549
     },
+    "0/flux": {
+        "kind": "flux-emulator",
+        "offset": 0.02
+      },
   "0/probe": {
     "kind": "iq",
     "frequency": 5200000000.0

--- a/tests/instruments/emulator/platforms/qubit/platform.py
+++ b/tests/instruments/emulator/platforms/qubit/platform.py
@@ -1,15 +1,16 @@
 import pathlib
 
-from qibolab import ConfigKinds, IqChannel, Platform, Qubit
+from qibolab import ConfigKinds, DcChannel, IqChannel, Platform, Qubit
 from qibolab.instruments.emulator import (
     DriveEmulatorConfig,
     EmulatorController,
+    FluxEmulatorConfig,
     HamiltonianConfig,
 )
 
 FOLDER = pathlib.Path(__file__).parent
 
-ConfigKinds.extend([HamiltonianConfig, DriveEmulatorConfig])
+ConfigKinds.extend([HamiltonianConfig, DriveEmulatorConfig, FluxEmulatorConfig])
 
 
 def create() -> Platform:
@@ -21,6 +22,7 @@ def create() -> Platform:
         qubits[q] = qubit = Qubit.default(q)
         channels |= {
             qubit.drive: IqChannel(mixer=None, lo=None),
+            qubit.flux: DcChannel(),
         }
 
     # register the instruments

--- a/tests/instruments/emulator/platforms/qutrit/parameters.json
+++ b/tests/instruments/emulator/platforms/qutrit/parameters.json
@@ -36,8 +36,11 @@
       "kind": "drive-emulator",
       "scale_factor": 0.1591549,
       "frequency": 4.8e9
-
     },
+    "0/flux": {
+        "kind": "flux-emulator",
+        "offset": 0
+      },
   "0/probe": {
     "kind": "iq",
     "frequency": 5200000000.0

--- a/tests/instruments/emulator/platforms/qutrit/parameters.json
+++ b/tests/instruments/emulator/platforms/qutrit/parameters.json
@@ -28,6 +28,7 @@
     "kind": "hamiltonian"
   },
     "0/drive": {
+<<<<<<< HEAD:tests/instruments/emulator/platforms/qutrit/parameters.json
       "kind": "drive-emulator",
       "scale_factor": 0.1591549,
       "frequency": 5e9
@@ -37,6 +38,14 @@
       "scale_factor": 0.1591549,
       "frequency": 4.8e9
 
+=======
+      "kind": "drive",
+      "frequency": 5000000000
+    },
+    "0/probe": {
+      "kind": "drive",
+      "frequency": 5200000000.0
+>>>>>>> a852ebb9 (feat: Add DriveConfig):tests/instruments/emulator/parameters.json
     },
   "0/probe": {
     "kind": "iq",

--- a/tests/instruments/emulator/platforms/qutrit/parameters.json
+++ b/tests/instruments/emulator/platforms/qutrit/parameters.json
@@ -28,7 +28,6 @@
     "kind": "hamiltonian"
   },
     "0/drive": {
-<<<<<<< HEAD:tests/instruments/emulator/platforms/qutrit/parameters.json
       "kind": "drive-emulator",
       "scale_factor": 0.1591549,
       "frequency": 5e9
@@ -38,14 +37,6 @@
       "scale_factor": 0.1591549,
       "frequency": 4.8e9
 
-=======
-      "kind": "drive",
-      "frequency": 5000000000
-    },
-    "0/probe": {
-      "kind": "drive",
-      "frequency": 5200000000.0
->>>>>>> a852ebb9 (feat: Add DriveConfig):tests/instruments/emulator/parameters.json
     },
   "0/probe": {
     "kind": "iq",

--- a/tests/instruments/emulator/platforms/qutrit/platform.py
+++ b/tests/instruments/emulator/platforms/qutrit/platform.py
@@ -1,6 +1,6 @@
 import pathlib
 
-from qibolab import ConfigKinds, IqChannel, Platform, Qubit
+from qibolab import ConfigKinds, DcChannel, IqChannel, Platform, Qubit
 from qibolab.instruments.emulator import (
     DriveEmulatorConfig,
     EmulatorController,
@@ -21,6 +21,7 @@ def create() -> Platform:
         qubits[q] = qubit = Qubit.default(q)
         channels |= {
             qubit.drive: IqChannel(mixer=None, lo=None),
+            qubit.flux: DcChannel(),
         }
 
     # register the instruments

--- a/tests/instruments/emulator/platforms/qutrit/platform.py
+++ b/tests/instruments/emulator/platforms/qutrit/platform.py
@@ -13,7 +13,7 @@ ConfigKinds.extend([HamiltonianConfig, DriveEmulatorConfig])
 
 
 def create() -> Platform:
-    """Create a dummy platform using the dummy instrument."""
+    """Create emulator platform with one qutrit."""
     qubits = {}
     channels = {}
 

--- a/tests/instruments/emulator/platforms/qutrit/platform.py
+++ b/tests/instruments/emulator/platforms/qutrit/platform.py
@@ -4,12 +4,13 @@ from qibolab import ConfigKinds, DcChannel, IqChannel, Platform, Qubit
 from qibolab.instruments.emulator import (
     DriveEmulatorConfig,
     EmulatorController,
+    FluxEmulatorConfig,
     HamiltonianConfig,
 )
 
 FOLDER = pathlib.Path(__file__).parent
 
-ConfigKinds.extend([HamiltonianConfig, DriveEmulatorConfig])
+ConfigKinds.extend([HamiltonianConfig, DriveEmulatorConfig, FluxEmulatorConfig])
 
 
 def create() -> Platform:

--- a/tests/instruments/emulator/platforms/split-transmons/parameters.json
+++ b/tests/instruments/emulator/platforms/split-transmons/parameters.json
@@ -1,0 +1,285 @@
+{
+    "settings": {
+      "nshots": 1024,
+      "relaxation_time": 0
+    },
+    "configs": {
+      "emulator/bounds": {
+      "kind": "bounds",
+      "waveforms": 1000000,
+      "readout": 50,
+      "instructions": 200
+    },
+    "hamiltonian":{
+      "transmon_levels": 3,
+      "single_qubit": {
+        "0": {
+          "frequency": 4813586970.0,
+          "anharmonicity": -217e6,
+          "sweetspot":  0.405,
+          "t1": {
+            "0-1": 37000,
+            "1-2": 18000
+          },
+          "t2": {
+            "0-1": 23000
+          }
+        },
+        "1": {
+          "frequency": 5518133438.0,
+          "anharmonicity": -212e6,
+          "sweetspot": 0.582,
+          "t1": {
+            "0-1": 32000,
+            "1-2": 16000
+                    },
+          "t2": {
+            "0-1": 9000
+          }
+        }
+      },
+      "pairs":{
+        "0-1": {
+          "coupling": 12e6
+        }
+      },
+      "kind": "hamiltonian"
+    },
+      "0/drive": {
+        "kind": "drive-emulator",
+        "frequency": 4813586970.0,
+        "rabi_frequency": 20e6,
+        "scale_factor": 10
+      },
+      "0/drive12": {
+        "kind": "drive-emulator",
+        "frequency": 4596587222,
+        "rabi_frequency": 20e6,
+        "scale_factor": 10
+      },
+      "1/drive": {
+        "kind": "drive-emulator",
+        "frequency": 5518133438.0,
+        "rabi_frequency": 20e6,
+        "scale_factor": 10
+      },
+      "1/drive12": {
+        "kind": "drive-emulator",
+        "frequency": 5305695381.0,
+        "rabi_frequency": 20e6,
+        "scale_factor": 10
+      },
+      "0/flux": {
+        "kind": "flux-emulator",
+        "offset": 0.405
+      },
+      "1/flux": {
+        "kind": "flux-emulator",
+        "offset": 0.582
+      },
+    "0/probe": {
+      "kind": "iq",
+      "frequency": 5200000000.0
+    },
+    "0/acquisition": {
+      "kind": "acquisition",
+      "delay": 0.0,
+      "smearing": 0.0,
+      "threshold": 0.0,
+      "iq_angle": 0.0,
+      "kernel": null
+    },
+    "1/probe": {
+      "kind": "iq",
+      "frequency": 5200000000.0
+    },
+    "1/acquisition": {
+      "kind": "acquisition",
+      "delay": 0.0,
+      "smearing": 0.0,
+      "threshold": 0.0,
+      "iq_angle": 0.0,
+      "kernel": null
+    }
+    },
+    "native_gates": {
+      "single_qubit": {
+        "0": {
+          "RX": [
+            [
+              "0/drive",
+              {
+                "duration": 40,
+                "amplitude": 0.1265,
+                "envelope": {
+                  "kind": "gaussian",
+                  "rel_sigma": 0.2
+                },
+                "relative_phase": 0.0,
+                "kind": "pulse"
+              }
+            ]
+          ],
+          "RX90": [
+            [
+              "0/drive",
+              {
+                "duration": 40,
+                "amplitude": 0.0633,
+                "envelope": {
+                  "kind": "gaussian",
+                  "rel_sigma": 0.2
+                },
+                "relative_phase": 0.0,
+                "kind": "pulse"
+              }
+            ]
+          ],
+          "RX12": [
+            [
+              "0/drive12",
+              {
+                "duration": 40.0,
+                "amplitude": 0.08937,
+                "envelope": {
+                  "kind": "gaussian",
+                  "rel_sigma": 0.2
+                },
+                "relative_phase": 0.0,
+                "kind": "pulse"
+              }
+            ]
+          ],
+          "MZ": [
+            [
+              "0/acquisition",
+              {
+                "kind": "readout",
+                "acquisition": {
+                  "kind": "acquisition",
+                  "duration": 10.0
+                },
+                "probe": {
+                  "duration": 10.0,
+                  "amplitude": 0.1,
+                  "envelope": {
+                    "kind": "gaussian_square",
+                    "rel_sigma": 0.2,
+                    "width": 0.75
+                  },
+                  "relative_phase": 0.0,
+                  "kind": "pulse"
+                }
+              }
+            ]
+          ],
+          "CP": null
+        },
+        "1": {
+          "RX": [
+            [
+              "1/drive",
+              {
+                "duration": 40,
+                "amplitude": 0.1266,
+                "envelope": {
+                  "kind": "gaussian",
+                  "rel_sigma": 0.2
+                },
+                "relative_phase": 0.0,
+                "kind": "pulse"
+              }
+            ]
+          ],
+          "RX90": [
+            [
+              "1/drive",
+              {
+                "duration": 40,
+                "amplitude": 0.0633,
+                "envelope": {
+                  "kind": "gaussian",
+                  "rel_sigma": 0.2
+                },
+                "relative_phase": 0.0,
+                "kind": "pulse"
+              }
+            ]
+          ],
+          "RX12": [
+            [
+              "1/drive12",
+              {
+                "duration": 40.0,
+                "amplitude": 0.0896,
+                "envelope": {
+                  "kind": "gaussian",
+                  "rel_sigma": 0.2
+                },
+                "relative_phase": 0.0,
+                "kind": "pulse"
+              }
+            ]
+          ],
+          "MZ": [
+            [
+              "1/acquisition",
+              {
+                "kind": "readout",
+                "acquisition": {
+                  "kind": "acquisition",
+                  "duration": 10.0
+                },
+                "probe": {
+                  "duration": 10.0,
+                  "amplitude": 0.1,
+                  "envelope": {
+                    "kind": "gaussian_square",
+                    "rel_sigma": 0.2,
+                    "width": 0.75
+                  },
+                  "relative_phase": 0.0,
+                  "kind": "pulse"
+                }
+              }
+            ]
+          ],
+          "CP": null
+        }
+      },
+      "two_qubit": {
+            "0-1": {
+                "CZ": [
+                    [
+                        "1/flux",
+                        {
+                            "kind": "pulse",
+                            "duration": 30,
+                            "amplitude": 0.1852,
+                            "envelope": {
+                                "kind": "snz",
+                                "t_idling": 4.0,
+                                "b_amplitude": 0.5
+                            },
+                            "relative_phase": 0.0
+                        }
+                    ],
+                    [
+                      "1/drive",
+                      {
+                          "kind": "virtualz",
+                          "phase": -4.656
+                      }
+                  ],
+                  [
+                      "0/drive",
+                      {
+                          "kind": "virtualz",
+                          "phase": -0.1494
+                      }
+                  ]
+                ]
+            }
+      }
+    }
+  }

--- a/tests/instruments/emulator/platforms/split-transmons/platform.py
+++ b/tests/instruments/emulator/platforms/split-transmons/platform.py
@@ -1,6 +1,4 @@
-import pathlib
-
-from qibolab import ConfigKinds, DcChannel, IqChannel, Platform, Qubit
+from qibolab import ConfigKinds, DcChannel, Hardware, IqChannel, Qubit
 from qibolab.instruments.emulator import (
     DriveEmulatorConfig,
     EmulatorController,
@@ -8,30 +6,27 @@ from qibolab.instruments.emulator import (
     HamiltonianConfig,
 )
 
-FOLDER = pathlib.Path(__file__).parent
-
 ConfigKinds.extend([HamiltonianConfig, DriveEmulatorConfig, FluxEmulatorConfig])
 
 
-def create() -> Platform:
-    """Create emulator platform with one qubit."""
+def create() -> Hardware:
+    """Create platform with two split-transmons coupled."""
     qubits = {}
     channels = {}
 
-    for q in range(1):
-        qubits[q] = qubit = Qubit.default(q)
+    for q in range(2):
+        qubits[q] = qubit = Qubit.default(q, drive_extra={(1, 2): f"{q}/drive12"})
         channels |= {
             qubit.drive: IqChannel(mixer=None, lo=None),
             qubit.flux: DcChannel(),
+            qubits[q].drive_extra[1, 2]: IqChannel(mixer=None, lo=None),
         }
-
     # register the instruments
     instruments = {
-        "dummy": EmulatorController(address="0.0.0.0", channels=channels),
+        "emulator": EmulatorController(address="0.0.0.0", channels=channels),
     }
 
-    return Platform.load(
-        path=FOLDER,
+    return Hardware(
         instruments=instruments,
         qubits=qubits,
     )

--- a/tests/instruments/emulator/test_circuits.py
+++ b/tests/instruments/emulator/test_circuits.py
@@ -38,7 +38,8 @@ def test_cnot(platform, setup):
     backend = construct_backend(backend="qibolab", platform=platform)
     if backend.platform.nqubits < 2:
         pytest.skip("CNOT requires at least two qubits.")
-
+    if backend.platform.natives.two_qubit[0, 1].CNOT is None:
+        pytest.skip(f"Platform {platform} doesn't support CNOT.")
     circuit = Circuit(2)
     if setup == "X":
         circuit.add(gates.GPI(0, 0))

--- a/tests/instruments/emulator/test_circuits.py
+++ b/tests/instruments/emulator/test_circuits.py
@@ -10,7 +10,7 @@ def test_measurement(platform):
     circuit = Circuit(1)
     circuit.add(gates.M(0))
     result = backend.execute_circuit(circuit, nshots=1000)
-    pytest.approx(result.samples().mean(), abs=5e-2) == 0
+    assert pytest.approx(result.samples().mean(), abs=5e-2) == 0
 
 
 def test_hadamard(platform):
@@ -19,7 +19,7 @@ def test_hadamard(platform):
     circuit.add(gates.GPI2(0, 0))
     circuit.add(gates.M(0))
     result = backend.execute_circuit(circuit, nshots=1000)
-    pytest.approx(result.samples().mean(), abs=1e-1) == 0.5
+    assert pytest.approx(result.samples().mean(), abs=1e-1) == 0.5
 
 
 def test_rz(platform):
@@ -30,4 +30,24 @@ def test_rz(platform):
     circuit.add(gates.GPI2(0, np.pi / 2))
     circuit.add(gates.M(0))
     result = backend.execute_circuit(circuit, nshots=1000)
-    pytest.approx(result.samples().mean(), abs=5e-2) == 1
+    assert pytest.approx(result.samples().mean(), abs=5e-2) == 1
+
+
+@pytest.mark.parametrize("setup", ["Id", "X"])
+def test_cnot(platform, setup):
+    backend = construct_backend(backend="qibolab", platform=platform)
+    if backend.platform.nqubits < 2:
+        pytest.skip("CNOT requires at least two qubits.")
+
+    circuit = Circuit(2)
+    if setup == "X":
+        circuit.add(gates.GPI(0, 0))
+    circuit.add(gates.CNOT(0, 1))
+    circuit.add(gates.M(0, 1))
+    result = backend.execute_circuit(circuit, nshots=1000)
+    assert (
+        pytest.approx(
+            result.frequencies()["00" if setup == "Id" else "11"] / 1000, abs=3e-1
+        )
+        == 1
+    )

--- a/tests/instruments/emulator/test_emulator.py
+++ b/tests/instruments/emulator/test_emulator.py
@@ -22,7 +22,7 @@ def test_integration_mode(platform):
     )
 
     assert result[acq_handle].shape == (NSHOTS, 2)
-    pytest.approx(result[acq_handle][:, 1].mean(), abs=1e-2) == 0
+    assert pytest.approx(result[acq_handle][:, 1].mean(), abs=1e-2) == 0
 
     result = platform.execute(
         [seq],
@@ -32,7 +32,7 @@ def test_integration_mode(platform):
     )
 
     assert result[acq_handle].shape == (2,)
-    pytest.approx(result[acq_handle][1], abs=1e-2) == 0
+    assert pytest.approx(result[acq_handle][1], abs=1e-2) == 0
 
 
 def test_align_fail(platform):

--- a/tests/instruments/emulator/test_hamiltonians.py
+++ b/tests/instruments/emulator/test_hamiltonians.py
@@ -9,6 +9,7 @@ from qibolab._core.instruments.emulator.hamiltonians import (
     ModulatedDelay,
     ModulatedDrive,
     ModulatedVirtualZ,
+    Qubit,
     waveform,
 )
 from qibolab._core.pulses.envelope import Rectangular
@@ -18,8 +19,9 @@ from qibolab._core.pulses.pulse import Delay, Pulse, VirtualZ, _PulseLike
 def test_dummy_waveform():
     acq_config = AcquisitionConfig(delay=0, smearing=0)
     dc_config = DcConfig(offset=0)
-    assert waveform(pulse=_PulseLike(), config=acq_config) is None
-    assert waveform(pulse=_PulseLike(), config=dc_config) is None
+    qubit = Qubit()
+    assert waveform(pulse=_PulseLike(), config=acq_config, qubit=qubit) is None
+    assert waveform(pulse=_PulseLike(), config=dc_config, qubit=qubit) is None
 
 
 @pytest.mark.parametrize(
@@ -33,7 +35,8 @@ def test_dummy_waveform():
 @pytest.mark.parametrize("level", [1, 2])
 def test_iq_waveform(pulse, level):
     iq_config = DriveEmulatorConfig(frequency=5e9)
-    modulated = waveform(pulse=pulse, config=iq_config)
+    qubit = Qubit(frequency=5e9)
+    modulated = waveform(pulse=pulse, config=iq_config, qubit=qubit)
     if isinstance(pulse, Pulse):
         assert isinstance(modulated, ModulatedDrive)
         assert pytest.approx(modulated.omega) == 2 * np.pi * 5

--- a/tests/instruments/emulator/test_sequence.py
+++ b/tests/instruments/emulator/test_sequence.py
@@ -68,7 +68,7 @@ def test_detuning_flux_pulse(platform: Platform):
     # move the qubit away while applying RX pulse
     seq = PulseSequence(
         [
-            (flux_channel, Pulse(duration=20, amplitude=0.5, envelope=Rectangular())),
+            (flux_channel, Pulse(duration=40, amplitude=0.8, envelope=Rectangular())),
         ]
     )
     seq += q0.RX()
@@ -86,7 +86,7 @@ def test_detuning_static_bias(platform: Platform):
         pytest.skip(f"Skipping due to missing flux channel for platform {platform}.")
     seq = q0.RX() | q0.MZ()
     acq_handle = list(seq.channel(platform.qubits[0].acquisition))[-1].id
-    updates = [{flux_channel: {"offset": 0.5}}]
+    updates = [{flux_channel: {"offset": 0.8}}]
     res = platform.execute([seq], nshots=1e4, updates=updates)[acq_handle]
     assert pytest.approx(res.mean(), abs=5e-2) != 1
 
@@ -101,7 +101,7 @@ def test_detuning_second_excited_state(platform: Platform):
         pytest.skip(f"Skipping due to missing flux channel for platform {platform}.")
     seq = q0.RX()
     seq |= [
-        (flux_channel, Pulse(duration=20, amplitude=0.5, envelope=Rectangular()))
+        (flux_channel, Pulse(duration=40, amplitude=0.8, envelope=Rectangular()))
     ] + q0.RX12()
     seq |= q0.MZ()
     acq_handle = list(seq.channel(platform.qubits[0].acquisition))[-1].id
@@ -114,7 +114,9 @@ def test_detuning_second_excited_state(platform: Platform):
 def test_cnot_sequence(platform: Platform, setup: str):
     """Test CNOT sequence with emulator."""
     if platform.nqubits < 2:
-        pytest.skip(f"Skipping due to missing qubit for platform {platform}.")
+        pytest.skip(f"Plaform {platform} requires at least two qubits.")
+    if platform.natives.two_qubit[0, 1].CNOT is None:
+        pytest.skip(f"Skipping due to missing CNOT for platform {platform}.")
     q0 = platform.natives.single_qubit[0]
     q1 = platform.natives.single_qubit[1]
     pair = platform.natives.two_qubit[0, 1]
@@ -129,3 +131,28 @@ def test_cnot_sequence(platform: Platform, setup: str):
     assert (
         pytest.approx(res[target_handle].mean(), abs=2e-1) == 0 if setup == "Id" else 1
     )
+
+
+def test_cz_sequence(
+    platform: Platform,
+):
+    """Test CZ sequence with emulator."""
+    if platform.nqubits < 2:
+        pytest.skip(f"Plaform {platform} requires at least two qubits.")
+    if platform.natives.two_qubit[0, 1].CZ is None:
+        pytest.skip(f"Skipping due to missing CNOT for platform {platform}.")
+    q0 = platform.natives.single_qubit[0]
+    q1 = platform.natives.single_qubit[1]
+    pair = platform.natives.two_qubit[0, 1]
+
+    seq = PulseSequence()
+    seq += q0.R(theta=np.pi / 2, phi=np.pi / 2)
+    seq += q1.R(theta=np.pi / 2, phi=np.pi / 2)
+    seq |= pair.CZ()
+    seq |= q0.RX() + q1.R(theta=np.pi / 2, phi=np.pi / 2)
+    seq |= q0.MZ() + q1.MZ()
+    control_handle = list(seq.channel(platform.qubits[0].acquisition))[-1].id
+    target_handle = list(seq.channel(platform.qubits[1].acquisition))[-1].id
+    res = platform.execute([seq], nshots=1e4)
+    assert pytest.approx(res[target_handle].mean(), abs=2e-1) == 0.5
+    assert pytest.approx(res[control_handle].mean(), abs=2e-1) == 0.5

--- a/tests/instruments/emulator/test_sequence.py
+++ b/tests/instruments/emulator/test_sequence.py
@@ -3,10 +3,11 @@
 import numpy as np
 import pytest
 
-from qibolab import Platform, PulseSequence, VirtualZ
+from qibolab import Platform, Pulse, PulseSequence, Rectangular, VirtualZ
 
 
 def test_ground_state(platform: Platform):
+    """Test the ground state of a qubit with emulator."""
     q0 = platform.natives.single_qubit[0]
     seq = q0.MZ()
     acq_handle = list(seq.channel(platform.qubits[0].acquisition))[-1].id
@@ -15,6 +16,7 @@ def test_ground_state(platform: Platform):
 
 
 def test_superposition_state(platform: Platform):
+    """Test superposition state of a qubit with emulator."""
     q0 = platform.natives.single_qubit[0]
     seq = q0.RX90() | q0.MZ()
     acq_handle = list(seq.channel(platform.qubits[0].acquisition))[-1].id
@@ -23,6 +25,7 @@ def test_superposition_state(platform: Platform):
 
 
 def test_excited_state(platform: Platform):
+    """Test excited state of a qubit with emulator."""
     q0 = platform.natives.single_qubit[0]
     seq = q0.RX() | q0.MZ()
     acq_handle = list(seq.channel(platform.qubits[0].acquisition))[-1].id
@@ -31,6 +34,7 @@ def test_excited_state(platform: Platform):
 
 
 def test_second_excited_state(platform: Platform):
+    """Test second excited state of a qubit with emulator."""
     q0 = platform.natives.single_qubit[0]
     if q0.RX12 is None:
         pytest.skip(f"Skipping due to missing RX12 for platform {platform}.")
@@ -41,6 +45,7 @@ def test_second_excited_state(platform: Platform):
 
 
 def test_virtualz_sequence(platform: Platform):
+    """Test virtual Z sequence of a qubit with emulator."""
     q0 = platform.natives.single_qubit[0]
     ch = platform.qubits[0].drive
     seq = (
@@ -52,3 +57,49 @@ def test_virtualz_sequence(platform: Platform):
     acq_handle = list(seq.channel(platform.qubits[0].acquisition))[-1].id
     res = platform.execute([seq], nshots=1e4)[acq_handle]
     assert pytest.approx(res.mean(), abs=5e-2) == 1
+
+
+def test_detuning_flux_pulse(platform: Platform):
+    """Test detuning caused by flux pulse."""
+    q0 = platform.natives.single_qubit[0]
+    flux_channel = platform.qubits[0].flux
+
+    # move the qubit away while applying RX pulse
+    seq = PulseSequence(
+        [
+            (flux_channel, Pulse(duration=20, amplitude=0.5, envelope=Rectangular())),
+        ]
+    )
+    seq += q0.RX()
+    seq |= q0.MZ()
+    acq_handle = list(seq.channel(platform.qubits[0].acquisition))[-1].id
+    res = platform.execute([seq], nshots=1e4)[acq_handle]
+    assert pytest.approx(res.mean(), abs=5e-2) != 1
+
+
+def test_detuning_static_bias(platform: Platform):
+    """Test detuning caused by static bias."""
+    q0 = platform.natives.single_qubit[0]
+    flux_channel = platform.qubits[0].flux
+    seq = q0.RX() | q0.MZ()
+    acq_handle = list(seq.channel(platform.qubits[0].acquisition))[-1].id
+    updates = [{flux_channel: {"offset": 0.5}}]
+    res = platform.execute([seq], nshots=1e4, updates=updates)[acq_handle]
+    assert pytest.approx(res.mean(), abs=5e-2) != 1
+
+
+def test_detuning_second_excited_state(platform: Platform):
+    """Test detuning second excited state of a qubit with emulator."""
+    q0 = platform.natives.single_qubit[0]
+    if q0.RX12 is None:
+        pytest.skip(f"Skipping due to missing RX12 for platform {platform}.")
+    flux_channel = platform.qubits[0].flux
+    seq = q0.RX()
+    seq |= [
+        (flux_channel, Pulse(duration=20, amplitude=0.5, envelope=Rectangular()))
+    ] + q0.RX12()
+    seq |= q0.MZ()
+    acq_handle = list(seq.channel(platform.qubits[0].acquisition))[-1].id
+    res = platform.execute([seq], nshots=1e4)[acq_handle]
+    # since we apply a flux pulse the qubit stays at 1
+    assert pytest.approx(res.mean(), abs=1e-1) == 1

--- a/tests/instruments/emulator/test_sequence.py
+++ b/tests/instruments/emulator/test_sequence.py
@@ -63,7 +63,8 @@ def test_detuning_flux_pulse(platform: Platform):
     """Test detuning caused by flux pulse."""
     q0 = platform.natives.single_qubit[0]
     flux_channel = platform.qubits[0].flux
-
+    if flux_channel not in platform.channels:
+        pytest.skip(f"Skipping due to missing flux channel for platform {platform}.")
     # move the qubit away while applying RX pulse
     seq = PulseSequence(
         [
@@ -81,6 +82,8 @@ def test_detuning_static_bias(platform: Platform):
     """Test detuning caused by static bias."""
     q0 = platform.natives.single_qubit[0]
     flux_channel = platform.qubits[0].flux
+    if flux_channel not in platform.channels:
+        pytest.skip(f"Skipping due to missing flux channel for platform {platform}.")
     seq = q0.RX() | q0.MZ()
     acq_handle = list(seq.channel(platform.qubits[0].acquisition))[-1].id
     updates = [{flux_channel: {"offset": 0.5}}]
@@ -91,9 +94,11 @@ def test_detuning_static_bias(platform: Platform):
 def test_detuning_second_excited_state(platform: Platform):
     """Test detuning second excited state of a qubit with emulator."""
     q0 = platform.natives.single_qubit[0]
+    flux_channel = platform.qubits[0].flux
     if q0.RX12 is None:
         pytest.skip(f"Skipping due to missing RX12 for platform {platform}.")
-    flux_channel = platform.qubits[0].flux
+    if flux_channel not in platform.channels:
+        pytest.skip(f"Skipping due to missing flux channel for platform {platform}.")
     seq = q0.RX()
     seq |= [
         (flux_channel, Pulse(duration=20, amplitude=0.5, envelope=Rectangular()))
@@ -103,3 +108,24 @@ def test_detuning_second_excited_state(platform: Platform):
     res = platform.execute([seq], nshots=1e4)[acq_handle]
     # since we apply a flux pulse the qubit stays at 1
     assert pytest.approx(res.mean(), abs=1e-1) == 1
+
+
+@pytest.mark.parametrize("setup", ["Id", "X"])
+def test_cnot_sequence(platform: Platform, setup: str):
+    """Test CNOT sequence with emulator."""
+    if platform.nqubits < 2:
+        pytest.skip(f"Skipping due to missing qubit for platform {platform}.")
+    q0 = platform.natives.single_qubit[0]
+    q1 = platform.natives.single_qubit[1]
+    pair = platform.natives.two_qubit[0, 1]
+    seq = PulseSequence()
+    if setup == "X":
+        seq += q0.RX()
+
+    seq = pair.CNOT()
+    seq |= q0.MZ() + q1.MZ()
+    target_handle = list(seq.channel(platform.qubits[1].acquisition))[-1].id
+    res = platform.execute([seq], nshots=1e4)
+    assert (
+        pytest.approx(res[target_handle].mean(), abs=2e-1) == 0 if setup == "Id" else 1
+    )


### PR DESCRIPTION
This PR is a first attempt at introducing flux-tunability to the emulator.
I've coded a prototype to have sweepers for both flux pulses and offset.

TODO:

- [x] Update documentation for flux-tunable qubit
- [x] Write tests including platform for flux-tunable qubit
- [x] Update documentation for two qubit platform (leftover from #1186)
- [x] Write tests including platform for two qubit platform (leftover from #1186)
