### PR TITLE
qblox: deduplicate waveforms 

### DIFF
--- a/src/qibolab/_core/instruments/qblox/cluster.py
+++ b/src/qibolab/_core/instruments/qblox/cluster.py
@@ -215,11 +215,11 @@ class Cluster(Controller):
                 log.data(data)
 
                 # process raw results to adhere to standard format
-                lenghts = integration_lenghts(sequences_, sequencers, self._modules)
+                lengths = integration_lenghts(sequences_, sequencers, self._modules)
                 psres.append(
                     extract(
                         data,
-                        lenghts,
+                        lengths,
                         options_.acquisition_type,
                         options_.results_shape(sweepers_),
                     )
@@ -244,7 +244,7 @@ class Cluster(Controller):
         sequencers with no sequence provided. In which case, it will attempt to assign
         sequencers to all available channels (as opposed to just those involved in the
         experiment, and thus in the sequences).
-        For the sake of simplifiying the usage of this function, a default acquisition
+        For the sake of simplifying the usage of this function, a default acquisition
         type is provided (:attr:`AcquisitionType.INTEGRATION`). The only true
         alternative to this value is :attr:`AcquisitionType.RAW`, since further
         configurations are required to operate in scope mode.

--- a/src/qibolab/_core/instruments/qblox/config/port.py
+++ b/src/qibolab/_core/instruments/qblox/config/port.py
@@ -28,13 +28,13 @@ QCM_SWEEP_TO_OFFSET = 2.5 / np.sqrt(2)
 There are two different ways to add an offset to the waveform played by the QCM module:
 
 - digitally summing an offset, which could be controlled both in real-time and by
-  conifgurations
-- adding an offset directly to the outcoming signal
+  configurations
+- adding an offset directly to the outgoing signal
 
 
 Since the QCM supplies outputs at 5 Vpp (`documented as +/-2.5 V
 <https://docs.qblox.com/en/main/products/architecture/modules/qcm.html#specifications>`_),
-a conversion is neeeded, because the first option will be defined in the interval (-1,
+a conversion is needed, because the first option will be defined in the interval (-1,
 1) in the parameters (internally mapping the floats on a suitable integers range), while
 the second is directly expressed in Volt.
 Hence, the conversion factor of ``2.5``.
@@ -295,7 +295,7 @@ def deduplicate_configs(configs: list[tuple[str, StrDict]]) -> dict[str, StrDict
     compatible values, and raises otherwise.
     Compatible here means equal (by comparison) among values which are set. For a value
     which may appear multiple times is allowed to be unset some of them, in which case
-    is implicitly set by the other occurences (as opposed to be compatible with its
+    is implicitly set by the other occurrences (as opposed to be compatible with its
     reset value).
     """
 

--- a/src/qibolab/_core/instruments/qblox/sequence/waveforms.py
+++ b/src/qibolab/_core/instruments/qblox/sequence/waveforms.py
@@ -2,6 +2,7 @@ from collections.abc import Iterable, Sequence
 from typing import Annotated, Union, cast
 
 import numpy as np
+import numpy.typing as npt
 from pydantic import UUID4, AfterValidator
 
 from qibolab._core.pulses import Pulse, PulseId, PulseLike, Readout
@@ -72,9 +73,9 @@ def _waveform(
     )
 
 
-def _deduplicate(
+def _deduplicate_pulses(
     pulses: Sequence[Pulse],
-) -> tuple[list[Pulse], list[int]]:
+) -> tuple[list[Pulse], npt.NDArray[np.intp]]:
     """Deduplicate non-swept pulses based on waveform-determining fields.
 
     The reason swept pulses are not deduplicated is that they are swept over duration so
@@ -87,21 +88,53 @@ def _deduplicate(
     uploaded waveform samples since it is handled via ``set_ph_delta`` in the Q1ASM
     program.
 
-    Args:
-        pulses: A sequence of Pulse objects to deduplicate.
-
     Returns:
         A tuple containing:
             - list[Pulse]: A list of unique pulses in order of first appearance.
-            - list[int]: A list of indices mapping each original pulse to its
-              corresponding index in the deduplicated list.
+            - npt.NDArray[np.intp]: Array of indices mapping each original pulse
+              to its corresponding index in the deduplicated list.
     """
     hashes = np.array([(p.duration, p.amplitude, hash(p.envelope)) for p in pulses])
     _, unique_idx, inverse_idx = np.unique(
         hashes, axis=0, return_index=True, return_inverse=True
     )
     unique_pulses = np.array(pulses)[unique_idx]
-    return list(unique_pulses), inverse_idx.tolist()
+    return list(unique_pulses), inverse_idx
+
+
+def _deduplicate_waveforms(
+    waveforms: dict[WaveformIndex, WaveformSpec],
+) -> tuple[dict[WaveformIndex, WaveformSpec], dict[WaveformIndex, WaveformIndex]]:
+    """Deduplicate waveforms by sampled waveform arrays.
+
+    Returns:
+        A tuple containing:
+            - dict[WaveformIndex, WaveformSpec]: The unique waveforms re-indexed from 0
+              in order of first appearance.
+            - dict[WaveformIndex, WaveformIndex]: Mapping from each original waveform
+              index to its deduplicated waveform index.
+    """
+
+    waveforms_ = list(waveforms.values())
+    waveform_arrays = np.array([waveform.waveform.data for waveform in waveforms_])
+    _, unique_idx, inverse_idx = np.unique(
+        waveform_arrays, axis=0, return_index=True, return_inverse=True
+    )
+
+    deduplicated = {
+        new_index: waveforms_[orig_index].model_copy(
+            update={
+                "waveform": waveforms_[orig_index].waveform.model_copy(
+                    update={"index": new_index}
+                )
+            }
+        )
+        for new_index, orig_index in enumerate(unique_idx)
+    }
+
+    orig_to_deduplicated_index = dict(zip(waveforms, inverse_idx))
+
+    return deduplicated, orig_to_deduplicated_index
 
 
 def waveforms(
@@ -123,7 +156,7 @@ def waveforms(
         if isinstance(p, (Pulse, Readout))
     ]
 
-    unique_pulses, inverse_idx = _deduplicate(pulses_not_swept)
+    unique_pulses, inverse_idx = _deduplicate_pulses(pulses_not_swept)
 
     # the ids for the swept pulses start counting from `static` since up to here we need
     # two indices (i and q) for each unique non-swept pulse
@@ -152,18 +185,23 @@ def waveforms(
         for ch, comp in enumerate(("i", "q"))
     }
 
+    deduplicated_waveforms, orig_to_deduplicated = _deduplicate_waveforms(waveforms)
+
     # mapping that associate each element in the full list of pulses identified by
     # (UUID, i or q) to an integer that can be associated with a WaveformSpec through
     # waveforms
     indices_map: WaveformIndices = {  # non-swept
-        (pulse.id, ch): (inv * 2 + ch, int(pulse.duration))
+        (pulse.id, ch): (int(orig_to_deduplicated[inv * 2 + ch]), int(pulse.duration))
         for inv, pulse in zip(inverse_idx, pulses_not_swept)
         for ch, _ in enumerate(("i", "q"))
     } | {  # swept
-        (pulse.id, 2 * i + ch): (static + 2 * k + ch, int(duration))
+        (pulse.id, 2 * i + ch): (
+            int(orig_to_deduplicated[static + 2 * k + ch]),
+            int(duration),
+        )
         for k, (pulse, sweep) in enumerate(pulses_swept)
         for i, duration in enumerate(np.arange(*sweep.irange))
         for ch, _ in enumerate(("i", "q"))
     }
 
-    return waveforms, indices_map
+    return deduplicated_waveforms, indices_map

--- a/src/qibolab/_core/instruments/qblox/sequence/waveforms.py
+++ b/src/qibolab/_core/instruments/qblox/sequence/waveforms.py
@@ -90,9 +90,9 @@ def _deduplicate_pulses(
 
     Returns:
         A tuple containing:
-            - list[Pulse]: A list of unique pulses in order of first appearance.
-            - npt.NDArray[np.int_]: Array of indices mapping each original pulse
-              to its corresponding index in the deduplicated list.
+            - list[Pulse]: A list of unique pulses.
+            - npt.NDArray[np.int_]: Array of indices mapping each original pulse to its
+              corresponding index in the deduplicated list.
     """
     hashes = np.array([(p.duration, p.amplitude, hash(p.envelope)) for p in pulses])
     _, unique_idx, inverse_idx = np.unique(
@@ -109,8 +109,7 @@ def _deduplicate_waveforms(
 
     Returns:
         A tuple containing:
-            - dict[WaveformIndex, WaveformSpec]: The unique waveforms re-indexed from 0
-              in order of first appearance.
+            - dict[WaveformIndex, WaveformSpec]: The unique waveforms re-indexed from 0.
             - dict[WaveformIndex, WaveformIndex]: Mapping from each original waveform
               index to its deduplicated waveform index.
     """

--- a/src/qibolab/_core/instruments/qblox/sequence/waveforms.py
+++ b/src/qibolab/_core/instruments/qblox/sequence/waveforms.py
@@ -143,13 +143,23 @@ def waveforms(
     amplitude_swept: set[PulseId],
     duration_swept: dict[PulseLike, Sweeper],
 ) -> tuple[dict[WaveformIndex, WaveformSpec], WaveformIndices]:
-    pulses = [
-        _pulse(e, e.id in amplitude_swept)
-        for e in sequence
-        if isinstance(e, (Pulse, Readout))
-    ]
+    """Build the waveform memory map and pulse-component index map for a sequence.
 
-    pulses_not_swept = [p for p in pulses if p not in duration_swept]
+    1. Split pulses into non-swept and duration-swept groups. Amplitude-swept pulses
+       have their amplitude reset to 1 so the sequencer scales them at runtime.
+    2. Deduplicate non-swept pulses structurally (by duration, amplitude, and envelope
+       hash) to avoid uploading identical waveforms for repeated pulses.
+    3. Sample waveforms: each unique pulse produces two entries (I, Q);
+    4. Deduplicate the sampled arrays a second time. This is mainly to catch cases where
+       unique envelopes share the same, non-unique, I or Q component.
+    5. Construct ``indices_map`` mapping ``(pulse UUID, quadrature)`` to the final
+       deduplicated memory index and the corresponding duration.
+    """
+    pulses_not_swept = [
+        _pulse(p, p.id in amplitude_swept)
+        for p in sequence
+        if isinstance(p, (Pulse, Readout)) and p not in duration_swept
+    ]
     pulses_swept = [
         (_pulse(p, p.id in amplitude_swept), duration_swept[p])
         for p in duration_swept

--- a/src/qibolab/_core/instruments/qblox/sequence/waveforms.py
+++ b/src/qibolab/_core/instruments/qblox/sequence/waveforms.py
@@ -185,6 +185,9 @@ def waveforms(
         for ch, comp in enumerate(("i", "q"))
     }
 
+    # perform deduplication of waveforms based on their sampled arrays, this is
+    # necessary _deduplicate_pulses only deduplicates non-unique Pulses, but not
+    # non-unique I and Q components.
     deduplicated_waveforms, orig_to_deduplicated = _deduplicate_waveforms(waveforms)
 
     # mapping that associate each element in the full list of pulses identified by

--- a/src/qibolab/_core/instruments/qblox/sequence/waveforms.py
+++ b/src/qibolab/_core/instruments/qblox/sequence/waveforms.py
@@ -75,7 +75,7 @@ def _waveform(
 
 def _deduplicate_pulses(
     pulses: Sequence[Pulse],
-) -> tuple[list[Pulse], npt.NDArray[np.intp]]:
+) -> tuple[list[Pulse], npt.NDArray[np.int_]]:
     """Deduplicate non-swept pulses based on waveform-determining fields.
 
     The reason swept pulses are not deduplicated is that they are swept over duration so
@@ -91,7 +91,7 @@ def _deduplicate_pulses(
     Returns:
         A tuple containing:
             - list[Pulse]: A list of unique pulses in order of first appearance.
-            - npt.NDArray[np.intp]: Array of indices mapping each original pulse
+            - npt.NDArray[np.int_]: Array of indices mapping each original pulse
               to its corresponding index in the deduplicated list.
     """
     hashes = np.array([(p.duration, p.amplitude, hash(p.envelope)) for p in pulses])

--- a/src/qibolab/_core/instruments/qblox/sequence/waveforms.py
+++ b/src/qibolab/_core/instruments/qblox/sequence/waveforms.py
@@ -2,7 +2,6 @@ from collections.abc import Iterable, Sequence
 from typing import Annotated, Union, cast
 
 import numpy as np
-import numpy.typing as npt
 from pydantic import UUID4, AfterValidator
 
 from qibolab._core.pulses import Pulse, PulseId, PulseLike, Readout
@@ -75,13 +74,18 @@ def _waveform(
 
 def _deduplicate(
     pulses: Sequence[Pulse],
-) -> tuple[list[Pulse], npt.NDArray[np.int_]]:
-    """Deduplicate non-swept pulses
+) -> tuple[list[Pulse], list[int]]:
+    """Deduplicate non-swept pulses based on waveform-determining fields.
 
     The reason swept pulses are not deduplicated is that they are swept over duration so
     there will be no duplicates. It is still possible that a swept pulse is the same as
     a non-swept pulse but this is not a prominent enough use-case to justify accounting
     for it.
+
+    Deduplication is based on (duration, amplitude, envelope) only. The
+    ``relative_phase`` field is intentionally excluded because it does not affect the
+    uploaded waveform samples since it is handled via ``set_ph_delta`` in the Q1ASM
+    program.
 
     Args:
         pulses: A sequence of Pulse objects to deduplicate.
@@ -89,15 +93,15 @@ def _deduplicate(
     Returns:
         A tuple containing:
             - list[Pulse]: A list of unique pulses in order of first appearance.
-            - npt.NDArray[np.int_]: An array of indices mapping each original pulse to
-              its corresponding index in the deduplicated list.
+            - list[int]: A list of indices mapping each original pulse to its
+              corresponding index in the deduplicated list.
     """
-    hashes = np.array([hash(p) for p in pulses])
+    hashes = np.array([(p.duration, p.amplitude, hash(p.envelope)) for p in pulses])
     _, unique_idx, inverse_idx = np.unique(
-        hashes, return_index=True, return_inverse=True
+        hashes, axis=0, return_index=True, return_inverse=True
     )
     unique_pulses = np.array(pulses)[unique_idx]
-    return list(unique_pulses), inverse_idx
+    return list(unique_pulses), inverse_idx.tolist()
 
 
 def waveforms(
@@ -126,7 +130,7 @@ def waveforms(
     static = 2 * len(unique_pulses)
 
     # mapping from integer to unique WaveformSpec
-    waveform_specs: dict[int, WaveformSpec] = {  # non-swept
+    waveforms: dict[int, WaveformSpec] = {  # non-swept
         2 * k + ch: _waveform(
             pulse,
             comp,
@@ -150,7 +154,7 @@ def waveforms(
 
     # mapping that associate each element in the full list of pulses identified by
     # (UUID, i or q) to an integer that can be associated with a WaveformSpec through
-    # waveform_specs
+    # waveforms
     indices_map: WaveformIndices = {  # non-swept
         (pulse.id, ch): (inv * 2 + ch, int(pulse.duration))
         for inv, pulse in zip(inverse_idx, pulses_not_swept)
@@ -162,4 +166,4 @@ def waveforms(
         for ch, _ in enumerate(("i", "q"))
     }
 
-    return waveform_specs, indices_map
+    return waveforms, indices_map

--- a/tests/qblox/test_waveforms.py
+++ b/tests/qblox/test_waveforms.py
@@ -1,0 +1,41 @@
+import numpy as np
+
+from qibolab._core.instruments.qblox.sequence.waveforms import waveforms
+from qibolab._core.pulses import Custom, Pulse
+
+
+def test_waveforms_deduplicate_equal_components_across_distinct_iq_pairs():
+    pulse_a = Pulse(
+        duration=4,
+        amplitude=1.0,
+        envelope=Custom(
+            i_=np.array([0.0, 0.2, 0.2, 0.0]),
+            q_=np.array([0.0, 0.1, -0.1, 0.0]),
+        ),
+    )
+    pulse_b = Pulse(
+        duration=4,
+        amplitude=1.0,
+        envelope=Custom(
+            i_=np.array([0.0, 0.2, 0.2, 0.0]),
+            q_=np.array([0.0, -0.2, 0.2, 0.0]),
+        ),
+    )
+
+    waveform_specs, indices_map = waveforms(
+        sequence=[pulse_a, pulse_b],
+        sampling_rate=1.0,
+        amplitude_swept=set(),
+        duration_swept={},
+    )
+
+    # Two unique Q components plus one shared I component.
+    assert len(waveform_specs) == 3
+
+    i_a_index, _ = indices_map[(pulse_a.id, 0)]
+    i_b_index, _ = indices_map[(pulse_b.id, 0)]
+    q_a_index, _ = indices_map[(pulse_a.id, 1)]
+    q_b_index, _ = indices_map[(pulse_b.id, 1)]
+
+    assert i_a_index == i_b_index
+    assert q_a_index != q_b_index != i_a_index


### PR DESCRIPTION
This PR makes two changes to deduplication of waveforms: the first at the level of Pulse and the second at the level of the level of the waveforms themselves.

- Deduplication is based on (duration, amplitude, envelope) only. The relative_phase field is intentionally excluded because it does not affect the uploaded waveform samples since it is handled via set_ph_delta in the Q1ASM program.

- deduplicate also at the level of sampled waveforms to account for the fact that two different pulse envelopes may share the same I or Q waveform. 

Tested in both drag_simple (where deduplication acutally does something) and allxy (which is a bit more precise test that nothing was broken)