### PR TITLE
Keysight software update

### DIFF
--- a/src/qibolab/_core/instruments/keysight/pulse.py
+++ b/src/qibolab/_core/instruments/keysight/pulse.py
@@ -6,7 +6,7 @@ from typing import Union
 
 from keysight import qcs
 
-from qibolab._core.pulses import Drag, Envelope, Gaussian, PulseId, Rectangular
+from qibolab._core.pulses import Envelope, PulseId
 from qibolab._core.pulses.pulse import PulseLike
 
 NS_TO_S = 1e-9
@@ -14,10 +14,10 @@ NS_TO_S = 1e-9
 
 def generate_qcs_envelope(shape: Envelope) -> qcs.Envelope:
     """Converts a Qibolab pulse envelope to a QCS Envelope object."""
-    if isinstance(shape, Rectangular):
+    if shape.kind == "rectangular":
         return qcs.ConstantEnvelope()
 
-    elif isinstance(shape, (Gaussian, Drag)):
+    elif shape.kind == "gaussian" or shape.kind == "drag":
         return qcs.GaussianEnvelope(shape.rel_sigma)
 
     else:

--- a/src/qibolab/_core/instruments/keysight/pulse.py
+++ b/src/qibolab/_core/instruments/keysight/pulse.py
@@ -6,7 +6,7 @@ from typing import Union
 
 from keysight import qcs
 
-from qibolab._core.pulses import Envelope, PulseId
+from qibolab._core.pulses import Drag, Envelope, Gaussian, PulseId, Rectangular
 from qibolab._core.pulses.pulse import PulseLike
 
 NS_TO_S = 1e-9
@@ -14,10 +14,10 @@ NS_TO_S = 1e-9
 
 def generate_qcs_envelope(shape: Envelope) -> qcs.Envelope:
     """Converts a Qibolab pulse envelope to a QCS Envelope object."""
-    if shape.kind == "rectangular":
+    if isinstance(shape, Rectangular):
         return qcs.ConstantEnvelope()
 
-    elif shape.kind == "gaussian" or shape.kind == "drag":
+    elif isinstance(shape, (Gaussian, Drag)):
         return qcs.GaussianEnvelope(shape.rel_sigma)
 
     else:

--- a/src/qibolab/_core/instruments/keysight/qcs.py
+++ b/src/qibolab/_core/instruments/keysight/qcs.py
@@ -156,14 +156,18 @@ class KeysightQCS(Controller):
 
             averaging = options.averaging_mode is not AveragingMode.SINGLESHOT
             for channel, input_ops in acquisition_map.items():
-                raw = fetch_result(
-                    results=results,
-                    channel=channel,
-                    acquisition_type=options.acquisition_type,
-                    averaging=averaging,
+                raw = next(
+                    iter(
+                        fetch_result(
+                            results=results,
+                            channel=channel,
+                            acquisition_type=options.acquisition_type,
+                            averaging=averaging,
+                        ).values()
+                    )
                 )
 
-                for result, input_op in zip(raw.values(), input_ops):
+                for result, input_op in zip(np.atleast_2d(raw.T), input_ops):
                     ret[input_op.id] = parse_result(result, options)
 
         return ret

--- a/src/qibolab/_core/instruments/keysight/results.py
+++ b/src/qibolab/_core/instruments/keysight/results.py
@@ -31,9 +31,9 @@ def fetch_result(
     if acquisition_type is AcquisitionType.RAW:
         raw = results.get_trace(channel, averaging)
     elif acquisition_type is AcquisitionType.INTEGRATION:
-        raw = results.get_iq(channel, averaging)
+        raw = results.get_iq(channel, averaging, acq_index=None)
     elif acquisition_type is AcquisitionType.DISCRIMINATION:
-        raw = results.get_classified(channel, averaging)
+        raw = results.get_classified(channel, averaging, acq_index=None)
     else:
         raise ValueError("Acquisition type unrecognized")
     return raw


### PR DESCRIPTION
To support new features from `keysight-qcs` version 2.5.4 update

- Up to 8 nested hardware sweepers can be used before switching to software sweeping
- Delay duration can now be swept in hardware
- Multiple measurements can now be done on a single channel (though this is not supported in Qibo yet)

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
