### PR TITLE
Support 2GSps in OPX1000

### DIFF
--- a/src/qibolab/_core/instruments/qm/config/__init__.py
+++ b/src/qibolab/_core/instruments/qm/config/__init__.py
@@ -1,5 +1,4 @@
 from .config import Configuration as Configuration
 from .devices import ControllerId as ControllerId
 from .devices import ModuleTypes as ModuleTypes
-from .pulses import SAMPLING_RATE as SAMPLING_RATE
 from .pulses import operation as operation

--- a/src/qibolab/_core/instruments/qm/config/config.py
+++ b/src/qibolab/_core/instruments/qm/config/config.py
@@ -90,8 +90,11 @@ class Configuration:
         else:
             keys = list(config.model_fields.keys())
             keys.remove("kind")
-        values = config.model_dump()
-        controller.analog_outputs[channel.port] = {k: values[k] for k in keys}
+        config_values = config.model_dump()
+        values = {k: config_values[k] for k in keys}
+        if config.sampling_rate > 1e9:
+            del values["upsampling_mode"]
+        controller.analog_outputs[channel.port] = values
         self.elements[id] = DcElement.from_channel(channel)
 
     def configure_mw_fem_line(
@@ -211,7 +214,7 @@ class Configuration:
     ):
         op = operation(pulse)
         if op not in self.pulses:
-            self.pulses[op] = self.register_waveforms(pulse, max_voltage)
+            self.pulses[op] = self.register_waveforms(pulse, sampling_rate, max_voltage)
         self.elements[element].operations[op] = op
         return op
 

--- a/src/qibolab/_core/instruments/qm/program/arguments.py
+++ b/src/qibolab/_core/instruments/qm/program/arguments.py
@@ -29,6 +29,7 @@ class Parameters:
     element: Optional[str] = None
     lo_frequency: Optional[int] = None
     max_offset: float = 0.5
+    doubled_samples: bool = False
 
 
 @dataclass

--- a/src/qibolab/_core/instruments/qm/program/instructions.py
+++ b/src/qibolab/_core/instruments/qm/program/instructions.py
@@ -24,7 +24,7 @@ def _delay(pulse: Delay, element: str, parameters: Parameters):
         duration = parameters.duration + 1
         qua.wait(duration, element)
     else:
-        duration = parameters.duration / 4
+        duration = parameters.duration / (8 if parameters.doubled_samples else 4)
         with qua.if_(duration < 4):
             qua.wait(4, element)
         with qua.else_():
@@ -131,7 +131,13 @@ def _process_sweeper(sweeper: Sweeper, args: ExecutionArguments):
 
     if parameter in INT_TYPE:
         variable = declare(int)
-        values = sweeper.values.astype(int)
+        if (
+            parameter is Parameter.duration
+            and abs(sweeper.values[1] - sweeper.values[0]) < 1
+        ):
+            values = (2 * sweeper.values).astype(int)
+        else:
+            values = sweeper.values.astype(int)
     else:
         variable = declare(fixed)
         values = sweeper.values


### PR DESCRIPTION
QM OPX1000 operates at 2GSps sampling rate (https://docs.quantum-machines.co/latest/docs/Guides/opx1000_fems/?h=samplin#low-frequency-fem-lf-fem) and this PR updates the driver to support that option, as well as playing waveforms with 0.5ns resolution. I based this on #1164 because the `sampling_rate` option was already exposed in our configs there, to avoid conflicts. I guess we could merge both PRs, even though the MW-FEM support cannot be tested, they still contain features that are useful for LF-FEMs.

Another potential issue to consider (not in this PR), is that the abstract `Controller` has a https://github.com/qiboteam/qibolab/blob/b85b9f00156deebd8535822a46ef2ca0eabf06cc/src/qibolab/_core/instruments/abstract.py#L64

property, which is not well-defined for configurations where different ports/devices can have different sampling rates. This was the case for ZI but is now the case for QM OPX1000 too.