### PR TITLE
Compile virtual z rotations into relative phases

### DIFF
--- a/src/qibolab/_core/sequence.py
+++ b/src/qibolab/_core/sequence.py
@@ -313,6 +313,12 @@ class PulseSequence(UserList[_Element]):
         return seq
 
     def collect_vzs(self) -> "PulseSequence":
+        """Collect subsequent :class:`VirtualZ` rotations.
+
+        For each channel, it divides :class:`VirtualZ` in groups delimited by pulses.
+        Each group is collected and transformed in a single :class:`VirtualZ`, just summing
+        the angles.
+        """
         seq = PulseSequence()
         phases = defaultdict(float)
 


### PR DESCRIPTION
Actually, both the directions are included.

- [ ] sum virtual Zs to reduce the amount of operations
- [ ] improve docs (with proper references)
- [ ] add emulator-independent tests
    - better to keep tests as minimal as possible - otherwise issues in one part of the code may easily propagate
    - we could also have soon a cyclic dependency problem (cf. #1257)

> [!WARNING]
> Phases should be relevant only for drive channels.
>
> However, here only `Pulse`s are taken into account, explicitly. So, `Pulse`s wrapped in `Readout`s operations are neglected. Which should not be a source of problems, since they are supposed to be placed on `"acquisition"` channels, and not to account for phases.
>
> *It is still possible to account for that, by using the `"probe"` separately from the `"acquisition"` channel - in which case they will be unwrapped `Pulse`s.*