### PR TITLE
Leave QM DC offsets on after disconnecting

### DIFF
--- a/src/qibolab/_core/instruments/qm/controller.py
+++ b/src/qibolab/_core/instruments/qm/controller.py
@@ -157,6 +157,12 @@ class QmController(Controller):
     where ``fems`` are not given.
     """
 
+    close_qm: bool = False
+    """Call ``close_all_quantum_machines()`` when disconnecting.
+
+    If ``False`` the DC offsets will be left on after disconnection.
+    Default is ``False``.
+    """
     cluster_name: Optional[str] = None
     """Name of the Quantum Machines clusters to use.
 
@@ -255,7 +261,8 @@ class QmController(Controller):
         """Disconnect from QM manager."""
         self._reset_temporary_calibration()
         if self.manager is not None:
-            self.manager.close_all_quantum_machines()
+            if self.close_qm:
+                self.manager.close_all_quantum_machines()
             self.manager = None
 
     def configure_device(self, device: str):

--- a/src/qibolab/_core/instruments/qm/controller.py
+++ b/src/qibolab/_core/instruments/qm/controller.py
@@ -157,12 +157,8 @@ class QmController(Controller):
     where ``fems`` are not given.
     """
 
-    close_qm: bool = False
-    """Call ``close_all_quantum_machines()`` when disconnecting.
-
-    If ``False`` the DC offsets will be left on after disconnection.
-    Default is ``False``.
-    """
+    keep_dc_offsets_on: bool = True
+    """Keep DC offsets on after disconnecting from Quantum Machines."""
     cluster_name: Optional[str] = None
     """Name of the Quantum Machines clusters to use.
 
@@ -261,7 +257,7 @@ class QmController(Controller):
         """Disconnect from QM manager."""
         self._reset_temporary_calibration()
         if self.manager is not None:
-            if self.close_qm:
+            if not self.keep_dc_offsets_on:
                 self.manager.close_all_quantum_machines()
             self.manager = None
 

--- a/src/qibolab/_core/instruments/qm/controller.py
+++ b/src/qibolab/_core/instruments/qm/controller.py
@@ -543,11 +543,9 @@ class QmController(Controller):
 
         # register DC elements so that all qubits are
         # sweetspot even when they are not used
-        offsets = []
         for id, channel in self.channels.items():
             if isinstance(channel, DcChannel):
                 self.configure_channel(id, configs)
-                offsets.append((id, configs[id].offset))
 
         probe_map = self.configure_channels(configs, sequence.channels)
         self.register_pulses(configs, sequence)
@@ -555,7 +553,7 @@ class QmController(Controller):
 
         args = ExecutionArguments(sequence, acquisitions, options.relaxation_time)
         self.preprocess_sweeps(sweepers, configs, args, probe_map)
-        experiment = program(args, options, sweepers, offsets)
+        experiment = program(args, options, sweepers)
 
         if self.script_file_name is not None:
             script = generate_qua_script(experiment, asdict(self.config))

--- a/src/qibolab/_core/instruments/qm/program/instructions.py
+++ b/src/qibolab/_core/instruments/qm/program/instructions.py
@@ -4,7 +4,6 @@ from qm import qua
 from qm.qua import declare, fixed, for_
 
 from qibolab._core.execution_parameters import AcquisitionType, ExecutionParameters
-from qibolab._core.identifier import ChannelId
 from qibolab._core.pulses import Align, Delay, Pulse, Readout, VirtualZ
 from qibolab._core.sweeper import ParallelSweepers, Parameter, Sweeper
 
@@ -190,14 +189,9 @@ def program(
     args: ExecutionArguments,
     options: ExecutionParameters,
     sweepers: list[ParallelSweepers],
-    offsets: list[tuple[ChannelId, float]],
 ):
     """QUA program implementing the required experiment."""
     with qua.program() as experiment:
-        # FIXME: force offset setting due to a bug in QUA 1.2.1a2 and OPX1000
-        for channel_id, offset in offsets:
-            qua.set_dc_offset(channel_id, "single", offset)
-
         n = declare(int)
         # declare acquisition variables
         for acquisition in args.acquisitions.values():


### PR DESCRIPTION
We have observed that leaving the DC offsets always on leads to more stable behavior in the two-qubit gate calibration. After a discussion with the QRC lab yesterday, we decided to implement this as the default behavior.

It is still possible to define a platform that switches off the offsets after disconnecting (old behavior), using `QmController(close_qm=True)`. The default behavior will be `close_qm=False` which means offsets always on.

Draft as I would like to check how it works on hardware before merging.