### PR TITLE
Qblox: Fix single shot routine for iqm5q

### DIFF
--- a/src/qibolab/_core/instruments/qblox/q1asm/ast_.py
+++ b/src/qibolab/_core/instruments/qblox/q1asm/ast_.py
@@ -737,6 +737,11 @@ class Line(Model):
         """Shortcut for simple lines instantiation."""
         return cls(instruction=instruction)
 
+    def update(self, update: dict[str, Any]) -> "Line":
+        """Update parameters in the underlying instructions keeping the same comments."""
+        new_instr = self.instruction.model_copy(update=update)
+        return self.model_copy(update={"instruction": new_instr})
+
     def asm(
         self,
         width: Optional[int] = None,

--- a/src/qibolab/_core/instruments/qblox/sequence/experiment.py
+++ b/src/qibolab/_core/instruments/qblox/sequence/experiment.py
@@ -21,6 +21,7 @@ from ..q1asm.ast_ import (
     Register,
     SetPhDelta,
     Wait,
+    WaitSync,
 )
 from .acquisition import AcquisitionSpec, MeasureId
 from .asm import Registers, convert
@@ -39,13 +40,19 @@ __all__ = []
 PHASE_FACTOR = 1e9 / (2 * np.pi)
 
 
-def play_pulse(pulse: Pulse, waveforms: WaveformIndices) -> Line:
+def play_pulse(
+    pulse: Pulse, waveforms: WaveformIndices, duration: Optional[int] = None
+) -> Line:
     uid = pulse.id
     w0 = waveforms[(uid, 0)]
     w1 = waveforms[(uid, 1)]
     assert w0[1] == w1[1]
     return Line(
-        instruction=Play(wave_0=w0[0], wave_1=w1[0], duration=w0[1]),
+        instruction=Play(
+            wave_0=w0[0],
+            wave_1=w1[0],
+            duration=w0[1] if duration is None else duration,
+        ),
         comment=f"id: 0x{uid.hex[:5]}",
     )
 
@@ -117,11 +124,11 @@ def play(
         acq = acquisitions[pulse.id]
         delay = int(time_of_flight) if time_of_flight is not None else 4
         return [
-            play_pulse(pulse.probe, waveforms).model_copy(update={"duration": delay}),
+            play_pulse(pulse.probe, waveforms, duration=delay),
             Acquire(
                 acquisition=acq.acquisition.index,
                 bin=Registers.bin.value,
-                duration=int(pulse.duration) - delay,
+                duration=int(pulse.duration),
             ),
         ]
     raise NotImplementedError(f"Instruction {type(pulse)} unsupported by Qblox driver.")
@@ -152,7 +159,7 @@ def experiment(
     time_of_flight: Optional[float],
 ) -> Block:
     """Representation of the actual experiment to be executed."""
-    return [
+    return [WaitSync(duration=4)] + [
         inst
         for block in (
             event(pulse, waveforms, acquisitions, time_of_flight) for pulse in sequence

--- a/src/qibolab/_core/instruments/qblox/sequence/experiment.py
+++ b/src/qibolab/_core/instruments/qblox/sequence/experiment.py
@@ -40,19 +40,13 @@ __all__ = []
 PHASE_FACTOR = 1e9 / (2 * np.pi)
 
 
-def play_pulse(
-    pulse: Pulse, waveforms: WaveformIndices, duration: Optional[int] = None
-) -> Line:
+def play_pulse(pulse: Pulse, waveforms: WaveformIndices) -> Line:
     uid = pulse.id
     w0 = waveforms[(uid, 0)]
     w1 = waveforms[(uid, 1)]
     assert w0[1] == w1[1]
     return Line(
-        instruction=Play(
-            wave_0=w0[0],
-            wave_1=w1[0],
-            duration=w0[1] if duration is None else duration,
-        ),
+        instruction=Play(wave_0=w0[0], wave_1=w1[0], duration=w0[1]),
         comment=f"id: 0x{uid.hex[:5]}",
     )
 
@@ -124,7 +118,7 @@ def play(
         acq = acquisitions[pulse.id]
         delay = int(time_of_flight) if time_of_flight is not None else 4
         return [
-            play_pulse(pulse.probe, waveforms, duration=delay),
+            play_pulse(pulse.probe, waveforms).update({"duration": delay}),
             Acquire(
                 acquisition=acq.acquisition.index,
                 bin=Registers.bin.value,

--- a/src/qibolab/_core/instruments/qblox/sequence/loops.py
+++ b/src/qibolab/_core/instruments/qblox/sequence/loops.py
@@ -151,7 +151,7 @@ def _sweep_update(p: Param, channel: set[ChannelId], pulses: set[PulseId]) -> Bl
                     comment=f"shift {p.description}",
                 ),
             )
-            if p.channel == channel or p.pulse in pulses
+            if p.channel in channel or p.pulse in pulses
             else ()
         ),
         *(update_instructions(p.role, p.reg) if p.channel in channel else ()),

--- a/src/qibolab/_core/instruments/qblox/sequence/program.py
+++ b/src/qibolab/_core/instruments/qblox/sequence/program.py
@@ -14,7 +14,6 @@ from ..q1asm.ast_ import (
     Program,
     Stop,
     Wait,
-    WaitSync,
 )
 from .acquisition import AcquisitionSpec, MeasureId
 from .experiment import experiment
@@ -76,7 +75,6 @@ def setup(
             if p.channel in channel
             for inst in update_instructions(p.role, p.start)
         ]
-        + [WaitSync(duration=4)]
     )
 
 


### PR DESCRIPTION
These fixes were found by comparing the generated q1asm program with the corresponding from 0.1. Now the single shot classification results on iqm5q match with 0.1 for the same parameters:
* 0.1: http://login.qrccluster.com:9000/fE-On1s1S0ujOvYFsxSXNg==
* 0.2 (using this fix): http://login.qrccluster.com:9000/Mx4HWZUSQgaVEtmArGjQ1w==

I have not tested other routines.