### PR TITLE
fix: pass gate name instead of `None` to `MissingNative`

### DIFF
--- a/src/qibolab/_core/native.py
+++ b/src/qibolab/_core/native.py
@@ -70,7 +70,7 @@ class NativeContainer(Model):
     def ensure(self, name: str) -> Native:
         value = getattr(self, name)
         if value is None:
-            raise MissingNative(value)
+            raise MissingNative(name)
         return value
 
 

--- a/src/qibolab/_core/platform/platform.py
+++ b/src/qibolab/_core/platform/platform.py
@@ -279,7 +279,7 @@ class Platform:
         couplers: QubitMap | None = None,
         name: str | None = None,
     ) -> "Platform":
-        """Dump platform."""
+        """Load platform."""
         parameters = Parameters.model_validate_json((path / PARAMETERS).read_text())
         return cls(
             name=name if name is not None else path.name,
@@ -293,7 +293,7 @@ class Platform:
         """Dump platform."""
         (path / PARAMETERS).write_text(self.parameters.model_dump_json(indent=4))
 
-    def _element(self, qubit: QubitId, coupler=False) -> tuple[QubitId, Qubit]:
+    def _element(self, qubit: QubitId, coupler: bool = False) -> tuple[QubitId, Qubit]:
         elements = self.qubits if not coupler else self.couplers
         try:
             return qubit, elements[qubit]


### PR DESCRIPTION
Noticed a small bug and didn't have an open PR to put it in. 