### PR TITLE
Remove Octave declaration

### DIFF
--- a/src/qibolab/_core/instruments/qm/controller.py
+++ b/src/qibolab/_core/instruments/qm/controller.py
@@ -259,6 +259,7 @@ class QmController(Controller):
             port=int(port),
             credentials=credentials,
             cluster_name=self.cluster_name,
+            octave_calibration_db_path=self._calibration_path,
         )
 
     def disconnect(self):


### PR DESCRIPTION
Explicit Octave declaration is no longer needed when instantiating the `QuantumMachinesManager` with the latest QUA versions. Dropping it simplifies the code and it is anyway duplicating the cluster configuration. The only side-effect I noticed is that Octaves need to be named as `"oct1", "oct2"` instead of `"octave1", "octave2"`, so the platforms need to be update accordingly.