### PR TITLE
Driver for SPI rack S4g modules

### DIFF
--- a/src/qibolab/_core/instruments/spi.py
+++ b/src/qibolab/_core/instruments/spi.py
@@ -93,5 +93,4 @@ class Spi(Instrument):
         """
         for channel_name, config in configs.items():
             module, dac = channel_to_dac(self.channels[channel_name])
-            if module in self.modules:
-                self.modules[module].set_current(dac, config.offset)
+            self.modules[module].set_current(dac, config.offset)

--- a/src/qibolab/_core/instruments/spi.py
+++ b/src/qibolab/_core/instruments/spi.py
@@ -1,0 +1,97 @@
+from typing import Optional
+
+from pydantic import Field
+from spirack import S4g_module, SPI_rack
+
+from ..components import DcChannel, DcConfig
+from ..identifier import ChannelId
+from ..parameters import ComponentId
+from ..serialize import Model
+from .abstract import Instrument
+
+__all__ = ["Spi"]
+
+
+def channel_to_dac(channel: DcChannel) -> tuple[int, int]:
+    """Read module and DAC numbers from channel object.
+
+    Assumes that ``channel.path`` has the following format:
+    ``{module_number}/{dac_number}``
+    """
+    module, dac = channel.path.split("/")
+    return int(module), int(dac)
+
+
+class S4g(Model):
+    """Driver for S4g modules of the SPI rack.
+
+    Uses https://qtwork.tudelft.nl/~mtiggelman/modules/i-source/s4g.html
+    """
+
+    module: Optional[S4g_module] = None
+    currents: dict[int, float] = Field(default_factory=dict)
+    """Currents cache on software (maintained even when we are not connected to the actual device)."""
+
+    def connect(self, spi: SPI_rack, number: int, reset_currents: bool = False):
+        if self.module is None:
+            self.module = S4g_module(spi, number, reset_currents=reset_currents)
+        self.upload()
+
+    def upload(self):
+        """Upload currents from our cache to the instrument."""
+        for dac, current in self.currents.items():
+            self.set_current(self.module, dac, current)
+
+    def set_current(self, dac: int, current: float):
+        """Update current value in cache and, if connected, upload to the instrument."""
+        self.currents[dac] = current
+        if self.module is not None:
+            self.module.set_current(dac, current)
+
+
+class Spi(Instrument):
+    """Driver for SPI rack.
+
+    Uses https://qtwork.tudelft.nl/~mtiggelman/spi-rack.html
+
+    Currently only supports S4g modules.
+    """
+
+    channels: dict[ChannelId, DcChannel] = Field(default_factory=dict)
+    close_currents: bool = False
+    baud: int = 9600
+    timeout: int = 1
+    modules: dict[int, S4g_module] = Field(default_factory=dict)
+
+    def __post_init__(self):
+        self.modules = {
+            i: S4g() for i in {channel_to_dac(ch)[0] for ch in self.channels.values()}
+        }
+
+    def connect(self):
+        """Connect to the instrument."""
+        spi = SPI_rack(port=self.address, baud=self.baud, timeout=self.timeout)
+        spi.unlock()
+        for nr, module in self.modules.items():
+            module.connect(spi, nr)
+
+    def disconnect(self):
+        if self.close_currents:
+            for module in self.modules.values():
+                for dac in module.currents:
+                    module.set_current(dac, 0)
+
+    def channel_module(self, channel_name: ChannelId) -> Optional[S4g_module]:
+        """Get ``spirack.S4g_module`` used on a particular channel."""
+        return self.modules[channel_to_dac(self.channels[channel_name])[0]].module
+
+    def setup(self, configs: dict[ComponentId, DcConfig]):
+        """Update currents based on channel configs.
+
+        If the instrument is connected the value is automatically uploaded to the instrument.
+        Otherwise the value is cached and will be uploaded when connection is established.
+        """
+        for channel_name, config in configs.items():
+            module, dac = channel_to_dac(self.channels[channel_name])
+            if module in self.modules:
+                self.modules[module].set_current(dac, config.offset)

--- a/src/qibolab/_core/platform/platform.py
+++ b/src/qibolab/_core/platform/platform.py
@@ -12,6 +12,7 @@ from ..execution_parameters import ExecutionParameters
 from ..identifier import ChannelId, QubitId, QubitPairId, Result
 from ..instruments.abstract import Controller
 from ..parameters import (
+    ComponentId,
     InstrumentMap,
     NativeGates,
     Parameters,
@@ -43,6 +44,13 @@ def _unique_acquisitions(sequences: list[PulseSequence]) -> bool:
         ids += (p.id for _, p in seq.acquisitions)
 
     return len(ids) == len(set(ids))
+
+
+def _filter_configs(
+    channels: dict[ChannelId, Channel], configs: dict[ComponentId, Config]
+) -> dict[ComponentId, Config]:
+    """Filter configs corresponding to a particular set of channels."""
+    return {ch: configs[ch] for ch in channels.keys() & configs.keys()}
 
 
 @dataclass
@@ -197,7 +205,12 @@ class Platform:
 
         for instrument in self.instruments.values():
             if isinstance(instrument, Controller):
-                new_result = instrument.play(configs, sequences, options, sweepers)
+                new_result = instrument.play(
+                    _filter_configs(instrument.channels, configs),
+                    sequences,
+                    options,
+                    sweepers,
+                )
                 if isinstance(new_result, dict):
                     result.update(new_result)
 
@@ -259,9 +272,7 @@ class Platform:
                 if name in configs:
                     instrument.setup(**configs[name].model_dump(exclude={"kind"}))
                 if hasattr(instrument, "channels"):
-                    instrument.setup(
-                        {ch: configs[ch] for ch in instrument.channels if ch in configs}
-                    )
+                    instrument.setup(_filter_configs(instrument.channels, configs))
 
         results = {}
         # pylint: disable=unsubscriptable-object

--- a/src/qibolab/_core/platform/platform.py
+++ b/src/qibolab/_core/platform/platform.py
@@ -254,9 +254,14 @@ class Platform:
 
         # for components that represent aux external instruments (e.g. lo) to the main
         # control instrument set the config directly
-        for name, cfg in configs.items():
-            if name in self.instruments:
-                self.instruments[name].setup(**cfg.model_dump(exclude={"kind"}))
+        for name, instrument in self.instruments.items():
+            if not isinstance(instrument, Controller):
+                if name in configs:
+                    instrument.setup(**configs[name].model_dump(exclude={"kind"}))
+                if hasattr(instrument, "channels"):
+                    instrument.setup(
+                        {ch: configs[ch] for ch in instrument.channels if ch in configs}
+                    )
 
         results = {}
         # pylint: disable=unsubscriptable-object

--- a/src/qibolab/_core/qubits.py
+++ b/src/qibolab/_core/qubits.py
@@ -33,6 +33,8 @@ class Qubit(Model):
     """Output channel, to probe the resonator."""
     acquisition: DefaultChannelType = None
     """Input channel, to acquire the readout results."""
+    dc_flux: Annotated[Optional[ChannelId], False] = None
+    """Output channel, to bias the qubit using a DC current source."""
 
     @property
     def channels(self) -> list[ChannelId]:

--- a/src/qibolab/instruments/spi.py
+++ b/src/qibolab/instruments/spi.py
@@ -1,0 +1,10 @@
+"""SPI rack drivers.
+
+https://qtwork.tudelft.nl/~mtiggelman/
+"""
+
+from qibolab._core.instruments import spi
+from qibolab._core.instruments.spi import *  # noqa: F403
+
+__all__ = []
+__all__ += spi.__all__


### PR DESCRIPTION
TODO:
* [x] Write a platform and test.
* [ ] Add `spirack` dependency (to appropriate `qibolab-*` repo)

There is an annoying assymetry, because `Spi.setup` now accepts a `configs: dict`, while `LocalOscillator.setup` was behaving differently. This also required a minor change in the `Platform.execute` to make sure the corresponding `configs` are properly uploaded to both types of instruments. Maybe there is a way to converge, either by sticking to the LO approach or changing to the new one. However, if we are only interested in a working version we could even merge as it is (after testing) and postpone the code improvements for later.

Current usage in `platform.py` should be the following:
```py
def create():
    ...
    spi_channels = {
        "0/dc_flux": DcChannel(device="spi", path="1/1")
        "1/dc_flux": DcChannel(device="spi", path="1/2")
        "2/dc_flux": DcChannel(device="spi", path="2/1")
    }
    instruments = {
        ...,
        Spi(address="/dev/ttyACM0", channels=spi_channels)
    }
```
and the parameters (current) for each SPI channel is provided as the `offset` of the corresponding `DcConfig` in parameters.json.

Note that each qubit will have both the previous flux channels connected to the controller (QM/Qblox/etc.) and the new channels connected to the SPI combined using a bias tee. Usually this will block the DC (offset) from the controller (not fully), so the controller will only be used to play flux pulses (for two-qubit gates, etc.) and the biasing will come fully from the SPI. We may also want to adjust the `Qubit` object to add the new channel, even though as usual this is just for Qibocal (and usage) simplification and is not strictly necessary.