### PR TITLE
Use samples instead of probabilities in emulator tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import pathlib
 from collections.abc import Callable
 from typing import Optional
 
+import numpy as np
 import numpy.typing as npt
 import pytest
 
@@ -14,6 +15,11 @@ from qibolab._core.sweeper import ParallelSweepers, Parameter, Sweeper
 ORIGINAL_PLATFORMS = os.environ.get(PLATFORMS, "")
 TESTING_PLATFORM_NAMES = ["dummy"]
 """Platforms used for testing without access to real instruments."""
+
+
+@pytest.fixture(scope="module", autouse=True)
+def seed():
+    np.random.seed(42)
 
 
 def pytest_addoption(parser):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ TESTING_PLATFORM_NAMES = ["dummy"]
 """Platforms used for testing without access to real instruments."""
 
 
-@pytest.fixture(scope="module", autouse=True)
+@pytest.fixture(autouse=True)
 def seed():
     np.random.seed(42)
 

--- a/tests/instruments/emulator/test_circuits.py
+++ b/tests/instruments/emulator/test_circuits.py
@@ -10,7 +10,7 @@ def test_measurement(platform):
     circuit = Circuit(1)
     circuit.add(gates.M(0))
     result = backend.execute_circuit(circuit, nshots=1000)
-    pytest.approx(result.probabilities(), abs=5e-2) == [1, 0]
+    pytest.approx(result.samples().mean(), abs=5e-2) == 0
 
 
 def test_hadamard(platform):
@@ -19,7 +19,7 @@ def test_hadamard(platform):
     circuit.add(gates.GPI2(0, 0))
     circuit.add(gates.M(0))
     result = backend.execute_circuit(circuit, nshots=1000)
-    pytest.approx(result.probabilities(), abs=1e-1) == [0.5, 0.5]
+    pytest.approx(result.samples().mean(), abs=1e-1) == 0.5
 
 
 def test_rz(platform):
@@ -30,4 +30,4 @@ def test_rz(platform):
     circuit.add(gates.GPI2(0, np.pi / 2))
     circuit.add(gates.M(0))
     result = backend.execute_circuit(circuit, nshots=1000)
-    pytest.approx(result.probabilities(), abs=5e-2) == [0, 1]
+    pytest.approx(result.samples().mean(), abs=5e-2) == 1


### PR DESCRIPTION
Some tests recently merged #1191 are failing in [main](https://github.com/qiboteam/qibolab/actions/runs/14511704298/job/40712017967). I think that the error is caused by the fact that with the `qutrit` platform we could have a few samples outside of the computational basis, which is breaking the result object in Qibo when we are computing probabilities.
As a workaround in the tests I am just using the samples and I verify the the average value is what we should expect.

Eventually we could try to generalize the `.probabilites()` in Qibo to support also states outside the computational basis, even if it will probably be quite painful given that Qibo only support qubits.
