### PR TITLE
Include `time_of_flight` in `Readout` duration 

### DIFF
--- a/src/qibolab/_core/instruments/emulator/results.py
+++ b/src/qibolab/_core/instruments/emulator/results.py
@@ -9,7 +9,7 @@ from ...execution_parameters import (
     ExecutionParameters,
 )
 from ...identifier import ChannelId, QubitId, Result
-from ...pulses import Acquisition, PulseId, Readout
+from ...pulses import Acquisition, Align, PulseId, Readout
 from ...sequence import PulseSequence
 from .engine import Operator
 from .hamiltonians import HamiltonianConfig
@@ -69,11 +69,13 @@ def calculate_probabilities_from_density_matrix(
 def acquisitions(sequence: PulseSequence) -> dict[PulseId, float]:
     """Compute acquisitions' times."""
     acq = {}
-    for ch in sequence.channels:
+    sequence_ = sequence.align_to_delays()
+    for ch in sequence_.channels:
         time = 0
-        for ev in sequence.channel(ch):
+        for ev in sequence_.channel(ch):
             if isinstance(ev, (Acquisition, Readout)):
                 acq[ev.id] = time
+            assert not isinstance(ev, Align)
             time += ev.duration
 
     return acq

--- a/src/qibolab/_core/instruments/emulator/results.py
+++ b/src/qibolab/_core/instruments/emulator/results.py
@@ -69,10 +69,9 @@ def calculate_probabilities_from_density_matrix(
 def acquisitions(sequence: PulseSequence) -> dict[PulseId, float]:
     """Compute acquisitions' times."""
     acq = {}
-    sequence_ = sequence.align_to_delays()
-    for ch in sequence_.channels:
+    for ch in sequence.channels:
         time = 0
-        for ev in sequence_.channel(ch):
+        for ev in sequence.channel(ch):
             if isinstance(ev, (Acquisition, Readout)):
                 acq[ev.id] = time
             assert not isinstance(ev, Align)

--- a/src/qibolab/_core/instruments/qblox/cluster.py
+++ b/src/qibolab/_core/instruments/qblox/cluster.py
@@ -16,7 +16,7 @@ from qibolab._core.execution_parameters import (
 )
 from qibolab._core.identifier import ChannelId, Result
 from qibolab._core.instruments.abstract import Controller
-from qibolab._core.pulses.pulse import PulseId
+from qibolab._core.pulses.pulse import PulseId, Readout
 from qibolab._core.sequence import PulseSequence
 from qibolab._core.serialize import Model
 from qibolab._core.sweeper import ParallelSweepers, normalize_sweepers
@@ -26,7 +26,7 @@ from .batching import batch_sequences_by_cluster_memory_limits
 from .config import PortAddress
 from .identifiers import SequencerMap, SlotId
 from .log import Logger
-from .results import AcquiredData, extract, integration_lenghts
+from .results import AcquiredData, extract, integration_lengths
 from .sequence import Q1Sequence, compile
 from .utils import (
     batch_shots,
@@ -71,6 +71,43 @@ def _compute_duration(
         [ps], sweepers, time_of_flight + wait_sync_duration
     )
     return duration
+
+
+def _add_time_of_flight(sequence: PulseSequence, configs: Configs) -> PulseSequence:
+    time_of_flights_ = time_of_flights(configs)
+    return PulseSequence(
+        [
+            (
+                ch,
+                ev
+                if not isinstance(ev, Readout)
+                else ev.model_copy(update={"time_of_flight": time_of_flights_[ch]}),
+            )
+            for ch, ev in sequence
+        ]
+    )
+
+
+def _batch_sequences(
+    sequences: list[PulseSequence],
+    sweepers: list[ParallelSweepers],
+    options: ExecutionParameters,
+    qcm_channels: set[ChannelId],
+    qrm_channels: set[ChannelId],
+    configs: Configs,
+) -> list[PulseSequence]:
+    batched_seqs = (
+        batch_sequences_by_cluster_memory_limits(
+            sequences,
+            sweepers,
+            options,
+            qcm_channels,
+            qrm_channels,
+        )
+        if options.averaging_mode.average
+        else sequences
+    )
+    return [_add_time_of_flight(b, configs).align_to_delays() for b in batched_seqs]
 
 
 class ClusterConfigs(Model):
@@ -153,16 +190,8 @@ class Cluster(Controller):
             if PortAddress.from_path(channelobj.path).slot in qrm_slots
         }
         qcm_channels = set(self.channels) - qrm_channels
-        batched_seqs: list[PulseSequence] = (
-            batch_sequences_by_cluster_memory_limits(
-                sequences,
-                sweepers,
-                options,
-                qcm_channels,
-                qrm_channels,
-            )
-            if options.averaging_mode.average
-            else sequences
+        batched_seqs = _batch_sequences(
+            sequences, sweepers, options, qcm_channels, qrm_channels, configs
         )
 
         # Execute each batch sequentially, and concatenate results
@@ -193,7 +222,6 @@ class Cluster(Controller):
                     sweepers_,
                     options_,
                     self.sampling_rate,
-                    time_of_flights(configs),
                 )
                 for channelid, seq in sequences_.items():
                     slot = PortAddress.from_path(self.channels[channelid].path).slot
@@ -215,7 +243,7 @@ class Cluster(Controller):
                 log.data(data)
 
                 # process raw results to adhere to standard format
-                lengths = integration_lenghts(sequences_, sequencers, self._modules)
+                lengths = integration_lengths(sequences_, sequencers, self._modules)
                 psres.append(
                     extract(
                         data,

--- a/src/qibolab/_core/instruments/qblox/results.py
+++ b/src/qibolab/_core/instruments/qblox/results.py
@@ -26,7 +26,7 @@ def _fill_empty_lenghts(
     }
 
 
-def integration_lenghts(
+def integration_lengths(
     sequences: dict[ChannelId, Q1Sequence],
     sequencers: SequencerMap,
     modules: dict[SlotId, Module],

--- a/src/qibolab/_core/instruments/qblox/sequence/experiment.py
+++ b/src/qibolab/_core/instruments/qblox/sequence/experiment.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from qibolab._core.pulses.pulse import (
     Acquisition,
     Align,
@@ -62,7 +60,6 @@ def play(
     parpulse: ParameterizedPulse,
     waveforms: WaveformIndices,
     acquisitions: dict[MeasureId, AcquisitionSpec],
-    time_of_flight: Optional[float],
 ) -> Block:
     """Process the individual pulse in experiment."""
     pulse = parpulse[0]
@@ -118,13 +115,14 @@ def play(
         raise NotImplementedError("Align operation not yet supported by Qblox.")
     if isinstance(pulse, Readout):
         acq = acquisitions[pulse.id]
-        delay = int(time_of_flight) if time_of_flight is not None else 4
         return [
-            play_pulse(pulse.probe, waveforms).update({"duration": delay}),
+            play_pulse(pulse.probe, waveforms).update(
+                {"duration": int(pulse.time_of_flight)}
+            ),
             Acquire(
                 acquisition=acq.acquisition.index,
                 bin=Registers.bin.value,
-                duration=int(pulse.duration),
+                duration=int(pulse.acquisition.duration),
             ),
         ]
     raise NotImplementedError(f"Instruction {type(pulse)} unsupported by Qblox driver.")
@@ -134,14 +132,13 @@ def event(
     parpulse: ParameterizedPulse,
     waveforms: WaveformIndices,
     acquisitions: dict[MeasureId, AcquisitionSpec],
-    time_of_flight: Optional[float],
 ) -> Block:
     params = parpulse[1]
     return [
         inst
         for block in (
             *(update_instructions(p.role, p.reg) for p in params),
-            *(play(parpulse, waveforms, acquisitions, time_of_flight),),
+            *(play(parpulse, waveforms, acquisitions),),
             *(reset_instructions(p.role, p.reg) for p in reversed(list(params))),
         )
         for inst in block
@@ -152,7 +149,6 @@ def experiment(
     sequence: SweepSequence,
     waveforms: WaveformIndices,
     acquisitions: dict[MeasureId, AcquisitionSpec],
-    time_of_flight: Optional[float],
 ) -> Block:
     """Representation of the actual experiment to be executed.
 
@@ -166,8 +162,6 @@ def experiment(
     """
     return [UpdParam(duration=4), WaitSync(duration=4)] + [
         inst
-        for block in (
-            event(pulse, waveforms, acquisitions, time_of_flight) for pulse in sequence
-        )
+        for block in (event(pulse, waveforms, acquisitions) for pulse in sequence)
         for inst in block
     ]

--- a/src/qibolab/_core/instruments/qblox/sequence/program.py
+++ b/src/qibolab/_core/instruments/qblox/sequence/program.py
@@ -1,5 +1,4 @@
 from collections.abc import Iterable, Sequence
-from typing import Optional
 
 from qibolab._core.execution_parameters import AveragingMode, ExecutionParameters
 from qibolab._core.identifier import ChannelId
@@ -97,7 +96,6 @@ def program(
     options: ExecutionParameters,
     sweepers: list[ParallelSweepers],
     channel: set[ChannelId],
-    time_of_flight: Optional[float],
     padding: int,
 ) -> Program:
     """Generate sequencer program."""
@@ -115,7 +113,7 @@ def program(
         sequence, [p for v in indexed_params.values() for p in v.pulse]
     )
     experiment_ = [
-        *experiment(sweepseq, waveforms, acquisitions, time_of_flight),
+        *experiment(sweepseq, waveforms, acquisitions),
         # Enforce a minimum wait of 4 ns corresponding to one clock cycle
         Wait(duration=min(padding, 4)),
     ]

--- a/src/qibolab/_core/instruments/qblox/sequence/sequence.py
+++ b/src/qibolab/_core/instruments/qblox/sequence/sequence.py
@@ -72,7 +72,6 @@ class Q1Sequence(Model):
         options: ExecutionParameters,
         sampling_rate: float,
         channel: set[ChannelId],
-        time_of_flight: Optional[float],
         duration: float,
     ) -> "Q1Sequence":
         padding = (
@@ -106,7 +105,6 @@ class Q1Sequence(Model):
                 options,
                 sweepers,
                 channel,
-                time_of_flight,
                 int(padding),
             ),
         )
@@ -153,7 +151,6 @@ def compile(
     sweepers: list[ParallelSweepers],
     options: ExecutionParameters,
     sampling_rate: float,
-    time_of_flights: dict[ChannelId, float],
 ) -> dict[ChannelId, Q1Sequence]:
     duration = sequence.duration
     sweeper_channels = {ch: [] for ch in swept_channels(sweepers)}
@@ -164,7 +161,6 @@ def compile(
             options,
             sampling_rate,
             _effective_channels(ch, seq),
-            time_of_flights.get(ch),
             duration,
         )
         for ch, seq in (sweeper_channels | sequence.by_channel).items()

--- a/src/qibolab/_core/pulses/pulse.py
+++ b/src/qibolab/_core/pulses/pulse.py
@@ -149,6 +149,7 @@ class Readout(_PulseLike):
 
     acquisition: Acquisition
     probe: Pulse
+    time_of_flight: float = 0.0
 
     @classmethod
     def from_probe(cls, probe: Pulse):
@@ -161,7 +162,7 @@ class Readout(_PulseLike):
     @property
     def duration(self) -> float:
         """Duration in ns."""
-        return self.acquisition.duration
+        return self.acquisition.duration + self.time_of_flight
 
     @property
     def id(self) -> PulseId:

--- a/src/qibolab/_core/sequence.py
+++ b/src/qibolab/_core/sequence.py
@@ -140,6 +140,11 @@ class PulseSequence(UserList[_Element]):
             - ``other``
 
         Guarantee simultaneous start and no overlap.
+
+        .. deprecated:: 0.3.0
+            This is deprecated since 0.2.14. Use align_to_delays instead.
+
+
         """
         _synchronize(self, PulseSequence(other).channels | self.channels)
         self.extend(other)
@@ -149,7 +154,8 @@ class PulseSequence(UserList[_Element]):
 
         Alias to :meth:`concatenate`.
         """
-        self.juxtapose(other)
+        self.align(self.channels)
+        self.extend(other)
         return self
 
     def __or__(self, other: Iterable[_Element]) -> "PulseSequence":
@@ -163,7 +169,7 @@ class PulseSequence(UserList[_Element]):
         copy |= other
         return copy
 
-    def align(self, channels: list[ChannelId]) -> Align:
+    def align(self, channels: Iterable[ChannelId]) -> Align:
         """Introduce align commands to the sequence."""
         align = Align()
         for channel in channels:

--- a/src/qibolab/_core/sequence.py
+++ b/src/qibolab/_core/sequence.py
@@ -85,11 +85,7 @@ class PulseSequence(UserList[_Element]):
 
     def channel_duration(self, channel: ChannelId) -> float:
         """Duration of the given channel."""
-        sequence = (
-            self.align_to_delays()
-            if any(isinstance(pulse, Align) for _, pulse in self)
-            else self
-        )
+        sequence = self.align_to_delays()
         return sum(pulse.duration for pulse in sequence.channel(channel))
 
     def pulse_channels(self, pulse_id: PulseId) -> list[ChannelId]:
@@ -150,20 +146,16 @@ class PulseSequence(UserList[_Element]):
         self.extend(other)
 
     def __ior__(self, other: Iterable[_Element]) -> "PulseSequence":
-        """Juxtapose two sequences.
-
-        Alias to :meth:`concatenate`.
-        """
-        self.align(self.channels)
+        """Pipe two sequences. ``other'' starts after ``self`` ends."""
+        other_channels = PulseSequence(other).channels
+        self.align(self.channels | other_channels)
         self.extend(other)
         return self
 
     def __or__(self, other: Iterable[_Element]) -> "PulseSequence":
-        """Juxtapose two sequences.
+        """Pipe two sequences.
 
         A copy is made, and no input is altered.
-
-        Other than that, it is based on :meth:`concatenate`.
         """
         copy = self.copy()
         copy |= other

--- a/tests/instruments/emulator/test_results.py
+++ b/tests/instruments/emulator/test_results.py
@@ -145,7 +145,7 @@ def test_apply_to_last_two_axes():
     assert pytest.approx(a) == b
 
 
-def test_resultz():
+def test_results():
     densities = random_states((2,) * 2, (3, 2))
     sequence = PulseSequence(
         [("0/drive", Pulse(duration=20, amplitude=0.8, envelope=Rectangular()))]

--- a/tests/instruments/emulator/test_results.py
+++ b/tests/instruments/emulator/test_results.py
@@ -153,15 +153,16 @@ def test_results():
     hamiltonian = HamiltonianConfig(qubits={q: Qubit() for q in range(2)})
     options = ExecutionParameters(nshots=1000)
 
+    sequence_ = sequence.align_to_delays()
     fres = former_results(
         states=densities,
-        sequence=sequence,
+        sequence=sequence_,
         hamiltonian=hamiltonian,
         options=options,
     )
     res = results(
         states=densities,
-        sequence=sequence,
+        sequence=sequence_,
         hamiltonian=hamiltonian,
         options=options,
     )

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -222,7 +222,8 @@ def test_pipe():
     # |= inserts an Align marker before appending other
     s1_ior = deepcopy(s1)
     s1_ior |= s2
-    assert any(isinstance(p, Align) for _, p in s1_ior)
+    assert isinstance(list(s1_ior.channel("ch1"))[1], Align)
+    assert isinstance(list(s1_ior.channel("ch2"))[0], Align)
     compiled = s1_ior.align_to_delays()
     assert not any(isinstance(p, Align) for _, p in compiled)
     assert compiled.channels == {"ch1", "ch2"}

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -4,6 +4,7 @@ from pydantic import TypeAdapter
 
 from qibolab._core.pulses import (
     Acquisition,
+    Align,
     Delay,
     Drag,
     Gaussian,
@@ -211,13 +212,42 @@ def test_juxtapose():
         assert channel == target_channels[i]
         assert isinstance(pulse, target_pulse_types[i])
 
-    # Check aliases
-    sa1 = deepcopy(s1)
-    sc1 = deepcopy(s1)
-    sa1 |= s2
-    sc1.juxtapose(s2)
-    assert sa1 == sc1
-    assert sc1 == s1 | s2
+
+def test_pipe():
+    p1 = Pulse(duration=40, amplitude=0.9, envelope=Drag(rel_sigma=0.2, beta=1))
+    s1 = PulseSequence([("ch1", p1)])
+    p2 = Pulse(duration=60, amplitude=0.9, envelope=Drag(rel_sigma=0.2, beta=1))
+    s2 = PulseSequence([("ch2", p2)])
+
+    # |= inserts an Align marker before appending other
+    s1_ior = deepcopy(s1)
+    s1_ior |= s2
+    assert any(isinstance(p, Align) for _, p in s1_ior)
+    compiled = s1_ior.align_to_delays()
+    assert not any(isinstance(p, Align) for _, p in compiled)
+    assert compiled.channels == {"ch1", "ch2"}
+    assert compiled.channel_duration("ch1") == 40
+    assert compiled.channel_duration("ch2") == 100
+    assert compiled.duration == 100
+
+    # | does not modify the original
+    s1_or = s1 | s2
+    assert s1 == PulseSequence([("ch1", p1)])
+    assert s1_or.align_to_delays() == compiled
+
+    # with shared channels: all ``self'' channels are synced before appending ``other''
+    p3 = Pulse(duration=20, amplitude=0.9, envelope=Drag(rel_sigma=0.2, beta=1))
+    p4 = Pulse(duration=80, amplitude=0.9, envelope=Drag(rel_sigma=0.2, beta=1))
+    p5 = Pulse(duration=50, amplitude=0.9, envelope=Drag(rel_sigma=0.2, beta=1))
+    p6 = Pulse(duration=30, amplitude=0.9, envelope=Drag(rel_sigma=0.2, beta=1))
+    s3 = PulseSequence([("ch1", p3), ("ch2", p4)])
+    s4 = PulseSequence([("ch1", p5), ("ch2", p6)])
+    s3 |= s4
+    compiled2 = s3.align_to_delays()
+    # ch1: 20 + Delay(60) + 50 = 130, ch2: 80 + 30 = 110
+    assert compiled2.channel_duration("ch1") == 20 + 60 + 50
+    assert compiled2.channel_duration("ch2") == 80 + 30
+    assert compiled2.duration == 130
 
 
 def test_copy():

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -228,8 +228,8 @@ def test_pipe():
     assert not any(isinstance(p, Align) for _, p in compiled)
     assert compiled.channels == {"ch1", "ch2"}
     assert compiled.channel_duration("ch1") == 40
-    assert compiled.channel_duration("ch2") == 100
-    assert compiled.duration == 100
+    assert compiled.channel_duration("ch2") == 40 + 60
+    assert compiled.duration == 40 + 60
 
     # | does not modify the original
     s1_or = s1 | s2
@@ -245,8 +245,7 @@ def test_pipe():
     s4 = PulseSequence([("ch1", p5), ("ch2", p6)])
     s3 |= s4
     compiled2 = s3.align_to_delays()
-    # ch1: 20 + Delay(60) + 50 = 130, ch2: 80 + 30 = 110
-    assert compiled2.channel_duration("ch1") == 20 + 60 + 50
+    assert compiled2.channel_duration("ch1") == 20 + 60 + 50  # 60 is from delay
     assert compiled2.channel_duration("ch2") == 80 + 30
     assert compiled2.duration == 130
 


### PR DESCRIPTION
When piping multiple sequences, the pipe operation considers the durations of the pulses played on each channel, and if they are not all the same, it appends delays to the shorter channels to ensure they all have an equal length. However, the time of flight was neglected in the determination of the duration of `Readout`. This means that the timings would be miscalculated and the mismatch would accumulate for each additional sequence.

In this PR we include a `time_of_flight` attribute in `Readout` and sum it to the duration of the acquisition pulse to obtain the total duration of the readout.

Because we may still wish to define a sequence before knowing the time of flight, we change the pipe operation `|=` of `PulseSequence` to use the symbolic `Align` as opposed to calculating an exact delay at the time of constructing the sequences. This way the time of flight can be updated later (the default value is 0.0), and the exact delays can be calculated by calling the `align_to_delays()` method. 

Finally, we introduce a test to test the new pipe behavior. 
