### PR TITLE
Compile virtual z rotations into relative phases

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -50,7 +50,9 @@ extensions = [
     "sphinx.ext.todo",
     "sphinx.ext.viewcode",
     "sphinx_design",
+    "sphinxcontrib.bibtex",
 ]
+bibtex_bibfiles = ["refs.bib"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -88,6 +88,7 @@ Contents
     :maxdepth: 2
     :caption: Appendix
 
+    refrences
     Publications <https://qibo.science/qibo/stable/appendix/citing-qibo.html>
 
 .. toctree::

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -88,7 +88,7 @@ Contents
     :maxdepth: 2
     :caption: Appendix
 
-    refrences
+    references
     Publications <https://qibo.science/qibo/stable/appendix/citing-qibo.html>
 
 .. toctree::

--- a/doc/source/references.rst
+++ b/doc/source/references.rst
@@ -1,0 +1,8 @@
+References
+==========
+
+In this page we collect the references used.
+
+
+.. bibliography::
+   :style: plain

--- a/doc/source/refs.bib
+++ b/doc/source/refs.bib
@@ -1,0 +1,8 @@
+@book{Manenti:2023zzn,
+  author = "Manenti, Riccardo and Motta, Mario",
+  title = "{Quantum Information Science}",
+  isbn = "978-0-19-878748-8",
+  publisher = "Oxford University Press",
+  month = "8",
+  year = "2023",
+}

--- a/flake.lock
+++ b/flake.lock
@@ -6,19 +6,24 @@
           "devenv"
         ],
         "flake-compat": [
-          "devenv"
+          "devenv",
+          "flake-compat"
         ],
         "git-hooks": [
-          "devenv"
+          "devenv",
+          "git-hooks"
         ],
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1744206633,
-        "narHash": "sha256-pb5aYkE8FOoa4n123slgHiOf1UbNSnKe5pEZC+xXD5g=",
+        "lastModified": 1777487137,
+        "narHash": "sha256-TuvKVBX60mqyMT6OB5JqVEh1YIWtFMR/igLCaCdC9tw=",
         "owner": "cachix",
         "repo": "cachix",
-        "rev": "8a60090640b96f9df95d1ab99e5763a586be1404",
+        "rev": "a66a440c321d35f7193472c317f42a55ccd1cb93",
         "type": "github"
       },
       "original": {
@@ -28,38 +33,233 @@
         "type": "github"
       }
     },
