### PR TITLE
Workflow fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,9 @@ name: tests
 on:
   workflow_dispatch:
   push:
-  pull_request: # (opened, synchronize, reopened)
+    branches:
+      - main
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,12 +3,13 @@ name: tests
 on:
   workflow_dispatch:
   push:
-    branches:
-      - main
+  merge_group:
   pull_request:
+    types: [labeled, opened]
 
 jobs:
   build:
+    if: contains(github.event.pull_request.labels.*.name, 'run-workflow') || github.event_name == 'push'
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,7 @@ name: tests
 on:
   workflow_dispatch:
   push:
-  pull_request:
-    types: opened
+  pull_request: # (opened, synchronize, reopened)
 
 jobs:
   build:


### PR DESCRIPTION
This attempts to enable the "Approve and Run" button for external collaborators (which is supposed to work with a fork action settings I have just enabled). Now the action will run when pushes ocur in the branch (synchronize type), not just when opened.