### PR TITLE
Propagate the effect of filters delay to time-of-flight

### DIFF
--- a/src/qibolab/_core/instruments/qblox/utils.py
+++ b/src/qibolab/_core/instruments/qblox/utils.py
@@ -64,7 +64,12 @@ def lo_configs(
 
 
 def time_of_flights(configs: Configs) -> dict[ChannelId, float]:
-    """Extract time of flights configurations."""
+    """Extract time of flights configurations.
+
+    An additional 340 ns are supplemented, to account for the extra delay caused by
+    usage of all pre-distortion filters, and consequent delay compensations. Cf.
+    https://docs.qblox.com/en/v0.17.1/cluster/real_time_predistortions.html#bypasses-and-delays
+    """
     return {
         ch: max(config.delay, 4.0) + 340
         for ch, config in configs.items()


### PR DESCRIPTION
https://docs.qblox.com/en/v0.17.1/cluster/real_time_predistortions.html#bypasses-and-delays

<img width="798" height="168" alt="image" src="https://github.com/user-attachments/assets/6feca1b3-76da-4349-9a89-081da35a0019" />

Leftover from https://github.com/qiboteam/qibolab/issues/1330 and #1331 