### PR TITLE
remove updparams to avoid real-time delay

### DIFF
--- a/src/qibolab/_core/instruments/qblox/cluster.py
+++ b/src/qibolab/_core/instruments/qblox/cluster.py
@@ -19,7 +19,7 @@ from qibolab._core.instruments.abstract import Controller
 from qibolab._core.pulses.pulse import PulseId, Readout
 from qibolab._core.sequence import PulseSequence
 from qibolab._core.serialize import Model
-from qibolab._core.sweeper import ParallelSweepers, normalize_sweepers
+from qibolab._core.sweeper import ParallelSweepers, Parameter, normalize_sweepers
 
 from . import config
 from .batching import batch_sequences_by_cluster_memory_limits
@@ -178,6 +178,18 @@ class Cluster(Controller):
     ) -> dict[PulseId, Result]:
         """Execute the given experiment."""
 
+        # If there are no sweepers present, the phases can be summed to simplify
+        # the pulse sequences.
+        phase_sweeper_present = any(
+            sweeper.parameter in {Parameter.relative_phase, Parameter.phase}
+            for parallel_sweepers in sweepers
+            for sweeper in parallel_sweepers
+        )
+        processed_sequences = [
+            ps if phase_sweeper_present else ps.to_vzs().collect_vzs()
+            for ps in sequences
+        ]
+
         # If acquisition is cyclic (averaging over shots on hardware), we combine as
         # many sequences as possible in a single batch, according to the cluster
         # memory limits.
@@ -191,7 +203,7 @@ class Cluster(Controller):
         }
         qcm_channels = set(self.channels) - qrm_channels
         batched_seqs = _batch_sequences(
-            sequences, sweepers, options, qcm_channels, qrm_channels, configs
+            processed_sequences, sweepers, options, qcm_channels, qrm_channels, configs
         )
 
         # Execute each batch sequentially, and concatenate results
@@ -222,6 +234,7 @@ class Cluster(Controller):
                     sweepers_,
                     options_,
                     self.sampling_rate,
+                    merged_vzs=not phase_sweeper_present,
                 )
                 for channelid, seq in sequences_.items():
                     slot = PortAddress.from_path(self.channels[channelid].path).slot

--- a/src/qibolab/_core/instruments/qblox/cluster.py
+++ b/src/qibolab/_core/instruments/qblox/cluster.py
@@ -110,6 +110,27 @@ def _batch_sequences(
     return [_add_time_of_flight(b, configs).align_to_delays() for b in batched_seqs]
 
 
+def _merge_phases_if_no_phase_sweeper(
+    sweepers: list[ParallelSweepers],
+    sequences: list[PulseSequence],
+) -> tuple[list[PulseSequence], bool]:
+    """
+    Process pulse sequences based on the presence of phase sweepers.
+
+    If any sweeper in the provided list is a phase or relative_phase sweeper,
+    the sequences are returned unchanged. Otherwise, the phases in the sequences
+    are summed to simplify the pulse sequences.
+    """
+    phase_sweeper_present = any(
+        sweeper.parameter in {Parameter.relative_phase, Parameter.phase}
+        for parallel_sweepers in sweepers
+        for sweeper in parallel_sweepers
+    )
+    return [
+        ps if phase_sweeper_present else ps.to_vzs().collect_vzs() for ps in sequences
+    ], phase_sweeper_present
+
+
 class ClusterConfigs(Model):
     modules: dict[int, config.ModuleConfig]
     sequencers: dict[int, dict[int, config.SequencerConfig]]
@@ -178,17 +199,9 @@ class Cluster(Controller):
     ) -> dict[PulseId, Result]:
         """Execute the given experiment."""
 
