### PR TITLE
don't cache qblox.cluster.Cluster._modules

### DIFF
--- a/src/qibolab/_core/instruments/qblox/cluster.py
+++ b/src/qibolab/_core/instruments/qblox/cluster.py
@@ -250,7 +250,7 @@ class Cluster(Controller):
 
         return acquisitions
 
-    @cached_property
+    @property
     def _modules(self) -> dict[SlotId, Module]:
         """Retrieve slot to module object mapping."""
         return {mod.slot_idx: mod for mod in self.cluster.modules if mod.present()}


### PR DESCRIPTION
In an RB experiment the cluster is connected and disconnected multiple times. By caching we try to interact with modules that have been disconnected.

Tested that it now works. 