### PR TITLE
return native single qubit  elemens all together (qubits and couplers)

### DIFF
--- a/src/qibolab/_core/parameters.py
+++ b/src/qibolab/_core/parameters.py
@@ -131,6 +131,10 @@ class NativeGates(Model):
     coupler: dict[QubitId, SingleQubitNatives] = Field(default_factory=dict)
     two_qubit: TwoQubitContainer = Field(default_factory=dict)
 
+    @property
+    def element(self) -> dict[QubitId, SingleQubitNatives]:
+        return self.single_qubit | self.coupler
+
 
 ComponentId = str
 """Identifier of a generic component.


### PR DESCRIPTION
This is useful to reuse routines for the characterization of the couplers. Reading from elements without discriminating if it's a coupler or a qubit will then allow us to carry for example f01spectroscopies of the coupler (by reusing channels of neighboring qubits). 

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