-        # If there are no sweepers present, the phases can be summed to simplify
-        # the pulse sequences.
-        phase_sweeper_present = any(
-            sweeper.parameter in {Parameter.relative_phase, Parameter.phase}
-            for parallel_sweepers in sweepers
-            for sweeper in parallel_sweepers
+        processed_sequences, phase_sweeper_present = _merge_phases_if_no_phase_sweeper(
+            sweepers, sequences
         )
-        processed_sequences = [
-            ps if phase_sweeper_present else ps.to_vzs().collect_vzs()
-            for ps in sequences
-        ]
 
         # If acquisition is cyclic (averaging over shots on hardware), we combine as
         # many sequences as possible in a single batch, according to the cluster

--- a/src/qibolab/_core/instruments/qblox/sequence/asm.py
+++ b/src/qibolab/_core/instruments/qblox/sequence/asm.py
@@ -16,6 +16,7 @@ class Registers(Enum):
     bin_reset = Register(number=1)
     shots = Register(number=2)
     wait = Register(number=3)
+    phase = Register(number=4)
 
     @classmethod
     def first_available(cls) -> int:
@@ -38,7 +39,7 @@ MAX_PARAM = {
 }
 """Maximum range for parameters.
 
-Declared in https://docs.qblox.com/en/main/cluster/q1_sequence_processor.html#q1-instructions
+Declared in https://docs.qblox.com/en/v0.16.0/cluster/q1_sequence_processor.html#q1-instructions
 
 Ranges may be one-sided (just positive) or two-sided. This is accounted for in
 :func:`convert`.

--- a/src/qibolab/_core/instruments/qblox/sequence/asm.py
+++ b/src/qibolab/_core/instruments/qblox/sequence/asm.py
@@ -16,7 +16,7 @@ class Registers(Enum):
     bin_reset = Register(number=1)
     shots = Register(number=2)
     wait = Register(number=3)
-    phase = Register(number=4)
+    phase_delta = Register(number=4)
 
     @classmethod
     def first_available(cls) -> int:

--- a/src/qibolab/_core/instruments/qblox/sequence/experiment.py
+++ b/src/qibolab/_core/instruments/qblox/sequence/experiment.py
@@ -81,21 +81,21 @@ def play(
                 (
                     [
                         Add(
-                            a=Registers.phase.value,
+                            a=Registers.phase_delta.value,
                             b=phase,
-                            destination=Registers.phase.value,
+                            destination=Registers.phase_delta.value,
                         )
                     ]
                     if phase != 0
                     else []
                 )
-                + ([SetPhDelta(value=Registers.phase.value)])
+                + ([SetPhDelta(value=Registers.phase_delta.value)])
                 + (
                     [play_pulse(pulse, waveforms)]
                     if len(duration_sweep) == 0
                     else play_duration_swept(duration_sweep)
                 )
-                + ([Move(source=minus_phase, destination=Registers.phase.value)])
+                + ([Move(source=minus_phase, destination=Registers.phase_delta.value)])
             )
 
     if isinstance(pulse, Delay):
@@ -115,11 +115,11 @@ def play(
         else:
             return [
                 Add(
-                    a=Registers.phase.value,
+                    a=Registers.phase_delta.value,
                     b=int(convert(pulse.phase, Parameter.relative_phase))
                     if len(params) == 0
                     else next(iter(params)).reg,
-                    destination=Registers.phase.value,
+                    destination=Registers.phase_delta.value,
                 )
             ]
     if isinstance(pulse, Acquisition):

--- a/src/qibolab/_core/instruments/qblox/sequence/experiment.py
+++ b/src/qibolab/_core/instruments/qblox/sequence/experiment.py
@@ -25,6 +25,7 @@ from ..q1asm.ast_ import (
 from .acquisition import AcquisitionSpec, MeasureId
 from .asm import Registers, convert
 from .sweepers import (
+    Param,
     ParameterizedPulse,
     ParamRole,
     SweepSequence,
@@ -36,7 +37,7 @@ from .waveforms import WaveformIndices
 __all__ = []
 
 
-def play_pulse(pulse: Pulse, waveforms: WaveformIndices) -> Line:
+def _play_pulse(pulse: Pulse, waveforms: WaveformIndices) -> Line:
     uid = pulse.id
     w0 = waveforms[(uid, 0)]
     w1 = waveforms[(uid, 1)]
@@ -47,7 +48,7 @@ def play_pulse(pulse: Pulse, waveforms: WaveformIndices) -> Line:
     )
 
 
-def play_duration_swept(registers: dict[ParamRole, Register]) -> list[Instruction]:
+def _play_duration_swept(registers: dict[ParamRole, Register]) -> list[Instruction]:
     return [
         Play(
             wave_0=registers[ParamRole.PULSE_I],
@@ -55,6 +56,113 @@ def play_duration_swept(registers: dict[ParamRole, Register]) -> list[Instructio
             duration=4,
         ),
         Wait(duration=registers[ParamRole.DURATION]),
+    ]
+
+
+def _process_pulse(
+    pulse: Pulse, params: set[Param], waveforms: WaveformIndices, merged_vzs: bool
+):
+    """
+    If merged_vzs is True, all virtual-Z gates are merged and phase handling is done in
+    _process_virtualz.
+
+    If merged_vzs is False, a nonzero pulse.relative_phase is added to previously
+    accumulated phase deltas in Registers.phase_delta and must be applied with
+    SetPhDelta before playing the pulse.
+    """
+    if merged_vzs:
+        assert pulse.relative_phase == 0.0
+        return [_play_pulse(pulse, waveforms)]
+    else:
+        phase = int(convert(pulse.relative_phase, Parameter.relative_phase))
+        minus_phase = int(convert(-pulse.relative_phase, Parameter.relative_phase))
+        duration_sweep = {
+            p.role: p.reg for p in params if p.role.value[1] is Parameter.duration
+        }
+        return (
+            (
+                [
+                    Add(
+                        a=Registers.phase_delta.value,
+                        b=phase,
+                        destination=Registers.phase_delta.value,
+                    )
+                ]
+                if phase != 0
+                else []
+            )
+            + ([SetPhDelta(value=Registers.phase_delta.value)])
+            + (
+                [_play_pulse(pulse, waveforms)]
+                if len(duration_sweep) == 0
+                else _play_duration_swept(duration_sweep)
+            )
+            + ([Move(source=minus_phase, destination=Registers.phase_delta.value)])
+        )
+
+
+def _process_delay(pulse: Delay, params: set[Param]):
+    if len(params) == 0:
+        return [
+            Line(
+                instruction=Wait(duration=int(pulse.duration)),
+                comment=f"id: 0x{pulse.id.hex[:5]}",
+            )
+        ]
+    else:
+        return [Wait(duration=next(iter(params)).reg)]
+
+
+def _process_virtualz(pulse: VirtualZ, params: set[Param], merged_vzs: bool):
+    """
+    If merged_vzs is True, there is only a single VirtualZ between plays, so it apply
+    the phase directly using SetPhDelta.
+
+    If merged_vzs is False, accumulate the phase delta in Registers.phase_delta. If
+    params are provided, take the value from the corresponding register.
+    """
+    if merged_vzs:
+        return [SetPhDelta(value=int(convert(pulse.phase, Parameter.relative_phase)))]
+    else:
+        return [
+            Add(
+                a=Registers.phase_delta.value,
+                b=int(convert(pulse.phase, Parameter.relative_phase))
+                if len(params) == 0
+                else next(iter(params)).reg,
+                destination=Registers.phase_delta.value,
+            )
+        ]
+
+
+def _process_acquisition(
+    pulse: Acquisition, acquisitions: dict[MeasureId, AcquisitionSpec]
+):
+    acq = acquisitions[pulse.id]
+    return [
+        Acquire(
+            acquisition=acq.acquisition.index,
+            bin=Registers.bin.value,
+            duration=acq.duration,
+        )
+    ]
+
+
+def _process_readout(
+    pulse: Readout,
+    waveforms: WaveformIndices,
+    acquisitions: dict[MeasureId, AcquisitionSpec],
+):
+    acq = acquisitions[pulse.id]
+    return [
+        _play_pulse(pulse.probe, waveforms).update(
+            {"duration": int(pulse.time_of_flight)}
+        ),
+        Acquire(
+            acquisition=acq.acquisition.index,
+            bin=Registers.bin.value,
+            duration=int(pulse.acquisition.duration),
+        ),
     ]
 
 
@@ -68,83 +176,17 @@ def play(
     pulse = parpulse[0]
     params = parpulse[1]
     if isinstance(pulse, Pulse):
-        if merged_vzs:
-            assert pulse.relative_phase == 0.0
-            return [play_pulse(pulse, waveforms)]
-        else:
-            phase = int(convert(pulse.relative_phase, Parameter.relative_phase))
-            minus_phase = int(convert(-pulse.relative_phase, Parameter.relative_phase))
-            duration_sweep = {
-                p.role: p.reg for p in params if p.role.value[1] is Parameter.duration
-            }
-            return (
-                (
-                    [
-                        Add(
-                            a=Registers.phase_delta.value,
-                            b=phase,
-                            destination=Registers.phase_delta.value,
-                        )
-                    ]
-                    if phase != 0
-                    else []
-                )
-                + ([SetPhDelta(value=Registers.phase_delta.value)])
-                + (
-                    [play_pulse(pulse, waveforms)]
-                    if len(duration_sweep) == 0
-                    else play_duration_swept(duration_sweep)
-                )
-                + ([Move(source=minus_phase, destination=Registers.phase_delta.value)])
-            )
-
+        return _process_pulse(pulse, params, waveforms, merged_vzs)
     if isinstance(pulse, Delay):
-        return [
-            Line(
-                instruction=Wait(duration=int(pulse.duration)),
-                comment=f"id: 0x{pulse.id.hex[:5]}",
-            )
-            if len(params) == 0
-            else Wait(duration=next(iter(params)).reg)
-        ]
+        return _process_delay(pulse, params)
     if isinstance(pulse, VirtualZ):
-        if merged_vzs:
-            return [
-                SetPhDelta(value=int(convert(pulse.phase, Parameter.relative_phase)))
-            ]
-        else:
-            return [
-                Add(
-                    a=Registers.phase_delta.value,
-                    b=int(convert(pulse.phase, Parameter.relative_phase))
-                    if len(params) == 0
-                    else next(iter(params)).reg,
-                    destination=Registers.phase_delta.value,
-                )
-            ]
+        return _process_virtualz(pulse, params, merged_vzs)
     if isinstance(pulse, Acquisition):
-        acq = acquisitions[pulse.id]
-        return [
-            Acquire(
-                acquisition=acq.acquisition.index,
-                bin=Registers.bin.value,
-                duration=acq.duration,
-            )
-        ]
+        return _process_acquisition(pulse, acquisitions)
     if isinstance(pulse, Align):
         raise NotImplementedError("Align operation not yet supported by Qblox.")
     if isinstance(pulse, Readout):
-        acq = acquisitions[pulse.id]
-        return [
-            play_pulse(pulse.probe, waveforms).update(
-                {"duration": int(pulse.time_of_flight)}
-            ),
-            Acquire(
-                acquisition=acq.acquisition.index,
-                bin=Registers.bin.value,
-                duration=int(pulse.acquisition.duration),
-            ),
-        ]
+        return _process_readout(pulse, waveforms, acquisitions)
     raise NotImplementedError(f"Instruction {type(pulse)} unsupported by Qblox driver.")
 
 

--- a/src/qibolab/_core/instruments/qblox/sequence/experiment.py
+++ b/src/qibolab/_core/instruments/qblox/sequence/experiment.py
@@ -10,9 +10,11 @@ from qibolab._core.sweeper import Parameter
 
 from ..q1asm.ast_ import (
     Acquire,
+    Add,
     Block,
     Instruction,
     Line,
+    Move,
     Play,
     Register,
     SetPhDelta,
@@ -72,17 +74,24 @@ def play(
             p.role: p.reg for p in params if p.role.value[1] is Parameter.duration
         }
         return (
-            ([SetPhDelta(value=phase)] if phase != 0 else [])
+            (
+                [
+                    Add(
+                        a=Registers.phase.value,
+                        b=phase,
+                        destination=Registers.phase.value,
+                    )
+                ]
+                if phase != 0
+                else []
+            )
+            + ([SetPhDelta(value=Registers.phase.value)])
             + (
                 [play_pulse(pulse, waveforms)]
                 if len(duration_sweep) == 0
                 else play_duration_swept(duration_sweep)
             )
-            + (
-                [SetPhDelta(value=minus_phase), UpdParam(duration=4)]
-                if phase != 0
-                else []
-            )
+            + ([Move(source=minus_phase, destination=Registers.phase.value)])
         )
     if isinstance(pulse, Delay):
         return [
@@ -95,12 +104,13 @@ def play(
         ]
     if isinstance(pulse, VirtualZ):
         return [
-            SetPhDelta(
-                value=int(convert(pulse.phase, Parameter.relative_phase))
+            Add(
+                a=Registers.phase.value,
+                b=int(convert(pulse.phase, Parameter.relative_phase))
                 if len(params) == 0
-                else next(iter(params)).reg
-            ),
-            UpdParam(duration=4),
+                else next(iter(params)).reg,
+                destination=Registers.phase.value,
+            )
         ]
     if isinstance(pulse, Acquisition):
         acq = acquisitions[pulse.id]

--- a/src/qibolab/_core/instruments/qblox/sequence/experiment.py
+++ b/src/qibolab/_core/instruments/qblox/sequence/experiment.py
@@ -62,37 +62,42 @@ def play(
     parpulse: ParameterizedPulse,
     waveforms: WaveformIndices,
     acquisitions: dict[MeasureId, AcquisitionSpec],
+    merged_vzs: bool,
 ) -> Block:
     """Process the individual pulse in experiment."""
     pulse = parpulse[0]
     params = parpulse[1]
-
     if isinstance(pulse, Pulse):
-        phase = int(convert(pulse.relative_phase, Parameter.relative_phase))
-        minus_phase = int(convert(-pulse.relative_phase, Parameter.relative_phase))
-        duration_sweep = {
-            p.role: p.reg for p in params if p.role.value[1] is Parameter.duration
-        }
-        return (
-            (
-                [
-                    Add(
-                        a=Registers.phase.value,
-                        b=phase,
-                        destination=Registers.phase.value,
-                    )
-                ]
-                if phase != 0
-                else []
+        if merged_vzs:
+            assert pulse.relative_phase == 0.0
+            return [play_pulse(pulse, waveforms)]
+        else:
+            phase = int(convert(pulse.relative_phase, Parameter.relative_phase))
+            minus_phase = int(convert(-pulse.relative_phase, Parameter.relative_phase))
+            duration_sweep = {
+                p.role: p.reg for p in params if p.role.value[1] is Parameter.duration
+            }
+            return (
+                (
+                    [
+                        Add(
+                            a=Registers.phase.value,
+                            b=phase,
+                            destination=Registers.phase.value,
+                        )
+                    ]
+                    if phase != 0
+                    else []
+                )
+                + ([SetPhDelta(value=Registers.phase.value)])
+                + (
+                    [play_pulse(pulse, waveforms)]
+                    if len(duration_sweep) == 0
+                    else play_duration_swept(duration_sweep)
+                )
+                + ([Move(source=minus_phase, destination=Registers.phase.value)])
             )
-            + ([SetPhDelta(value=Registers.phase.value)])
-            + (
-                [play_pulse(pulse, waveforms)]
-                if len(duration_sweep) == 0
-                else play_duration_swept(duration_sweep)
-            )
-            + ([Move(source=minus_phase, destination=Registers.phase.value)])
-        )
+
     if isinstance(pulse, Delay):
         return [
             Line(
@@ -103,15 +108,20 @@ def play(
             else Wait(duration=next(iter(params)).reg)
         ]
     if isinstance(pulse, VirtualZ):
-        return [
-            Add(
-                a=Registers.phase.value,
-                b=int(convert(pulse.phase, Parameter.relative_phase))
-                if len(params) == 0
-                else next(iter(params)).reg,
-                destination=Registers.phase.value,
-            )
-        ]
+        if merged_vzs:
+            return [
+                SetPhDelta(value=int(convert(pulse.phase, Parameter.relative_phase)))
+            ]
+        else:
+            return [
+                Add(
+                    a=Registers.phase.value,
+                    b=int(convert(pulse.phase, Parameter.relative_phase))
+                    if len(params) == 0
+                    else next(iter(params)).reg,
+                    destination=Registers.phase.value,
+                )
+            ]
     if isinstance(pulse, Acquisition):
         acq = acquisitions[pulse.id]
         return [
@@ -142,13 +152,14 @@ def event(
     parpulse: ParameterizedPulse,
     waveforms: WaveformIndices,
     acquisitions: dict[MeasureId, AcquisitionSpec],
+    merged_vzs: bool,
 ) -> Block:
     params = parpulse[1]
     return [
         inst
         for block in (
             *(update_instructions(p.role, p.reg) for p in params),
-            *(play(parpulse, waveforms, acquisitions),),
+            *(play(parpulse, waveforms, acquisitions, merged_vzs),),
             *(reset_instructions(p.role, p.reg) for p in reversed(list(params))),
         )
         for inst in block
@@ -159,6 +170,7 @@ def experiment(
     sequence: SweepSequence,
     waveforms: WaveformIndices,
     acquisitions: dict[MeasureId, AcquisitionSpec],
+    merged_vzs: bool,
 ) -> Block:
     """Representation of the actual experiment to be executed.
 
@@ -172,6 +184,8 @@ def experiment(
     """
     return [UpdParam(duration=4), WaitSync(duration=4)] + [
         inst
-        for block in (event(pulse, waveforms, acquisitions) for pulse in sequence)
+        for block in (
+            event(pulse, waveforms, acquisitions, merged_vzs) for pulse in sequence
+        )
         for inst in block
     ]

--- a/src/qibolab/_core/instruments/qblox/sequence/program.py
+++ b/src/qibolab/_core/instruments/qblox/sequence/program.py
@@ -97,11 +97,11 @@ def program(
     sweepers: list[ParallelSweepers],
     channel: set[ChannelId],
     padding: int,
+    merged_vzs: bool,
 ) -> Program:
     """Generate sequencer program."""
     assert options.nshots is not None
     assert options.relaxation_time is not None
-
     loops_ = loops(
         sweepers,
         options.nshots,
@@ -113,7 +113,7 @@ def program(
         sequence, [p for v in indexed_params.values() for p in v.pulse]
     )
     experiment_ = [
-        *experiment(sweepseq, waveforms, acquisitions),
+        *experiment(sweepseq, waveforms, acquisitions, merged_vzs),
         # Enforce a minimum wait of 4 ns corresponding to one clock cycle
         Wait(duration=min(padding, 4)),
     ]

--- a/src/qibolab/_core/instruments/qblox/sequence/program.py
+++ b/src/qibolab/_core/instruments/qblox/sequence/program.py
@@ -53,6 +53,10 @@ def setup(
                 instruction=Move(source=0, destination=Registers.bin_reset.value),
                 comment="init bin reset",
             ),
+            Line(
+                instruction=Move(source=0, destination=Registers.phase_delta.value),
+                comment="init delta phase register",
+            ),
         ]
         + [
             Line(

--- a/src/qibolab/_core/instruments/qblox/sequence/sequence.py
+++ b/src/qibolab/_core/instruments/qblox/sequence/sequence.py
@@ -73,6 +73,7 @@ class Q1Sequence(Model):
         sampling_rate: float,
         channel: set[ChannelId],
         duration: float,
+        merged_vzs: bool,
     ) -> "Q1Sequence":
         padding = (
             duration
@@ -106,6 +107,7 @@ class Q1Sequence(Model):
                 sweepers,
                 channel,
                 int(padding),
+                merged_vzs,
             ),
         )
 
@@ -151,6 +153,7 @@ def compile(
     sweepers: list[ParallelSweepers],
     options: ExecutionParameters,
     sampling_rate: float,
+    merged_vzs: bool,
 ) -> dict[ChannelId, Q1Sequence]:
     duration = sequence.duration
     sweeper_channels = {ch: [] for ch in swept_channels(sweepers)}
@@ -162,6 +165,7 @@ def compile(
             sampling_rate,
             _effective_channels(ch, seq),
             duration,
+            merged_vzs,
         )
         for ch, seq in (sweeper_channels | sequence.by_channel).items()
     }

--- a/src/qibolab/_core/instruments/qblox/sequence/sweepers.py
+++ b/src/qibolab/_core/instruments/qblox/sequence/sweepers.py
@@ -209,7 +209,7 @@ _SWEEP_UPDATE: dict[Parameter, _Update] = {
     ),
     Parameter.relative_phase: _Update(
         update=lambda v: Add(
-            a=Registers.phase.value, b=v, destination=Registers.phase.value
+            a=Registers.phase_delta.value, b=v, destination=Registers.phase_delta.value
         ),
         reset=None,
     ),

--- a/src/qibolab/_core/instruments/qblox/sequence/sweepers.py
+++ b/src/qibolab/_core/instruments/qblox/sequence/sweepers.py
@@ -4,7 +4,16 @@ from itertools import groupby
 from typing import Optional
 
 from qibolab._core.identifier import ChannelId
-from qibolab._core.instruments.qblox.q1asm.ast_ import SetAwgGain, SetAwgOffs, SetFreq
+from qibolab._core.instruments.qblox.q1asm.ast_ import (
+    Add,
+    Instruction,
+    Register,
+    SetAwgGain,
+    SetAwgOffs,
+    SetFreq,
+    Value,
+)
+from qibolab._core.instruments.qblox.sequence.asm import Registers
 from qibolab._core.pulses.pulse import (
     Pulse,
     PulseId,
@@ -13,12 +22,6 @@ from qibolab._core.pulses.pulse import (
 from qibolab._core.serialize import Model
 from qibolab._core.sweeper import ParallelSweepers, Parameter, Range, Sweeper
 
-from ..q1asm.ast_ import (
-    Instruction,
-    Register,
-    SetPhDelta,
-    Value,
-)
 from .asm import MAX_PARAM, convert
 
 __all__ = []
@@ -204,7 +207,12 @@ _SWEEP_UPDATE: dict[Parameter, _Update] = {
             value_1=MAX_PARAM[Parameter.amplitude],
         ),
     ),
-    Parameter.relative_phase: _Update(update=lambda v: SetPhDelta(value=v), reset=None),
+    Parameter.relative_phase: _Update(
+        update=lambda v: Add(
+            a=Registers.phase.value, b=v, destination=Registers.phase.value
+        ),
+        reset=None,
+    ),
     Parameter.duration: _Update(update=None, reset=None),
 }
 

--- a/src/qibolab/_core/native.py
+++ b/src/qibolab/_core/native.py
@@ -37,9 +37,10 @@ def rotation(
 ) -> PulseSequence:
     """Create a sequence for single-qubit rotation.
 
-    ``theta`` will be the angle of the rotation, while ``phi`` the angle that the rotation axis forms with x axis.
-    If ``rx90`` is True the rotation will be performed starting from an RX90 pulse doubling its amplitude,
-    if the amplitude is greater than 0.5 two pulses are played.
+    ``theta`` will be the angle of the rotation, while ``phi`` the angle that the
+    rotation axis forms with x axis. If ``rx90`` is True the rotation will be performed
+    starting from an RX90 pulse doubling its amplitude, if the amplitude is greater than
+    0.5 two pulses are played.
     """
     theta, phi = _normalize_angles(theta, phi)
     ch, pulse = seq[0]
@@ -91,7 +92,8 @@ class SingleQubitNatives(NativeContainer):
     def R(self, theta: float = np.pi, phi: float = 0.0) -> PulseSequence:
         """Create a sequence for single-qubit rotation.
 
-        ``theta`` will be the angle of the rotation, while ``phi`` the angle that the rotation axis forms with x axis.
+        ``theta`` will be the angle of the rotation, while ``phi`` the angle that the
+        rotation axis forms with x axis.
         """
         if self.RX90 is not None:
             return rotation(self.RX90(), theta, phi, rx90=True)

--- a/src/qibolab/_core/native.py
+++ b/src/qibolab/_core/native.py
@@ -113,5 +113,5 @@ class TwoQubitNatives(NativeContainer):
         and control qubits."""
         return all(
             info.metadata[0]["symmetric"] or getattr(self, fld) is None
-            for fld, info in self.model_fields.items()
+            for fld, info in type(self).model_fields.items()
         )

--- a/tests/qblox/test_virtualz_instructions.py
+++ b/tests/qblox/test_virtualz_instructions.py
@@ -1,0 +1,49 @@
+"""Test compile with and without rel_phase sweeper"""
+
+import numpy as np
+
+from qibolab._core.execution_parameters import ExecutionParameters
+from qibolab._core.instruments.qblox.q1asm.ast_ import Add, Line, SetPhDelta
+from qibolab._core.instruments.qblox.sequence.asm import Registers
+from qibolab._core.instruments.qblox.sequence.sequence import compile
+from qibolab._core.pulses import VirtualZ
+from qibolab._core.sequence import PulseSequence
+from qibolab._core.sweeper import Parameter, Sweeper
+
+
+def test_virtualz_with_phase_sweeper_add_and_register():
+    vz = VirtualZ(phase=0.25)
+    seq = PulseSequence([("ch1", vz)])
+    sweeper = Sweeper(
+        parameter=Parameter.relative_phase,
+        values=np.array([0.1, 0.2, 0.3]),
+        pulses=[vz],
+    )
+    options = ExecutionParameters(nshots=5, relaxation_time=10)
+    result = compile(seq, [[sweeper]], options, sampling_rate=1.0, merged_vzs=False)
+    instrs = result["ch1"].program.elements
+
+    line_instrs = [i for i in instrs if isinstance(i, Line)]
+    add_instrs = [i for i in line_instrs if isinstance(i.instruction, Add)]
+    assert add_instrs, "Expected at least one 'Add' instruction for phase sweep."
+    assert any(
+        isinstance(i.instruction, Add)
+        and i.instruction.destination == Registers.phase_delta.value
+        for i in add_instrs
+    ), "Expected 'Add' instruction to use phase_delta register as argument."
+    assert not any(isinstance(i.instruction, SetPhDelta) for i in line_instrs), (
+        "Did not expect 'SetPhDelta' instruction when phase is swept."
+    )
+
+
+def test_virtualz_without_phase_sweeper_setphdelta_and_no_register():
+    vz = VirtualZ(phase=0.25)
+    seq = PulseSequence([("ch1", vz)])
+    options = ExecutionParameters(nshots=1, relaxation_time=10)
+    result = compile(seq, [], options, 1.0, merged_vzs=True)
+    instrs = result["ch1"].program.elements
+
+    line_instrs = [i for i in instrs if isinstance(i, Line)]
+    assert any(isinstance(i.instruction, SetPhDelta) for i in line_instrs), (
+        "Expected at least one 'SetPhDelta' instruction for static phase."
+    )

--- a/tests/qblox/test_virtualz_instructions.py
+++ b/tests/qblox/test_virtualz_instructions.py
@@ -11,7 +11,7 @@ from qibolab._core.sequence import PulseSequence
 from qibolab._core.sweeper import Parameter, Sweeper
 
 
-def test_virtualz_with_phase_sweeper_add_and_register():
+def test_virtualz_with_phase_sweeper():
     vz = VirtualZ(phase=0.25)
     seq = PulseSequence([("ch1", vz)])
     sweeper = Sweeper(
@@ -36,7 +36,7 @@ def test_virtualz_with_phase_sweeper_add_and_register():
     )
 
 
-def test_virtualz_without_phase_sweeper_setphdelta_and_no_register():
+def test_virtualz_without_phase_sweeper():
     vz = VirtualZ(phase=0.25)
     seq = PulseSequence([("ch1", vz)])
     options = ExecutionParameters(nshots=1, relaxation_time=10)


### PR DESCRIPTION
The qblox transpilation may introduce `upd_param` instructions that take 4ns each, but they are not accounted for while aligning different channels. 

If there are **sweeper**: accumulate phases in a register instead of following up each `SetPhDelta` with an `UpdParam`. 

If there are **no sweepers**: Merge all phases into a single virtual-z gate. This also avoid the need for an `UpdParam`.  
