### PR TITLE
Use the correct amount of shots to estimate duration

### DIFF
--- a/src/qibolab/_core/instruments/qblox/cluster.py
+++ b/src/qibolab/_core/instruments/qblox/cluster.py
@@ -124,14 +124,14 @@ class Cluster(Controller):
                 # then configure modules and sequencers
                 # (including sequences upload)
                 sequencers = self._configure(
-                    sequences_, configs, options.acquisition_type
+                    sequences_, configs, options_.acquisition_type
                 )
                 log.status(self.cluster, sequencers)
 
                 # finally execute the experiment, and fetch results
-                duration = options.estimate_duration([ps], sweepers_)
+                duration = options_.estimate_duration([ps], sweepers_)
                 data = self._execute(
-                    sequencers, sequences_, duration, options.acquisition_type
+                    sequencers, sequences_, duration, options_.acquisition_type
                 )
                 log.data(data)
 


### PR DESCRIPTION
This should only affect the wait time in case of shots.

It could have an interplay with the timeouts. But since it should be shrinking the delays before fetching the results, it can only get worse.

On the good side, it will only save some waiting time (which may be relevant for long experiments).