### PR TITLE
Update qutip.py to store Hamiltonian and State Evolutions as filename-Max Time Evolution (Closes #1415)

### DIFF
--- a/src/qibolab/_core/instruments/emulator/engine/qutip.py
+++ b/src/qibolab/_core/instruments/emulator/engine/qutip.py
@@ -51,9 +51,9 @@ class QutipEngine(SimulationEngine):
         count = max(count_1, count_2)
 
         self.engine.qsave(
-            hamiltonian, str(dump_dir) + f"/{HAMILTONIAN_FILENAME}_{count}"
+            hamiltonian, str(dump_dir) + f"/{HAMILTONIAN_FILENAME}_{count*2}"
         )
-        self.engine.qsave(sim_results, str(dump_dir) + f"/{STATE_FILENAME}_{count}")
+        self.engine.qsave(sim_results, str(dump_dir) + f"/{STATE_FILENAME}_{count*2}")
 
     def evolve(
         self,

--- a/src/qibolab/_core/instruments/emulator/engine/qutip.py
+++ b/src/qibolab/_core/instruments/emulator/engine/qutip.py
@@ -51,9 +51,9 @@ class QutipEngine(SimulationEngine):
         count = max(count_1, count_2)
 
         self.engine.qsave(
-            hamiltonian, str(dump_dir) + f"/{HAMILTONIAN_FILENAME}_{count*2}"
+            hamiltonian, str(dump_dir) + f"/{HAMILTONIAN_FILENAME}_{count * 2}"
         )
-        self.engine.qsave(sim_results, str(dump_dir) + f"/{STATE_FILENAME}_{count*2}")
+        self.engine.qsave(sim_results, str(dump_dir) + f"/{STATE_FILENAME}_{count * 2}")
 
     def evolve(
         self,


### PR DESCRIPTION
Changes the filename to be in max resolution of 2 ns timesteps. Fails all tests the original repository fails, collecting 166 items, raising 10 errors, skipping 1. However, it multiplies an integer item by an integer and is not expected to negatively impact types and does not expand the scope of the code, using the iterator already present. No relevant documentation to update.

AI was used in discussions individual programming syntax or lines (like if not None -> is true) but no rewrites or directory explanations were made as well as explaining basic python errors.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
