### PR TITLE
introduce turn_off_on_disconnect flag in LocalOscillator

### DIFF
--- a/src/qibolab/_core/instruments/oscillator.py
+++ b/src/qibolab/_core/instruments/oscillator.py
@@ -26,7 +26,7 @@ class Device(Protocol):
         """Turn device on."""
 
     def off(self):
-        """Turn device on."""
+        """Turn device off."""
 
     def close(self):
         """Close connection with device."""
@@ -75,7 +75,7 @@ class LocalOscillator(Instrument):
     settings: Optional[InstrumentSettings] = Field(
         default_factory=lambda: LocalOscillatorSettings()
     )
-    power_down_on_disconnect: Optional[bool] = True
+    turn_off_on_disconnect: Optional[bool] = True
 
     frequency = _property("frequency")
     power = _property("power")
@@ -98,7 +98,7 @@ class LocalOscillator(Instrument):
 
     def disconnect(self):
         if self.device is not None:
-            if self.power_down_on_disconnect:
+            if self.turn_off_on_disconnect:
                 self.device.off()
             self.device.close()
             self.device = None


### PR DESCRIPTION
This PR introduces a `turn_off_on_disconnect` in `LocalOscillator`, that is `True` by default, but can be set to `False` to keep the LO alive upon calling `disconnect()`. This is based on a suggestion by Hany according to whom it results in a better signal to noise ratio. 