### PR TITLE
Fix SNZ envelope

### DIFF
--- a/src/qibolab/_core/pulses/envelope.py
+++ b/src/qibolab/_core/pulses/envelope.py
@@ -268,25 +268,29 @@ class Snz(BaseEnvelope):
     kind: Literal["snz"] = "snz"
 
     t_idling: int
-    """Fraction of interval where idling."""
+    """Absolute idling time."""
     b_amplitude: float = 0.5
     """Relative B amplitude (wrt A)."""
 
-    def i(self, samples: int):
+    def i(self, samples: int) -> Waveform:
         """I.
 
         .. todo::
 
             Add docstring
         """
+        assert samples > self.t_idling, "Number of samples shorter than the idling time."
+        assert (samples - self.t_idling) % 2 == 0, "The total duration of the square pulses should be even." 
+
         square_pulse_duration = int((samples - self.t_idling) / 2 - 1)
+        square_pulse = np.ones(square_pulse_duration)
         return np.concatenate(
             [
-                np.ones(square_pulse_duration),
+                square_pulse,
                 [self.b_amplitude],
                 np.zeros(self.t_idling),
                 [-1 * self.b_amplitude],
-                -1 * np.ones(square_pulse_duration),
+                -1 * square_pulse,
             ]
         )
 

--- a/src/qibolab/_core/pulses/envelope.py
+++ b/src/qibolab/_core/pulses/envelope.py
@@ -267,31 +267,20 @@ class Snz(BaseEnvelope):
 
     kind: Literal["snz"] = "snz"
 
-    t_idling: float
+    t_idling: int
     """Fraction of interval where idling."""
     b_amplitude: float = 0.5
     """Relative B amplitude (wrt A)."""
 
-    def i(self, samples: int) -> Waveform:
+    def i(self, samples: int) :
         """I.
 
         .. todo::
 
             Add docstring
         """
-        # convert timings to samples
-        half_pulse_duration = (1 - self.t_idling) * samples / 2
-        aspan = np.sum(np.arange(samples) < half_pulse_duration)
-        idle = samples - 2 * (aspan + 1)
-        pulse = np.ones(samples)
-        pulse[-aspan:] = -1
-        # the aspan + 1 sample is B (and so the aspan + 1 + idle + 1), indexes are 0-based
-        pulse[aspan] = self.b_amplitude
-        pulse[aspan + 1 + idle] = -self.b_amplitude
-        # set idle time to 0
-        pulse[aspan + 1 : aspan + 1 + idle] = 0
-        return pulse
-
+        square_pulse_duration = int((samples - self.t_idling)/2 - 1 )
+        return np.concatenate([np.ones(square_pulse_duration), [self.b_amplitude], np.zeros(self.t_idling), [-1*self.b_amplitude], -1*np.ones(square_pulse_duration)])
 
 class ECap(BaseEnvelope):
     r"""ECap pulse envelope.

--- a/src/qibolab/_core/pulses/envelope.py
+++ b/src/qibolab/_core/pulses/envelope.py
@@ -268,7 +268,7 @@ class Snz(BaseEnvelope):
     kind: Literal["snz"] = "snz"
 
     t_idling: int
-    """Absolute idling time."""
+    """Absolute idling time, in number of samples."""
     b_amplitude: float = 0.5
     """Relative B amplitude (wrt A)."""
 

--- a/src/qibolab/_core/pulses/envelope.py
+++ b/src/qibolab/_core/pulses/envelope.py
@@ -303,8 +303,8 @@ class Snz(BaseEnvelope):
                 square_pulse,
                 [self.b_amplitude],
                 np.zeros(self.t_idling),
-                [-1 * self.b_amplitude],
-                -1 * square_pulse,
+                [-self.b_amplitude],
+                -square_pulse,
             ]
         )
 

--- a/src/qibolab/_core/pulses/envelope.py
+++ b/src/qibolab/_core/pulses/envelope.py
@@ -273,7 +273,7 @@ class Snz(BaseEnvelope):
     """Relative B amplitude (wrt A)."""
 
     def i(self, samples: int) -> Waveform:
-        """I.
+        r"""I.
 
         .. math::
 

--- a/src/qibolab/_core/pulses/envelope.py
+++ b/src/qibolab/_core/pulses/envelope.py
@@ -275,9 +275,19 @@ class Snz(BaseEnvelope):
     def i(self, samples: int) -> Waveform:
         """I.
 
