### PR TITLE
Fix amplitude sweeper for `Readout` in QM

### DIFF
--- a/src/qibolab/_core/sweeper.py
+++ b/src/qibolab/_core/sweeper.py
@@ -91,6 +91,8 @@ class Sweeper(Model):
     def check_values(self):
         _alternative_fields((self.pulses, "pulses"), (self.channels, "channels"))
 
+        if self.values is None and self.range is None:
+            raise ValueError("Cannot create a sweeper without values or range.")
         if self.pulses is not None and self.parameter in Parameter.channels():
             raise ValueError(
                 f"Cannot create a sweeper for {self.parameter} without specifying channels."

--- a/src/qibolab/_core/sweeper.py
+++ b/src/qibolab/_core/sweeper.py
@@ -90,7 +90,6 @@ class Sweeper(Model):
     @model_validator(mode="after")
     def check_values(self):
         _alternative_fields((self.pulses, "pulses"), (self.channels, "channels"))
-        _alternative_fields((self.range, "range"), (self.values, "values"))
 
         if self.pulses is not None and self.parameter in Parameter.channels():
             raise ValueError(

--- a/tests/test_sweeper.py
+++ b/tests/test_sweeper.py
@@ -61,13 +61,6 @@ def test_sweeper_errors():
     with pytest.raises(ValueError, match="(?=.*range)(?=.*values)"):
         Sweeper(
             parameter=Parameter.frequency,
-            values=parameter_range,
-            range=(0, 10, 1),
-            channels=[channel],
-        )
-    with pytest.raises(ValueError, match="(?=.*range)(?=.*values)"):
-        Sweeper(
-            parameter=Parameter.frequency,
             channels=[channel],
         )
     with pytest.raises(ValueError, match="Amplitude"):


### PR DESCRIPTION
Fixes the issue with the punchout routine reported in https://github.com/qiboteam/qibolab/issues/1272. 

For the absolute sweeper to work in an "absolute fashion" we need to register a sweeper with adjusted amplitude in the QM config. The problem was that this adjusted was implemented properly for `Pulse` objects, but not for `Readout` objects (needed for the punchout).