### PR TITLE
Fixing QM kernels error

### DIFF
--- a/src/qibolab/_core/components/configs.py
+++ b/src/qibolab/_core/components/configs.py
@@ -135,6 +135,8 @@ class AcquisitionConfig(Config):
             the expliciti definition is required in order to solve the ambiguity about
             the arrays equality
         """
+        # FIXME: temporary solution to avoid error described in
+        # https://github.com/qiboteam/qibolab/pull/1312
         raw_kernel_comparison = self.kernel == other.kernel
         return (
             (self.delay == other.delay)


### PR DESCRIPTION
This PR fixes the following error which appears I would say randomly when using QM.
```bash
  File "/nfs/users/andrea.pasquale/qibolab/src/qibolab/_core/components/configs.py", line 143, in __eq__
    and (self.kernel == other.kernel).all()
AttributeError: 'bool' object has no attribute 'all'

```