+    "cachix_2": {
+      "inputs": {
+        "devenv": [
+          "devenv",
+          "crate2nix"
+        ],
+        "flake-compat": [
+          "devenv",
+          "crate2nix"
+        ],
+        "git-hooks": "git-hooks",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1767714506,
+        "narHash": "sha256-WaTs0t1CxhgxbIuvQ97OFhDTVUGd1HA+KzLZUZBhe0s=",
+        "owner": "cachix",
+        "repo": "cachix",
+        "rev": "894c649f0daaa38bbcfb21de64be47dfa7cd0ec9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "latest",
+        "repo": "cachix",
+        "type": "github"
+      }
+    },
+    "cachix_3": {
+      "inputs": {
+        "devenv": [
+          "devenv",
+          "crate2nix",
+          "crate2nix_stable"
+        ],
+        "flake-compat": [
+          "devenv",
+          "crate2nix",
+          "crate2nix_stable"
+        ],
+        "git-hooks": "git-hooks_2",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1767714506,
+        "narHash": "sha256-WaTs0t1CxhgxbIuvQ97OFhDTVUGd1HA+KzLZUZBhe0s=",
+        "owner": "cachix",
+        "repo": "cachix",
+        "rev": "894c649f0daaa38bbcfb21de64be47dfa7cd0ec9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "latest",
+        "repo": "cachix",
+        "type": "github"
+      }
+    },
+    "crate2nix": {
+      "inputs": {
+        "cachix": "cachix_2",
+        "crate2nix_stable": "crate2nix_stable",
+        "devshell": "devshell_2",
+        "flake-compat": "flake-compat_2",
+        "flake-parts": "flake-parts_2",
+        "nix-test-runner": "nix-test-runner_2",
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ],
+        "pre-commit-hooks": "pre-commit-hooks_2"
+      },
+      "locked": {
+        "lastModified": 1772186516,
+        "narHash": "sha256-8s28pzmQ6TOIUzznwFibtW1CMieMUl1rYJIxoQYor58=",
+        "owner": "rossng",
+        "repo": "crate2nix",
+        "rev": "ba5dd398e31ee422fbe021767eb83b0650303a6e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rossng",
+        "repo": "crate2nix",
+        "rev": "ba5dd398e31ee422fbe021767eb83b0650303a6e",
+        "type": "github"
+      }
+    },
+    "crate2nix_stable": {
+      "inputs": {
+        "cachix": "cachix_3",
+        "crate2nix_stable": [
+          "devenv",
+          "crate2nix",
+          "crate2nix_stable"
+        ],
+        "devshell": "devshell",
+        "flake-compat": "flake-compat",
+        "flake-parts": "flake-parts",
+        "nix-test-runner": "nix-test-runner",
+        "nixpkgs": "nixpkgs_3",
+        "pre-commit-hooks": "pre-commit-hooks"
+      },
+      "locked": {
+        "lastModified": 1769627083,
+        "narHash": "sha256-SUuruvw1/moNzCZosHaa60QMTL+L9huWdsCBN6XZIic=",
+        "owner": "nix-community",
+        "repo": "crate2nix",
+        "rev": "7c33e664668faecf7655fa53861d7a80c9e464a2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "0.15.0",
+        "repo": "crate2nix",
+        "type": "github"
+      }
+    },
     "devenv": {
       "inputs": {
         "cachix": "cachix",
-        "flake-compat": "flake-compat",
-        "git-hooks": "git-hooks",
+        "crate2nix": "crate2nix",
+        "flake-compat": "flake-compat_3",
+        "flake-parts": "flake-parts_3",
+        "ghostty": "ghostty",
+        "git-hooks": "git-hooks_3",
         "nix": "nix",
+        "nixd": "nixd",
         "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1777911862,
+        "narHash": "sha256-Vi3Zpj4M9hRhsOhMvbZMaYr0LC0NvG2cekJMrpaChGo=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "5297dd928c090440d90b9277d5113847b1edef19",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "devshell": {
+      "inputs": {
+        "nixpkgs": [
+          "devenv",
+          "crate2nix",
+          "crate2nix_stable",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1749202057,
-        "narHash": "sha256-KLR5kv+bXjyBayFBs2RyDsmCiiCC1S7c0fSc/LrWUdw=",
-        "owner": "cachix",
-        "repo": "devenv",
-        "rev": "1c28c31f09f8a5ab134e1943b29b9d2f302cfbcd",
+        "lastModified": 1768818222,
+        "narHash": "sha256-460jc0+CZfyaO8+w8JNtlClB2n4ui1RbHfPTLkpwhU8=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "255a2b1725a20d060f566e4755dbf571bbbb5f76",
         "type": "github"
       },
       "original": {
-        "owner": "cachix",
-        "repo": "devenv",
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "devshell_2": {
+      "inputs": {
+        "nixpkgs": [
+          "devenv",
+          "crate2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1768818222,
+        "narHash": "sha256-460jc0+CZfyaO8+w8JNtlClB2n4ui1RbHfPTLkpwhU8=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "255a2b1725a20d060f566e4755dbf571bbbb5f76",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
         "type": "github"
       }
     },
     "flake-compat": {
-      "flake": false,
       "locked": {
         "lastModified": 1733328505,
         "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "revCount": 69,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.1.0/01948eb7-9cba-704f-bbf3-3fa956735b52/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz"
+      }
+    },
+    "flake-compat_2": {
+      "locked": {
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "revCount": 69,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.1.0/01948eb7-9cba-704f-bbf3-3fa956735b52/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz"
+      }
+    },
+    "flake-compat_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
         "type": "github"
       },
       "original": {
@@ -68,14 +268,30 @@
         "type": "github"
       }
     },
-    "flake-compat_2": {
+    "flake-compat_4": {
       "flake": false,
       "locked": {
-        "lastModified": 1733328505,
-        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "lastModified": 1761588595,
+        "narHash": "sha256-XKUZz9zewJNUj46b4AJdiRZJAvSZ0Dqj2BNfXvFlJC4=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "rev": "f387cd2afec9419c8ee37694406ca490c3f34ee5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
         "type": "github"
       },
       "original": {
@@ -88,16 +304,17 @@
       "inputs": {
         "nixpkgs-lib": [
           "devenv",
-          "nix",
+          "crate2nix",
+          "crate2nix_stable",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1712014858,
-        "narHash": "sha256-sB4SWl2lX95bExY2gMFG5HIzvva5AVMJd4Igm+GpZNw=",
+        "lastModified": 1768135262,
+        "narHash": "sha256-PVvu7OqHBGWN16zSi6tEmPwwHQ4rLPU9Plvs8/1TUBY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9126214d0a59633752a136528f5f3b9aa8565b7d",
+        "rev": "80daad04eddbbf5a4d883996a73f3f542fa437ac",
         "type": "github"
       },
       "original": {
@@ -106,23 +323,152 @@
         "type": "github"
       }
     },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "devenv",
+          "crate2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1768135262,
+        "narHash": "sha256-PVvu7OqHBGWN16zSi6tEmPwwHQ4rLPU9Plvs8/1TUBY=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "80daad04eddbbf5a4d883996a73f3f542fa437ac",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_3": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "devenv",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777678872,
+        "narHash": "sha256-EPIFsulyon7Z1vLQq5Fk64GR8L7cQsT+IPhcsukVbgk=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "5250617bffd85403b14dbf43c3870e7f255d2c16",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "ghostty": {
+      "inputs": {
+        "flake-compat": "flake-compat_4",
+        "home-manager": "home-manager",
+        "nixpkgs": "nixpkgs_4",
+        "systems": "systems",
+        "zig": "zig",
+        "zon2nix": "zon2nix"
+      },
+      "locked": {
+        "lastModified": 1777773742,
+        "narHash": "sha256-dZFc+8az7BUIs8+v45XqNnY5G6oXEwVfVVHZQuATSGQ=",
+        "owner": "ghostty-org",
+        "repo": "ghostty",
+        "rev": "1547dd667ab6d1f4ebcdc7282adc54c95752ee67",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ghostty-org",
+        "repo": "ghostty",
+        "type": "github"
+      }
+    },
     "git-hooks": {
       "inputs": {
         "flake-compat": [
-          "devenv"
+          "devenv",
+          "crate2nix",
+          "cachix",
+          "flake-compat"
         ],
         "gitignore": "gitignore",
+        "nixpkgs": [
+          "devenv",
+          "crate2nix",
+          "cachix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1765404074,
+        "narHash": "sha256-+ZDU2d+vzWkEJiqprvV5PR26DVFN2vgddwG5SnPZcUM=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "2d6f58930fbcd82f6f9fd59fb6d13e37684ca529",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "git-hooks_2": {
+      "inputs": {
+        "flake-compat": [
+          "devenv",
+          "crate2nix",
+          "crate2nix_stable",
+          "cachix",
+          "flake-compat"
+        ],
+        "gitignore": "gitignore_2",
+        "nixpkgs": [
+          "devenv",
+          "crate2nix",
+          "crate2nix_stable",
+          "cachix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1765404074,
+        "narHash": "sha256-+ZDU2d+vzWkEJiqprvV5PR26DVFN2vgddwG5SnPZcUM=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "2d6f58930fbcd82f6f9fd59fb6d13e37684ca529",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "git-hooks_3": {
+      "inputs": {
+        "flake-compat": [
+          "devenv",
+          "flake-compat"
+        ],
+        "gitignore": "gitignore_5",
         "nixpkgs": [
           "devenv",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1746537231,
-        "narHash": "sha256-Wb2xeSyOsCoTCTj7LOoD6cdKLEROyFAArnYoS+noCWo=",
+        "lastModified": 1776796298,
+        "narHash": "sha256-PcRvlWayisPSjd0UcRQbhG8Oqw78AcPE6x872cPRHN8=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "fa466640195d38ec97cf0493d6d6882bc4d14969",
+        "rev": "3cfd774b0a530725a077e17354fbdb87ea1c4aad",
         "type": "github"
       },
       "original": {
@@ -132,6 +478,102 @@
       }
     },
     "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "devenv",
+          "crate2nix",
+          "cachix",
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "gitignore_2": {
+      "inputs": {
+        "nixpkgs": [
+          "devenv",
+          "crate2nix",
+          "crate2nix_stable",
+          "cachix",
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "gitignore_3": {
+      "inputs": {
+        "nixpkgs": [
+          "devenv",
+          "crate2nix",
+          "crate2nix_stable",
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "gitignore_4": {
+      "inputs": {
+        "nixpkgs": [
+          "devenv",
+          "crate2nix",
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "gitignore_5": {
       "inputs": {
         "nixpkgs": [
           "devenv",
@@ -153,62 +595,130 @@
         "type": "github"
       }
     },
-    "libgit2": {
-      "flake": false,
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "devenv",
+          "ghostty",
+          "nixpkgs"
+        ]
+      },
       "locked": {
-        "lastModified": 1697646580,
-        "narHash": "sha256-oX4Z3S9WtJlwvj0uH9HlYcWv+x1hqp8mhXl7HsLu2f0=",
-        "owner": "libgit2",
-        "repo": "libgit2",
-        "rev": "45fd9ed7ae1a9b74b957ef4f337bc3c8b3df01b5",
+        "lastModified": 1770586272,
+        "narHash": "sha256-Ucci8mu8QfxwzyfER2DQDbvW9t1BnTUJhBmY7ybralo=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "b1f916ba052341edc1f80d4b2399f1092a4873ca",
         "type": "github"
       },
       "original": {
-        "owner": "libgit2",
-        "repo": "libgit2",
+        "owner": "nix-community",
+        "repo": "home-manager",
         "type": "github"
       }
     },
     "nix": {
       "inputs": {
         "flake-compat": [
-          "devenv"
+          "devenv",
+          "flake-compat"
         ],
-        "flake-parts": "flake-parts",
-        "libgit2": "libgit2",
-        "nixpkgs": "nixpkgs_2",
+        "flake-parts": [
+          "devenv",
+          "flake-parts"
+        ],
+        "git-hooks-nix": [
+          "devenv",
+          "git-hooks"
+        ],
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ],
         "nixpkgs-23-11": [
           "devenv"
         ],
         "nixpkgs-regression": [
           "devenv"
-        ],
-        "pre-commit-hooks": [
-          "devenv"
         ]
       },
       "locked": {
-        "lastModified": 1745930071,
-        "narHash": "sha256-bYyjarS3qSNqxfgc89IoVz8cAFDkF9yPE63EJr+h50s=",
-        "owner": "domenkozar",
+        "lastModified": 1776511668,
+        "narHash": "sha256-g2KEBuHpc3a56c+jPcg0+w6LSuIj6f+zzdztLCOyIhc=",
+        "owner": "cachix",
         "repo": "nix",
-        "rev": "b455edf3505f1bf0172b39a735caef94687d0d9c",
+        "rev": "42d4b7de21c15f28c568410f4383fa06a8458a40",
         "type": "github"
       },
       "original": {
-        "owner": "domenkozar",
-        "ref": "devenv-2.24",
+        "owner": "cachix",
+        "ref": "devenv-2.34",
         "repo": "nix",
+        "type": "github"
+      }
+    },
+    "nix-test-runner": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1588761593,
+        "narHash": "sha256-FKJykltAN/g3eIceJl4SfDnnyuH2jHImhMrXS2KvGIs=",
+        "owner": "stoeffel",
+        "repo": "nix-test-runner",
+        "rev": "c45d45b11ecef3eb9d834c3b6304c05c49b06ca2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "stoeffel",
+        "repo": "nix-test-runner",
+        "type": "github"
+      }
+    },
+    "nix-test-runner_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1588761593,
+        "narHash": "sha256-FKJykltAN/g3eIceJl4SfDnnyuH2jHImhMrXS2KvGIs=",
+        "owner": "stoeffel",
+        "repo": "nix-test-runner",
+        "rev": "c45d45b11ecef3eb9d834c3b6304c05c49b06ca2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "stoeffel",
+        "repo": "nix-test-runner",
+        "type": "github"
+      }
+    },
+    "nixd": {
+      "inputs": {
+        "flake-parts": [
+          "devenv",
+          "flake-parts"
+        ],
+        "nixpkgs": "nixpkgs_5",
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1777345723,
+        "narHash": "sha256-BhY3D5DhpDnnUcaY+AL/cpyYX+OIjQgnAkbPLZ08C38=",
+        "owner": "nix-community",
+        "repo": "nixd",
+        "rev": "6bf30951a3dc407a798d30db427e3f96ac9b39f5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixd",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1733212471,
-        "narHash": "sha256-M1+uCoV5igihRfcUKrr1riygbe73/dzNnzPsmaLCmpo=",
+        "lastModified": 1765186076,
+        "narHash": "sha256-hM20uyap1a0M9d344I692r+ik4gTMyj60cQWO+hAYP8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "55d15ad12a74eb7d4646254e13638ad0c4128776",
+        "rev": "addf7cf5f383a3101ecfba091b98d0a1263dc9b8",
         "type": "github"
       },
       "original": {
@@ -220,17 +730,17 @@
     },
     "nixpkgs-python": {
       "inputs": {
-        "flake-compat": "flake-compat_2",
+        "flake-compat": "flake-compat_5",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1749044308,
-        "narHash": "sha256-4PxjidSLpNuB+/YXtbaMoqkaNpZ7IGJDi2Rbo9TqmrM=",
+        "lastModified": 1777642067,
+        "narHash": "sha256-6eDIurv/KtJPS/oUT2ZPYzbTq7Qr4GEn3w7JNgObidY=",
         "owner": "cachix",
         "repo": "nixpkgs-python",
-        "rev": "0cf34980e6a88fd56b18656b766ba5dfd4d4de0e",
+        "rev": "0e0fd8c0fb36b707d0f90c38b13265d366db8798",
         "type": "github"
       },
       "original": {
@@ -241,27 +751,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1717432640,
-        "narHash": "sha256-+f9c4/ZX5MWDOuB1rKoWj+lBNm0z0rs4CK47HBLxy1o=",
+        "lastModified": 1765186076,
+        "narHash": "sha256-hM20uyap1a0M9d344I692r+ik4gTMyj60cQWO+hAYP8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "88269ab3044128b7c2f4c7d68448b2fb50456870",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "release-24.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1748929857,
-        "narHash": "sha256-lcZQ8RhsmhsK8u7LIFsJhsLh/pzR9yZ8yqpTzyGdj+Q=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "c2a03962b8e24e669fb37b7df10e7c79531ff1a4",
+        "rev": "addf7cf5f383a3101ecfba091b98d0a1263dc9b8",
         "type": "github"
       },
       "original": {
@@ -271,15 +765,153 @@
         "type": "github"
       }
     },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1769433173,
+        "narHash": "sha256-Gf1dFYgD344WZ3q0LPlRoWaNdNQq8kSBDLEWulRQSEs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "13b0f9e6ac78abbbb736c635d87845c4f4bee51b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1770537093,
+        "narHash": "sha256-XV30uo8tXuxdzuV8l3sojmlPRLd/8tpMsOp4lNzLGUo=",
+        "rev": "fef9403a3e4d31b0a23f0bacebbec52c248fbb51",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre942631.fef9403a3e4d/nixexprs.tar.xz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz"
+      }
+    },
+    "nixpkgs_5": {
+      "locked": {
+        "lastModified": 1776877367,
+        "narHash": "sha256-wMN1gM00sUQ2KC9CNr/XEOGdfOrl67PabIRv9AYayTo=",
+        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.05pre985613.0726a0ecb6d4/nixexprs.tar.xz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz"
+      }
+    },
+    "nixpkgs_6": {
+      "locked": {
+        "lastModified": 1777578337,
+        "narHash": "sha256-Ad49moKWeXtKBJNy2ebiTQUEgdLyvGmTeykAQ9xM+Z4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": [
+          "devenv",
+          "crate2nix",
+          "crate2nix_stable",
+          "flake-compat"
+        ],
+        "gitignore": "gitignore_3",
+        "nixpkgs": [
+          "devenv",
+          "crate2nix",
+          "crate2nix_stable",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1769069492,
+        "narHash": "sha256-Efs3VUPelRduf3PpfPP2ovEB4CXT7vHf8W+xc49RL/U=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "a1ef738813b15cf8ec759bdff5761b027e3e1d23",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks_2": {
+      "inputs": {
+        "flake-compat": [
+          "devenv",
+          "crate2nix",
+          "flake-compat"
+        ],
+        "gitignore": "gitignore_4",
+        "nixpkgs": [
+          "devenv",
+          "crate2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1769069492,
+        "narHash": "sha256-Efs3VUPelRduf3PpfPP2ovEB4CXT7vHf8W+xc49RL/U=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "a1ef738813b15cf8ec759bdff5761b027e3e1d23",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "devenv": "devenv",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs_6",
         "nixpkgs-python": "nixpkgs-python",
-        "systems": "systems"
+        "systems": "systems_2"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777778183,
+        "narHash": "sha256-Lqv9MZO0XAGcMbXJU+ULBSMD41Pf391uJehylUQKe7Y=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "dbba5f888c82ef3ce594c451c33ac2474eb80847",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     },
     "systems": {
+      "flake": false,
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -291,6 +923,122 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "devenv",
+          "nixd",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775636079,
+        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "zig": {
+      "inputs": {
+        "flake-compat": [
+          "devenv",
+          "ghostty",
+          "flake-compat"
+        ],
+        "nixpkgs": [
+          "devenv",
+          "ghostty",
+          "nixpkgs"
+        ],
+        "systems": [
+          "devenv",
+          "ghostty",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776789209,
+        "narHash": "sha256-G6B7Q4TXn7MZ1mB+f9rymjsYF5PLWoSvmbxijb/99bw=",
+        "owner": "mitchellh",
+        "repo": "zig-overlay",
+        "rev": "14fe971844e841297ddd2ce9783d6892b467af39",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mitchellh",
+        "repo": "zig-overlay",
+        "type": "github"
+      }
+    },
+    "zig_2": {
+      "inputs": {
+        "nixpkgs": [
+          "devenv",
+          "ghostty",
+          "zon2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777234348,
+        "narHash": "sha256-fKw44a4qbUuI5eTG8k0gPbqMV5TOrjYF35PBzsYgd2U=",
+        "ref": "refs/heads/main",
+        "rev": "2c781c0609ecda600ab98f98cca417bbd981bd53",
+        "revCount": 1677,
+        "type": "git",
+        "url": "https://codeberg.org/jcollie/zig-overlay.git"
+      },
+      "original": {
+        "type": "git",
+        "url": "https://codeberg.org/jcollie/zig-overlay.git"
+      }
+    },
+    "zon2nix": {
+      "inputs": {
+        "nixpkgs": [
+          "devenv",
+          "ghostty",
+          "nixpkgs"
+        ],
+        "zig": "zig_2"
+      },
+      "locked": {
+        "lastModified": 1777314365,
+        "narHash": "sha256-eLxQaD0wc96Neqkln8wHS0rNq/chPODifFkhwrwilEU=",
+        "owner": "jcollie",
+        "repo": "zon2nix",
+        "rev": "a5a1d412ad1ab6305511997bbc92b3a9dd6cb784",
+        "type": "github"
+      },
+      "original": {
+        "owner": "jcollie",
+        "ref": "main",
+        "repo": "zon2nix",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -77,9 +77,4 @@
         };
       });
   };
-
-  nixConfig = {
-    extra-trusted-public-keys = "devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=";
-    extra-substituters = "https://devenv.cachix.org";
-  };
 }

--- a/src/qibolab/_core/sequence.py
+++ b/src/qibolab/_core/sequence.py
@@ -309,3 +309,27 @@ class PulseSequence(UserList[_Element]):
                 seq.append((ch, ev))
 
         return seq
+
+    def collect_vzs(self) -> "PulseSequence":
+        seq = PulseSequence()
+        phases = defaultdict(float)
+
+        def collect(ch: ChannelId):
+            if not np.isclose(phases[ch], 0.0):
+                seq.append((ch, VirtualZ(phase=phases[ch])))
+                phases[ch] = 0.0
+
+        for ch, ev in self:
+            if isinstance(ev, VirtualZ):
+                phases[ch] += ev.phase
+                continue
+
+            if isinstance(ev, Pulse):
+                collect(ch)
+
+            seq.append((ch, ev))
+
+        for ch in self.channels:
+            collect(ch)
+
+        return seq

--- a/src/qibolab/_core/sequence.py
+++ b/src/qibolab/_core/sequence.py
@@ -288,3 +288,24 @@ class PulseSequence(UserList[_Element]):
                 for el in els
             ]
         )
+
+    def to_relative_phases(self) -> "PulseSequence":
+        seq = PulseSequence()
+        phases = defaultdict(float)
+
+        for ch, ev in self:
+            if isinstance(ev, VirtualZ):
+                phases[ch] += ev.phase
+            elif isinstance(ev, Pulse):
+                seq.append(
+                    (
+                        ch,
+                        ev.model_copy(
+                            update={"relative_phase": ev.relative_phase + phases[ch]}
+                        ),
+                    )
+                )
+            else:
+                seq.append((ch, ev))
+
+        return seq

--- a/src/qibolab/_core/sequence.py
+++ b/src/qibolab/_core/sequence.py
@@ -263,14 +263,21 @@ class PulseSequence(UserList[_Element]):
         return seqs
 
     def to_vzs(self) -> "PulseSequence":
-        """Split relative phases to :class:`VirtualZ` elements.
+        """Transform :class:`Pulse` relative phases to :class:`VirtualZ` elements.
 
-        The basic formula just relies on the composition of Pauli matrices' exponential
-        and it is available from many sources. One of those could be MM p. 626.
+        The relative phase for a pulse can be applied to the pulse itself, or applying
+        the inverse transformation to the reference frame, right before and right after
+        the pulse itself.
 
-        .. todo::
+        This method realizes this mapping from :class:`Pulse` relative phases to
+        :class:`VirtualZ`, leaving all relative phases to their default value of
+        ``0.0``.
+        The method is compatible with the presence of further :class:`VirtualZ` in the
+        original sequence.
 
-            Add MM as a proper reference, such that it ends up in the bibliography
+        The basic formula just relies on the composition of Pauli matrices'
+        exponential. Cf. :cite:t:`Manenti:2023zzn`, Sec. 14.6.4 (or any other similar
+        reference).
         """
         return PulseSequence(
             [
@@ -290,6 +297,15 @@ class PulseSequence(UserList[_Element]):
         )
 
     def to_relative_phases(self) -> "PulseSequence":
+        """Embed :class:`VirtualZ` transformations into :class:`Pulse` relative phases.
+
+        This method implements a transformation which is the conceptual opposite of the
+        one realized by :meth:`to_vzs`.
+        The two functions are not exactly inverse to each other, since there could be
+        multiple :class:`VirtualZ` in the original sequence (which would be collapsed by
+        a round trip), and pulses' relative phases and frame transformations can
+        coexist.
+        """
         seq = PulseSequence()
         phases = defaultdict(float)
 

--- a/src/qibolab/_core/sequence.py
+++ b/src/qibolab/_core/sequence.py
@@ -311,6 +311,12 @@ class PulseSequence(UserList[_Element]):
         return seq
 
     def collect_vzs(self) -> "PulseSequence":
+        """Collect subsequent :class:`VirtualZ` rotations.
+
+        For each channel, it divides :class:`VirtualZ` in groups delimited by pulses.
+        Each group is collected and transformed in a single :class:`VirtualZ`, just summing
+        the angles.
+        """
         seq = PulseSequence()
         phases = defaultdict(float)
 

--- a/src/qibolab/_core/sequence.py
+++ b/src/qibolab/_core/sequence.py
@@ -263,6 +263,15 @@ class PulseSequence(UserList[_Element]):
         return seqs
 
     def to_vzs(self) -> "PulseSequence":
+        """Split relative phases to :class:`VirtualZ` elements.
+
+        The basic formula just relies on the composition of Pauli matrices' exponential
+        and it is available from many sources. One of those could be MM p. 626.
+
+        .. todo::
+
+            Add MM as a proper reference, such that it ends up in the bibliography
+        """
         return PulseSequence(
             [
                 el

--- a/src/qibolab/_core/sequence.py
+++ b/src/qibolab/_core/sequence.py
@@ -5,13 +5,14 @@ from collections.abc import Callable, Iterable
 from functools import cache
 from typing import Any, Union
 
+import numpy as np
 from pydantic import TypeAdapter
 from pydantic_core import core_schema
 
-from qibolab._core.pulses.pulse import PulseId
+from qibolab._core.pulses.pulse import PulseId, VirtualZ
 
 from .identifier import ChannelId
-from .pulses import Acquisition, Align, Delay, PulseLike, Readout
+from .pulses import Acquisition, Align, Delay, Pulse, PulseLike, Readout
 
 __all__ = ["PulseSequence"]
 
@@ -260,3 +261,21 @@ class PulseSequence(UserList[_Element]):
             seqs[ch].append(pulse)
 
         return seqs
+
+    def to_vzs(self) -> "PulseSequence":
+        return PulseSequence(
+            [
+                el
+                for els in (
+                    [(ch, ev)]
+                    if not isinstance(ev, Pulse) or np.isclose(ev.relative_phase, 0)
+                    else [
+                        (ch, VirtualZ(phase=ev.relative_phase)),
+                        (ch, ev.model_copy(update={"relative_phase": 0})),
+                        (ch, VirtualZ(phase=-ev.relative_phase)),
+                    ]
+                    for ch, ev in self
+                )
+                for el in els
+            ]
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,11 @@ def seed():
     np.random.seed(42)
 
 
+@pytest.fixture(scope="session")
+def prng() -> np.random.Generator:
+    return np.random.default_rng(seed=42)
+
+
 def pytest_addoption(parser):
     parser.addoption(
         "--platform",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ def seed():
 
 
 @pytest.fixture(scope="session")
-def prng() -> np.random.Generator:
+def rng() -> np.random.Generator:
     return np.random.default_rng(seed=42)
 
 

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -435,7 +435,35 @@ def test_phases_blocks_collect(prng: np.random.Generator) -> None:
 
 
 def test_relative_phases_to_vzs(prng: np.random.Generator) -> None:
-    pass
+    phases = prng.random(10)
+    seq = PulseSequence(
+        [
+            (
+                f"ch{i}",
+                Pulse(
+                    duration=10,
+                    amplitude=0.1,
+                    envelope=Rectangular(),
+                    relative_phase=ph,
+                ),
+            )
+            for i, ph in enumerate(phases)
+        ]
+    )
+    vzs_seq = seq.to_vzs()
+    forward: list[float] = []
+    backward: list[float] = []
+    for i in range(10):
+        pre, pulse, post = vzs_seq[3 * i : 3 * (i + 1)]
+        assert pre[0] == post[0] == pulse[0] == f"ch{i}"
+        assert isinstance(pre[1], VirtualZ)
+        forward.append(pre[1].phase)
+        assert isinstance(pulse[1], Pulse)
+        assert pytest.approx(pulse[1].relative_phase) == 0
+        assert isinstance(post[1], VirtualZ)
+        backward.append(post[1].phase)
+
+    assert pytest.approx(forward) == phases == pytest.approx(-np.array(backward))
 
 
 def test_vzs_to_relative_phases(prng: np.random.Generator) -> None:

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -410,6 +410,11 @@ def test_readouts():
 
 
 def test_phases_collect(prng: np.random.Generator) -> None:
+    """Compare a sequence of individual phases after collection.
+
+    Since the virtual rotations are the only elements present in the sequence, we expect
+    them to be collected in a single rotation, equal to the sum.
+    """
     phases = prng.random(10)
     phases_seq = PulseSequence([("ch", VirtualZ(phase=ph)) for ph in phases])
     collected = phases_seq.collect_vzs()
@@ -419,6 +424,12 @@ def test_phases_collect(prng: np.random.Generator) -> None:
 
 
 def test_phases_blocks_collect(prng: np.random.Generator) -> None:
+    """Compare blocks of phases after collection.
+
+    Similar to the former test, :func:`test_phases_collect`, but in this case multiple
+    segments are present, separated by pulses' execution. Which act as a barrier for the
+    phase collection.
+    """
     phases_blocks = [prng.random(n) for n in (5, 3, 8)]
     blocks_seqs = (
         (("ch", VirtualZ(phase=ph)) for ph in phases) for phases in phases_blocks
@@ -435,6 +446,12 @@ def test_phases_blocks_collect(prng: np.random.Generator) -> None:
 
 
 def test_relative_phases_to_vzs(prng: np.random.Generator) -> None:
+    """Compare phase values after relative phases to virtual rotations conversion.
+
+    Each relative phase gets compiled into two different phase rotations, before and
+    after the pulse execution, to change the reference frame only for that individual
+    operation.
+    """
     phases = prng.random(10)
     seq = PulseSequence(
         [
@@ -467,6 +484,12 @@ def test_relative_phases_to_vzs(prng: np.random.Generator) -> None:
 
 
 def test_vzs_to_relative_phases(prng: np.random.Generator) -> None:
+    """Compare phase values after virtual rotations to relative phases conversion.
+
+    First compare multiple ones on different channels, than on a single one. The two
+    cases are distinct, since the virtual rotations are intended to be accumulated on a
+    channel.
+    """
     phases = prng.random(10)
     seq = PulseSequence(
         [

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -483,6 +483,44 @@ def test_relative_phases_to_vzs(prng: np.random.Generator) -> None:
     assert pytest.approx(forward) == phases == pytest.approx(-np.array(backward))
 
 
+def test_relative_phases_to_collected_vzs(prng: np.random.Generator) -> None:
+    """Compare phase values after relative phases expansion and collection.
+
+    Similar to the former test, :func:`test_relative_phases_to_vzs`, but this takes
+    place on a single channel, to be able to benchmark a successive virtual rotations
+    collection process.
+    """
+    phases = prng.random(10)
+    seq = PulseSequence(
+        [
+            (
+                "ch",
+                Pulse(
+                    duration=10,
+                    amplitude=0.1,
+                    envelope=Rectangular(),
+                    relative_phase=ph,
+                ),
+            )
+            for ph in phases
+        ]
+    )
+
+    collected_vzs_seq = seq.to_vzs().collect_vzs()
+    collected_phases: list[float] = []
+    for i in range(10):
+        vz, pulse = collected_vzs_seq[2 * i : 2 * (i + 1)]
+        assert vz[0] == pulse[0] == "ch"
+        assert isinstance(vz[1], VirtualZ)
+        collected_phases.append(vz[1].phase)
+        assert isinstance(pulse[1], Pulse)
+        assert pytest.approx(pulse[1].relative_phase) == 0
+
+    assert pytest.approx(collected_phases) == np.diff(phases, prepend=0.0)
+    assert isinstance(collected_vzs_seq[-1][1], VirtualZ)
+    assert pytest.approx(collected_vzs_seq[-1][1].phase) == -phases[-1]
+
+
 def test_vzs_to_relative_phases(prng: np.random.Generator) -> None:
     """Compare phase values after virtual rotations to relative phases conversion.
 

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -1,5 +1,7 @@
 from copy import deepcopy
 
+import numpy as np
+import pytest
 from pydantic import TypeAdapter
 
 from qibolab._core.pulses import (
@@ -405,3 +407,12 @@ def test_readouts():
 
     aslist = TypeAdapter(PulseSequence).dump_python(sequence)
     assert PulseSequence.load(aslist) == sequence
+
+
+def test_phases_transforms(prng: np.random.Generator) -> None:
+    phases = prng.random(10)
+    sequence = PulseSequence([("ch", VirtualZ(phase=ph)) for ph in phases])
+    collected = sequence.collect_vzs()
+    event = collected[0][1]
+    assert isinstance(event, VirtualZ)
+    assert pytest.approx(event.phase) == np.sum(phases)

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -409,10 +409,34 @@ def test_readouts():
     assert PulseSequence.load(aslist) == sequence
 
 
-def test_phases_transforms(prng: np.random.Generator) -> None:
+def test_phases_collect(prng: np.random.Generator) -> None:
     phases = prng.random(10)
-    sequence = PulseSequence([("ch", VirtualZ(phase=ph)) for ph in phases])
-    collected = sequence.collect_vzs()
+    phases_seq = PulseSequence([("ch", VirtualZ(phase=ph)) for ph in phases])
+    collected = phases_seq.collect_vzs()
     event = collected[0][1]
     assert isinstance(event, VirtualZ)
     assert pytest.approx(event.phase) == np.sum(phases)
+
+
+def test_phases_blocks_collect(prng: np.random.Generator) -> None:
+    phases_blocks = [prng.random(n) for n in (5, 3, 8)]
+    blocks_seqs = (
+        (("ch", VirtualZ(phase=ph)) for ph in phases) for phases in phases_blocks
+    )
+    pulse_seq = [("ch", Pulse(duration=10, amplitude=0.1, envelope=Rectangular()))]
+    phases_blocks_seq = PulseSequence(
+        [ev for block in blocks_seqs for subseq in (block, pulse_seq) for ev in subseq]
+    )
+    blocks_collected = phases_blocks_seq.collect_vzs()
+    for i, phases in enumerate(phases_blocks):
+        vz = blocks_collected[2 * i][1]
+        assert isinstance(vz, VirtualZ)
+        assert pytest.approx(vz.phase) == phases.sum()
+
+
+def test_relative_phases_to_vzs(prng: np.random.Generator) -> None:
+    pass
+
+
+def test_vzs_to_relative_phases(prng: np.random.Generator) -> None:
+    pass

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -467,4 +467,33 @@ def test_relative_phases_to_vzs(prng: np.random.Generator) -> None:
 
 
 def test_vzs_to_relative_phases(prng: np.random.Generator) -> None:
-    pass
+    phases = prng.random(10)
+    seq = PulseSequence(
+        [
+            (f"ch{i}", ev)
+            for i, ph in enumerate(phases)
+            for ev in (
+                VirtualZ(phase=ph),
+                Pulse(duration=10, amplitude=0.1, envelope=Rectangular()),
+            )
+        ]
+    )
+    relph_seq = seq.to_relative_phases()
+    for ph, ev in zip(phases, relph_seq):
+        assert isinstance(ev[1], Pulse)
+        assert pytest.approx(ev[1].relative_phase) == ph
+
+    seq = PulseSequence(
+        [
+            ("ch", ev)
+            for ph in phases
+            for ev in (
+                VirtualZ(phase=ph),
+                Pulse(duration=10, amplitude=0.1, envelope=Rectangular()),
+            )
+        ]
+    )
+    relph_1ch_seq = seq.to_relative_phases()
+    for ph, ev in zip(np.add.accumulate(phases), relph_1ch_seq):
+        assert isinstance(ev[1], Pulse)
+        assert pytest.approx(ev[1].relative_phase) == ph

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -409,13 +409,13 @@ def test_readouts():
     assert PulseSequence.load(aslist) == sequence
 
 
-def test_phases_collect(prng: np.random.Generator) -> None:
+def test_phases_collect(rng: np.random.Generator) -> None:
     """Compare a sequence of individual phases after collection.
 
     Since the virtual rotations are the only elements present in the sequence, we expect
     them to be collected in a single rotation, equal to the sum.
     """
-    phases = prng.random(10)
+    phases = rng.random(10)
     phases_seq = PulseSequence([("ch", VirtualZ(phase=ph)) for ph in phases])
     collected = phases_seq.collect_vzs()
     event = collected[0][1]
@@ -423,14 +423,14 @@ def test_phases_collect(prng: np.random.Generator) -> None:
     assert pytest.approx(event.phase) == np.sum(phases)
 
 
-def test_phases_blocks_collect(prng: np.random.Generator) -> None:
+def test_phases_blocks_collect(rng: np.random.Generator) -> None:
     """Compare blocks of phases after collection.
 
     Similar to the former test, :func:`test_phases_collect`, but in this case multiple
     segments are present, separated by pulses' execution. Which act as a barrier for the
     phase collection.
     """
-    phases_blocks = [prng.random(n) for n in (5, 3, 8)]
+    phases_blocks = [rng.random(n) for n in (5, 3, 8)]
     blocks_seqs = (
         (("ch", VirtualZ(phase=ph)) for ph in phases) for phases in phases_blocks
     )
@@ -445,14 +445,14 @@ def test_phases_blocks_collect(prng: np.random.Generator) -> None:
         assert pytest.approx(vz.phase) == phases.sum()
 
 
-def test_relative_phases_to_vzs(prng: np.random.Generator) -> None:
+def test_relative_phases_to_vzs(rng: np.random.Generator) -> None:
     """Compare phase values after relative phases to virtual rotations conversion.
 
     Each relative phase gets compiled into two different phase rotations, before and
     after the pulse execution, to change the reference frame only for that individual
     operation.
     """
-    phases = prng.random(10)
+    phases = rng.random(10)
     seq = PulseSequence(
         [
             (
@@ -483,14 +483,14 @@ def test_relative_phases_to_vzs(prng: np.random.Generator) -> None:
     assert pytest.approx(forward) == phases == pytest.approx(-np.array(backward))
 
 
-def test_relative_phases_to_collected_vzs(prng: np.random.Generator) -> None:
+def test_relative_phases_to_collected_vzs(rng: np.random.Generator) -> None:
     """Compare phase values after relative phases expansion and collection.
 
     Similar to the former test, :func:`test_relative_phases_to_vzs`, but this takes
     place on a single channel, to be able to benchmark a successive virtual rotations
     collection process.
     """
-    phases = prng.random(10)
+    phases = rng.random(10)
     seq = PulseSequence(
         [
             (
@@ -521,14 +521,14 @@ def test_relative_phases_to_collected_vzs(prng: np.random.Generator) -> None:
     assert pytest.approx(collected_vzs_seq[-1][1].phase) == -phases[-1]
 
 
-def test_vzs_to_relative_phases(prng: np.random.Generator) -> None:
+def test_vzs_to_relative_phases(rng: np.random.Generator) -> None:
     """Compare phase values after virtual rotations to relative phases conversion.
 
     First compare multiple ones on different channels, than on a single one. The two
     cases are distinct, since the virtual rotations are intended to be accumulated on a
     channel.
     """
-    phases = prng.random(10)
+    phases = rng.random(10)
     seq = PulseSequence(
         [
             (f"ch{i}", ev)


### PR DESCRIPTION
Actually, both the directions are included.

- [x] sum virtual Zs to reduce the amount of operations
- [x] improve docs (with proper references)
- [x] add emulator-independent tests
    - better to keep tests as minimal as possible - otherwise issues in one part of the code may easily propagate
    - we could also have soon a cyclic dependency problem (cf. #1257)

> [!WARNING]
> Phases should be relevant only for drive channels.
>
> However, here only `Pulse`s are taken into account, explicitly. So, `Pulse`s wrapped in `Readout`s operations are neglected. Which should not be a source of problems, since they are supposed to be placed on `"acquisition"` channels, and not to account for phases.
>
> *It is still possible to account for that, by using the `"probe"` separately from the `"acquisition"` channel - in which case they will be unwrapped `Pulse`s.*

(essentially reopening #1274)