-        .. todo::
+        .. math::
 
-            Add docstring
+            \Phi(t) = 
+            \begin{cases}
+            1 & \text{for } 0 \leq t < \tau \\
+            b & \text{for } t = \tau \\
+            0 & \text{for } \tau < t < \tau + \tau_{idle}\\
+            b & \text{for } t = \tau + \tau_{idle}\\
+            -1 & \text{for } \tau + \tau_{idle} < t \leq 2\tau + \tau_{idle} \\
+            \end{cases}.
+
+        Where $\tau$ is the duration of the square pulse.
+
         """
         assert samples > self.t_idling, "Number of samples shorter than the idling time."
         assert (samples - self.t_idling) % 2 == 0, "The total duration of the square pulses should be even." 

--- a/src/qibolab/_core/pulses/envelope.py
+++ b/src/qibolab/_core/pulses/envelope.py
@@ -277,20 +277,24 @@ class Snz(BaseEnvelope):
 
         .. math::
 
-            \Phi(t) = 
+            \\Phi(t) =
             \begin{cases}
-            1 & \text{for } 0 \leq t < \tau \\
+            1 & \text{for } 0 \\leq t < \tau \\
             b & \text{for } t = \tau \\
             0 & \text{for } \tau < t < \tau + \tau_{idle}\\
             b & \text{for } t = \tau + \tau_{idle}\\
-            -1 & \text{for } \tau + \tau_{idle} < t \leq 2\tau + \tau_{idle} \\
-            \end{cases}.
+            -1 & \text{for } \tau + \tau_{idle} < t \\leq 2\tau + \tau_{idle} \\
+            \\end{cases}.
 
         Where $\tau$ is the duration of the square pulse.
 
         """
-        assert samples > self.t_idling, "Number of samples shorter than the idling time."
-        assert (samples - self.t_idling) % 2 == 0, "The total duration of the square pulses should be even." 
+        assert samples > self.t_idling, (
+            "Number of samples shorter than the idling time."
+        )
+        assert (samples - self.t_idling) % 2 == 0, (
+            "The total duration of the square pulses should be even."
+        )
 
         square_pulse_duration = int((samples - self.t_idling) / 2 - 1)
         square_pulse = np.ones(square_pulse_duration)

--- a/src/qibolab/_core/pulses/envelope.py
+++ b/src/qibolab/_core/pulses/envelope.py
@@ -272,15 +272,24 @@ class Snz(BaseEnvelope):
     b_amplitude: float = 0.5
     """Relative B amplitude (wrt A)."""
 
-    def i(self, samples: int) :
+    def i(self, samples: int):
         """I.
 
         .. todo::
 
             Add docstring
         """
-        square_pulse_duration = int((samples - self.t_idling)/2 - 1 )
-        return np.concatenate([np.ones(square_pulse_duration), [self.b_amplitude], np.zeros(self.t_idling), [-1*self.b_amplitude], -1*np.ones(square_pulse_duration)])
+        square_pulse_duration = int((samples - self.t_idling) / 2 - 1)
+        return np.concatenate(
+            [
+                np.ones(square_pulse_duration),
+                [self.b_amplitude],
+                np.zeros(self.t_idling),
+                [-1 * self.b_amplitude],
+                -1 * np.ones(square_pulse_duration),
+            ]
+        )
+
 
 class ECap(BaseEnvelope):
     r"""ECap pulse envelope.


### PR DESCRIPTION
In `main`, the idling time of SNZ is proportional to the number of samples, meaning it adjusts dynamically when sweeping the pulse duration for the Chevron experiment. Together with @Luca-Ben-Herrmann, we tested various pulse parameters but were unable to observe the characteristic Chevron pattern. For example, this [report](http://login.qrccluster.com:9000/NW8L2RmfQjanw-1v8w_ANA==/) shows one of the outputs. Although the [paper](https://arxiv.org/pdf/2008.07411) does not explain the detail of Chevron experiment, it is not clear why the idling time needs to be swept.  

In this branch, the idling time is fixed (absolute), as seen in this [report](http://login.qrccluster.com:9000/_aXKWNYbS86SvszFZZhOKQ==/). Additionally, this PR includes code refactoring to increase readability.  

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.



