### PR TITLE
Sweep `phase` of `VirtualZ` in QM

### DIFF
--- a/src/qibolab/_core/instruments/qm/program/instructions.py
+++ b/src/qibolab/_core/instruments/qm/program/instructions.py
@@ -31,6 +31,14 @@ def _delay(pulse: Delay, element: str, parameters: Parameters):
             qua.wait(duration, element)
 
 
+def _virtualz(pulse: VirtualZ, element: str, parameters: Parameters):
+    if parameters.phase is not None:
+        phase = parameters.phase
+    else:
+        phase = normalize_phase(pulse.phase)
+    qua.frame_rotation_2pi(phase, element)
+
+
 def _play_multiple_waveforms(element: str, parameters: Parameters):
     """Sweeping pulse duration using distinctly uploaded waveforms."""
     assert not parameters.interpolated
@@ -97,15 +105,15 @@ def play(args: ExecutionArguments):
         element = str(channel_id)
         op = operation(pulse)
         params = args.parameters[pulse.id]
-        if isinstance(pulse, Delay):
-            _delay(pulse, element, params)
-        elif isinstance(pulse, Pulse):
+        if isinstance(pulse, Pulse):
             _play(op, element, params)
         elif isinstance(pulse, Readout):
             acquisition = args.acquisitions.get((op, element))
             _play(op, element, params, acquisition)
+        elif isinstance(pulse, Delay):
+            _delay(pulse, element, params)
         elif isinstance(pulse, VirtualZ):
-            qua.frame_rotation_2pi(normalize_phase(pulse.phase), element)
+            _virtualz(pulse, element, params)
         elif isinstance(pulse, Align) and pulse.id not in processed_aligns:
             channel_ids = args.sequence.pulse_channels(pulse.id)
             qua.align(*(str(ch) for ch in channel_ids))

--- a/src/qibolab/_core/instruments/qm/program/instructions.py
+++ b/src/qibolab/_core/instruments/qm/program/instructions.py
@@ -32,7 +32,11 @@ def _delay(pulse: Delay, element: str, parameters: Parameters):
 
 
 def _virtualz(pulse: VirtualZ, element: str, parameters: Parameters):
-    phase = parameters.phase if parameters.phase is not None else normalize_phase(pulse.phase)
+    phase = (
+        parameters.phase
+        if parameters.phase is not None
+        else normalize_phase(pulse.phase)
+    )
     qua.frame_rotation_2pi(phase, element)
 
 

--- a/src/qibolab/_core/instruments/qm/program/instructions.py
+++ b/src/qibolab/_core/instruments/qm/program/instructions.py
@@ -32,10 +32,7 @@ def _delay(pulse: Delay, element: str, parameters: Parameters):
 
 
 def _virtualz(pulse: VirtualZ, element: str, parameters: Parameters):
-    if parameters.phase is not None:
-        phase = parameters.phase
-    else:
-        phase = normalize_phase(pulse.phase)
+    phase = parameters.phase if parameters.phase is not None else normalize_phase(pulse.phase)
     qua.frame_rotation_2pi(phase, element)
 
 

--- a/src/qibolab/_core/instruments/qm/program/sweepers.py
+++ b/src/qibolab/_core/instruments/qm/program/sweepers.py
@@ -125,6 +125,7 @@ NORMALIZERS = {
     Parameter.frequency: normalize_frequency,
     Parameter.amplitude: normalize_amplitude,
     Parameter.relative_phase: normalize_phase,
+    Parameter.phase: normalize_phase,
     Parameter.duration_interpolated: normalize_duration,
 }
 """Functions to normalize sweeper values.
@@ -138,6 +139,7 @@ SWEEPER_METHODS = {
     Parameter.duration: _duration,
     Parameter.duration_interpolated: _duration_interpolated,
     Parameter.relative_phase: _relative_phase,
+    Parameter.phase: _relative_phase,
     Parameter.offset: _offset,
 }
 """Methods that return part of QUA program to be used inside the loop."""

--- a/src/qibolab/_core/sweeper.py
+++ b/src/qibolab/_core/sweeper.py
@@ -7,7 +7,7 @@ import numpy.typing as npt
 from pydantic import model_validator
 
 from .identifier import ChannelId
-from .pulses import PulseLike
+from .pulses import PulseLike, VirtualZ
 from .serialize import Model
 
 __all__ = ["Parameter", "ParallelSweepers", "Sweeper"]
@@ -24,6 +24,7 @@ class Parameter(Enum):
     duration = (auto(), _PULSE)
     duration_interpolated = (auto(), _PULSE)
     relative_phase = (auto(), _PULSE)
+    phase = (auto(), _PULSE)
     offset = (auto(), _CHANNEL)
 
     @classmethod
@@ -95,6 +96,10 @@ class Sweeper(Model):
             raise ValueError(
                 f"Cannot create a sweeper for {self.parameter} without specifying pulses."
             )
+        if self.parameter is Parameter.phase and not all(
+            isinstance(pulse, VirtualZ) for pulse in self.pulses
+        ):
+            raise TypeError("Cannot create a phase sweeper on non-VirtualZ pulses.")
 
         if self.range is not None:
             object.__setattr__(self, "values", np.arange(*self.range))

--- a/tests/test_sweeper.py
+++ b/tests/test_sweeper.py
@@ -19,6 +19,9 @@ def test_sweeper_pulses(parameter):
     if parameter in Parameter.channels():
         with pytest.raises(ValueError, match="channels"):
             _ = Sweeper(parameter=parameter, values=parameter_range, pulses=[pulse])
+    elif parameter is Parameter.phase:
+        with pytest.raises(TypeError):
+            _ = Sweeper(parameter=parameter, values=parameter_range, pulses=[pulse])
     else:
         sweeper = Sweeper(parameter=parameter, values=parameter_range, pulses=[pulse])
         assert sweeper.parameter is parameter


### PR DESCRIPTION
Fixes #1193, by propagating the sweeping of `VirtualZ` to the QM driver.

I also added a new `Parameter.phase` to match the `VirtualZ.phase` attribute. This part is optional, as we could also use the existing `Parameter.relative_phase`, however this would break the symmetry between `Parameter` and `Pulse` attribute names which in all other cases agree. Now `VirtualZ` sweepers need to be defined as
```py
vz = VirtualZ(phase=0)
sweeper = Sweeper(parameter=Parameter.phase, range=..., pulses=[vz])
```
@alecandido (and others) let me know what you think about this point, or if you prefer to drop the `Parameter.phase` and use the existing `Parameter.relative_phase` instead. Note that the duplication between `Pulse.relative_phase` and `VirtualZ.phase` is already known (#1157) but dropping any of the two would be breaking.

It is also worth noting that in the above example, using `sweeper = Sweeper(parameter=Parameter.relative_phase, range=..., pulses=[vz])` would also work, at least for QM. One could imagine more complicated examples where multiple `PulseLike` objects of different types are mixed in the `Sweeper.pulses` of a single sweeper, however I am not sure if it is worth going down that road in practice.