### PR TITLE
Fix AllXY always ground-state

### DIFF
--- a/src/qibolab/_core/instruments/qblox/results.py
+++ b/src/qibolab/_core/instruments/qblox/results.py
@@ -100,7 +100,7 @@ def _scope(data: ScopeData) -> Result:
 
 
 def _classification(data: Thresholded) -> Result:
-    return np.array(data, dtype=int)
+    return np.array(data, dtype=float)
 
 
 def extract(

--- a/src/qibolab/_core/instruments/qblox/results.py
+++ b/src/qibolab/_core/instruments/qblox/results.py
@@ -100,7 +100,7 @@ def _scope(data: ScopeData) -> Result:
 
 
 def _classification(data: Thresholded) -> Result:
-    return np.array(data, dtype=float)
+    return np.array(data)
 
 
 def extract(


### PR DESCRIPTION
Fixes #1303

Measurements were assumed to be singleshot and therefore a list of 0s and 1s, in the code this was enforced by setting `dtype=int`. Instead, if the measurement is not singleshot but cyclic, meaning the average over shots is done in the qblox machine, the result is the ratio of excited states to ground states, so not an integer. See the issue for a more detailed discussion. 