### PR TITLE
Qblox fixes for running circuits

### DIFF
--- a/src/qibolab/_core/instruments/qblox/config/sequencer.py
+++ b/src/qibolab/_core/instruments/qblox/config/sequencer.py
@@ -112,7 +112,7 @@ class SequencerConfig(Model):
             if config.iq_angle is not None:
                 cfg.thresholded_acq_rotation = np.degrees(config.iq_angle % (2 * np.pi))
             if config.threshold is not None:
-                cfg.thresholded_acq_threshold = config.threshold
+                cfg.thresholded_acq_threshold = config.threshold * length
             # demodulation
             cfg.demod_en_acq = acquisition is not AcquisitionType.RAW
 

--- a/src/qibolab/_core/instruments/qblox/config/sequencer.py
+++ b/src/qibolab/_core/instruments/qblox/config/sequencer.py
@@ -112,6 +112,8 @@ class SequencerConfig(Model):
             if config.iq_angle is not None:
                 cfg.thresholded_acq_rotation = np.degrees(config.iq_angle % (2 * np.pi))
             if config.threshold is not None:
+                # threshold needs to be compensated by length
+                # see: https://docs.qblox.com/en/main/api_reference/sequencer.html#Sequencer.thresholded_acq_threshold
                 cfg.thresholded_acq_threshold = config.threshold * length
             # demodulation
             cfg.demod_en_acq = acquisition is not AcquisitionType.RAW

--- a/src/qibolab/_core/instruments/qblox/results.py
+++ b/src/qibolab/_core/instruments/qblox/results.py
@@ -100,7 +100,7 @@ def _scope(data: ScopeData) -> Result:
 
 
 def _classification(data: Thresholded) -> Result:
-    return np.array(data)
+    return np.array(data, dtype=int)
 
 
 def extract(

--- a/src/qibolab/_core/instruments/qblox/sequence/asm.py
+++ b/src/qibolab/_core/instruments/qblox/sequence/asm.py
@@ -50,7 +50,7 @@ def convert(value: float, kind: Parameter) -> float:
     if kind is Parameter.amplitude:
         return value * MAX_PARAM[kind]
     if kind is Parameter.relative_phase:
-        return (value / (2 * np.pi)) % 1.0 * MAX_PARAM[kind]
+        return ((value % (2 * np.pi)) / (2 * np.pi)) % 1.0 * MAX_PARAM[kind]
     if kind is Parameter.frequency:
         return value / 500e6 * MAX_PARAM[kind]
     if kind is Parameter.offset:

--- a/src/qibolab/_core/instruments/qblox/sequence/experiment.py
+++ b/src/qibolab/_core/instruments/qblox/sequence/experiment.py
@@ -74,6 +74,7 @@ def play(
 
     if isinstance(pulse, Pulse):
         phase = int(convert(pulse.relative_phase, Parameter.relative_phase))
+        minus_phase = int(convert(-pulse.relative_phase, Parameter.relative_phase))
         duration_sweep = {
             p.role: p.reg for p in params if p.role.value[1] is Parameter.duration
         }
@@ -84,7 +85,7 @@ def play(
                 if len(duration_sweep) == 0
                 else play_duration_swept(duration_sweep)
             )
-            + ([SetPhDelta(value=-phase)] if phase != 0 else [])
+            + ([SetPhDelta(value=minus_phase)] if phase != 0 else [])
         )
     if isinstance(pulse, Delay):
         return [

--- a/src/qibolab/_core/instruments/qblox/sequence/experiment.py
+++ b/src/qibolab/_core/instruments/qblox/sequence/experiment.py
@@ -20,6 +20,7 @@ from ..q1asm.ast_ import (
     Play,
     Register,
     SetPhDelta,
+    UpdParam,
     Wait,
     WaitSync,
 )
@@ -85,7 +86,11 @@ def play(
                 if len(duration_sweep) == 0
                 else play_duration_swept(duration_sweep)
             )
-            + ([SetPhDelta(value=minus_phase)] if phase != 0 else [])
+            + (
+                [SetPhDelta(value=minus_phase), UpdParam(duration=4)]
+                if phase != 0
+                else []
+            )
         )
     if isinstance(pulse, Delay):
         return [
@@ -102,7 +107,8 @@ def play(
                 value=int(pulse.phase * PHASE_FACTOR)
                 if len(params) == 0
                 else next(iter(params)).reg
-            )
+            ),
+            UpdParam(duration=4),
         ]
     if isinstance(pulse, Acquisition):
         acq = acquisitions[pulse.id]


### PR DESCRIPTION
Fixes the following three issues observed when trying to execute circuits on Qblox:

1. b191950: q1asm error from `set_ph_delta` being used with negative values when trying to execute any gate.
2. 1221a1d: classified (thresholded) results being inaccurate (cherry-picked from #1252)
3. 34e119f: `.frequencies()` calculation from qibo failing.

I have not confirmed the fixes work on hardware (verifying the actual results), however they fix the errors when running on a qblox cluster not connected to QPU (particularly the `qblox-test` from https://github.com/qiboteam/qibolab_platforms_qrc/pull/196).