### PR TITLE
Decouple probe and acquisition length for QM driver

### DIFF
--- a/src/qibolab/_core/instruments/qm/controller.py
+++ b/src/qibolab/_core/instruments/qm/controller.py
@@ -477,11 +477,6 @@ class QmController(Controller):
             if not isinstance(readout, Readout):
                 continue
 
-            if readout.probe.duration != readout.acquisition.duration:
-                raise ValueError(
-                    "Quantum Machines does not support acquisition with different duration than probe."
-                )
-
             probe_id = self.channels[channel_id].probe
             max_voltage = channel_max_voltage(configs[probe_id])
             sampling_rate = channel_sampling_rate(configs[probe_id])


### PR DESCRIPTION
In this PR I'm trying to decouple the probe and acquisition length for QM.
I've verified the implementation using the TOF protocol in qibocal http://login.qrccluster.com:9000/Q6E1IJW7TI2YZRIoP0YCrA==/
I was able to get pretty good readout fidelities with a probe len of 400 ns and an acquisition length of 1000ns. 

