### PR TITLE
ignoring cache in qm controller.py

### DIFF
--- a/src/qibolab/_core/instruments/qm/controller.py
+++ b/src/qibolab/_core/instruments/qm/controller.py
@@ -550,7 +550,7 @@ class QmController(Controller):
             sweepers=sweepers,
         )
 
-        if True: # TODO: new_experiment != self.experiment or self.manager is None:
+        if True:  # TODO: new_experiment != self.experiment or self.manager is None:
             # register DC elements so that all qubits are
             # sweetspot even when they are not used
             for id, channel in self.channels.items():


### PR DESCRIPTION
Quick momentary fix: ignoring QM cache for pulse sequence, it is still problematic.

Checklist:
- [x] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
