### PR TITLE
Publish configs as part of official API

### DIFF
--- a/src/qibolab/_core/components/__init__.py
+++ b/src/qibolab/_core/components/__init__.py
@@ -15,9 +15,10 @@ have unique names, and in any relevant context can be referred to by
 their name.
 """
 
-from . import channels
+from . import channels, configs
 from .channels import *
 from .configs import *
 
 __all__ = []
 __all__ += channels.__all__
+__all__ += configs.__all__


### PR DESCRIPTION
I don't remember exactly which was the rationale to keep this private, but I believe it was along the line of "it is not needed, better to keep it private".

However, notice that QM configs are public
https://github.com/qiboteam/qibolab/blob/main/src/qibolab/_core/instruments/qm/components/__init__.py#L1-L5
since that is strictly needed for extending `ConfigKind`, and support serialization.

While built-in configurations are already included, and thus not explicitly required to be public, they are always used as part of `Parameters` (despite the type definition being dynamic).
Thus, it is true that the classes do not strictly need to be accessed outside Qibolab. But changing their interface would break existing `parameters.json` file. Then, it is more consistent to have them public, and document them.