### PR TITLE
fixing bug in _deduplicate_waveforms

### DIFF
--- a/src/qibolab/_core/instruments/qblox/sequence/waveforms.py
+++ b/src/qibolab/_core/instruments/qblox/sequence/waveforms.py
@@ -115,9 +115,11 @@ def _deduplicate_waveforms(
     """
 
     waveforms_ = list(waveforms.values())
-    waveform_arrays = np.array([waveform.waveform.data for waveform in waveforms_])
+    waveform_arrays = np.array(
+        [waveform.waveform.data.tobytes() for waveform in waveforms_]
+    )
     _, unique_idx, inverse_idx = np.unique(
-        waveform_arrays, axis=0, return_index=True, return_inverse=True
+        waveform_arrays, return_index=True, return_inverse=True
     )
 
     deduplicated = {

--- a/tests/qblox/test_waveforms.py
+++ b/tests/qblox/test_waveforms.py
@@ -67,7 +67,7 @@ def test_waveforms_deduplicate_across_distinct_lengths():
         duration_swept={},
     )
 
-    # ThrTwoee unique Q components plus two unique I components.
+    # Two unique Q components plus two unique I components.
     assert len(waveform_specs) == 4
 
     i_a_index, _ = indices_map[(pulse_a.id, 0)]

--- a/tests/qblox/test_waveforms.py
+++ b/tests/qblox/test_waveforms.py
@@ -41,7 +41,7 @@ def test_waveforms_deduplicate_equal_components_across_distinct_iq_pairs():
     assert q_a_index != q_b_index != i_a_index
 
 
-def test_waveforms_deduplicate_equal_components_across_distinct_length():
+def test_waveforms_deduplicate_across_distinct_lengths():
     pulse_a = Pulse(
         duration=6,
         amplitude=1.0,

--- a/tests/qblox/test_waveforms.py
+++ b/tests/qblox/test_waveforms.py
@@ -39,3 +39,40 @@ def test_waveforms_deduplicate_equal_components_across_distinct_iq_pairs():
 
     assert i_a_index == i_b_index
     assert q_a_index != q_b_index != i_a_index
+
+
+def test_waveforms_deduplicate_equal_components_across_distinct_length():
+    pulse_a = Pulse(
+        duration=6,
+        amplitude=1.0,
+        envelope=Custom(
+            i_=np.array([0.0, 0.2, 0.2, 0.0, 0.1, 0.1]),
+            q_=np.array([0.0, 0.1, -0.1, 0.0, 0.1, -0.1]),
+        ),
+    )
+
+    pulse_b = Pulse(
+        duration=4,
+        amplitude=1.0,
+        envelope=Custom(
+            i_=np.array([0.0, 0.2, 0.2, 0.0]),
+            q_=np.array([0.0, -0.2, 0.2, 0.0]),
+        ),
+    )
+
+    waveform_specs, indices_map = waveforms(
+        sequence=[pulse_a, pulse_b],
+        sampling_rate=1.0,
+        amplitude_swept=set(),
+        duration_swept={},
+    )
+
+    # ThrTwoee unique Q components plus two unique I components.
+    assert len(waveform_specs) == 4
+
+    i_a_index, _ = indices_map[(pulse_a.id, 0)]
+    i_b_index, _ = indices_map[(pulse_b.id, 0)]
+    q_a_index, _ = indices_map[(pulse_a.id, 1)]
+    q_b_index, _ = indices_map[(pulse_b.id, 1)]
+
+    assert q_a_index != q_b_index != i_a_index != i_b_index


### PR DESCRIPTION
This small PR fixes a bug introduced in PR #1426. That PR assumes that all waveforms in the function have the same length. However, when running Hamiltonian Tomography in [qibocal CR](https://github.com/qiboteam/qibocal/pull/1414), we found that this assumption no longer holds.

To address this, we introduced a more flexible solution: each waveform is first cast to a byte string, and then `np.unique` is applied.
This allows us to correctly handle waveforms with different lengths.

