### PR TITLE
Fix incorrect condition for setting amplitude to 1 in swept pulses

### DIFF
--- a/src/qibolab/_core/instruments/qblox/sequence/waveforms.py
+++ b/src/qibolab/_core/instruments/qblox/sequence/waveforms.py
@@ -107,12 +107,14 @@ def waveforms(
     duration_swept: dict[PulseLike, Sweeper],
 ) -> tuple[dict[WaveformIndex, WaveformSpec], WaveformIndices]:
     pulses = [
-        _pulse(e, amplitude_swept) for e in sequence if isinstance(e, (Pulse, Readout))
+        _pulse(e, e.id in amplitude_swept)
+        for e in sequence
+        if isinstance(e, (Pulse, Readout))
     ]
 
     pulses_not_swept = [p for p in pulses if p not in duration_swept]
     pulses_swept = [
-        (_pulse(p, amplitude_swept), duration_swept[p])
+        (_pulse(p, p.id in amplitude_swept), duration_swept[p])
         for p in duration_swept
         if isinstance(p, (Pulse, Readout))
     ]


### PR DESCRIPTION
The `amplitude_swept` parameter in the `_pulse` function is defined as a boolean, but we were incorrectly passing a `set[PulseId]` instead. Because of this type mismatch, the logic that checks whether a pulse is amplitude-swept behaved incorrectly, which meant that the amplitude could be unintentionally set to 1.0.