### PR TITLE
Align Qblox attenuation with parameters convention

### DIFF
--- a/src/qibolab/_core/instruments/qblox/config/port.py
+++ b/src/qibolab/_core/instruments/qblox/config/port.py
@@ -227,7 +227,7 @@ class PortConfig(BaseModel):
         self.lo_freq = int(lo.frequency)
 
     def att_(self, lo: OscillatorConfig) -> None:
-        self.att = int(lo.power)
+        self.att = -int(lo.power)
 
     def mixer(self, mixer: IqMixerConfig) -> None:
         self.offset_path0 = mixer.offset_i


### PR DESCRIPTION
The original purpose of calling it `.power` was to also allow amplification.

Despite amplification not being available in Qblox, we should preserve the meaning of the configuration value, to make it consistent with other instruments (especially for the sake of exposing a uniform interface to Qibocal and similar projects).