### PR TITLE
Match integration length to acquisition duration

### DIFF
--- a/src/qibolab/_core/instruments/qblox/config/sequencer.py
+++ b/src/qibolab/_core/instruments/qblox/config/sequencer.py
@@ -18,6 +18,7 @@ from qibolab._core.execution_parameters import AcquisitionType
 from qibolab._core.identifier import ChannelId
 from qibolab._core.serialize import Model
 
+from ..q1asm.ast_ import Acquire, Line
 from ..sequence import Q1Sequence
 from .port import PortAddress
 
@@ -26,7 +27,12 @@ __all__ = []
 
 def _integration_length(sequence: Q1Sequence) -> Optional[int]:
     """Find integration length based on sequence waveform lengths."""
-    lengths = {len(waveform.data) for waveform in sequence.waveforms.values()}
+    lengths = {
+        line.instruction.duration
+        for line in sequence.program.elements
+        if isinstance(line, Line)
+        if isinstance(line.instruction, Acquire)
+    }
     if len(lengths) == 0:
         return None
     if len(lengths) == 1:


### PR DESCRIPTION
Currently we are using the length of the probe waveform as the integration length, however this does not work well when the acquisition duration is significanly different than the probe duration. This modifies it to use the acquisition duration.

Here is an example from qw5q_platinum, where the probe duration is 300ns and the acquisition duration is 1200ns:
* before fix: http://login.qrccluster.com:9000/b5NGSyqVR_eNu3AVLwslvw==
* after fix: http://login.qrccluster.com:9000/1IS9bqNiThmAtdK37eo5WA==

