### PR TITLE
Update qutip.py to store Hamiltonian and State Evolutions as filename-Max Time Evolution (Closes #1415)

### DIFF
--- a/src/qibolab/_core/instruments/emulator/engine/qutip.py
+++ b/src/qibolab/_core/instruments/emulator/engine/qutip.py
@@ -51,9 +51,9 @@ class QutipEngine(SimulationEngine):
         count = max(count_1, count_2)
 
         self.engine.qsave(
-            hamiltonian, str(dump_dir) + f"/{HAMILTONIAN_FILENAME}_{count}"
+            hamiltonian, str(dump_dir) + f"/{HAMILTONIAN_FILENAME}_{count*2}"
         )
-        self.engine.qsave(sim_results, str(dump_dir) + f"/{STATE_FILENAME}_{count}")
+        self.engine.qsave(sim_results, str(dump_dir) + f"/{STATE_FILENAME}_{count*2}")
 
     def evolve(
         self,

--- a/src/qibolab/_core/instruments/emulator/engine/qutip.py
+++ b/src/qibolab/_core/instruments/emulator/engine/qutip.py
@@ -51,9 +51,9 @@ class QutipEngine(SimulationEngine):
         count = max(count_1, count_2)
 
         self.engine.qsave(
-            hamiltonian, str(dump_dir) + f"/{HAMILTONIAN_FILENAME}_{count*2}"
+            hamiltonian, str(dump_dir) + f"/{HAMILTONIAN_FILENAME}_{count * 2}"
         )
-        self.engine.qsave(sim_results, str(dump_dir) + f"/{STATE_FILENAME}_{count*2}")
+        self.engine.qsave(sim_results, str(dump_dir) + f"/{STATE_FILENAME}_{count * 2}")
 
     def evolve(
         self,


### PR DESCRIPTION
Abstract: Higher quality submission requested by @alecandido covering the scope of the code I analyzed. Several hours went into analyzing the upstream effects to the code detailed here. First mesolve was used as a temporary variable, then this was discarded in favour of using the time array code, which led to using the minimum resolution (maximum time step) of the code. This prevents the code from rolling over and creating leading zeroes or decimals that change the data type en lieu of assuming 2 ns per naming scheme, or the choice value in INTEGRATION_MAX_TIME_STEP

Coverage: No changes in documentation. Data type has not changed in defining the file string, so coverage cannot decrease.

Examination: searches for "evolve(" only appear in the emulator, and every instance is taking Hamiltonian as an argument. In qutips.py, evolve also creates timesteps from the first axis of the Hamiltonian so evolve cannot store an instance of an interrupted for-loop in file storage. Even if we could use variable time (of evolve) in dump_results, it would require evolutions of the system each time. This conflicts with requests of storing a non-local variable during execution as pointed out in a follow up comment. Examining the other methods, they all create operators of (now bringing in physical knowledge) higher dimensionality than the one integer. However, n_steps = max(time_diff) / INTEGRATION_MIN_TIME_STEP * INTEGRATION_MULTIPLIER. Not only is n_steps already taking the maximum time difference, it multiplies its Hz conversion to a standard of 200 fractions per advancement. But reciprocal 5e-3 is already 200 so each time step is approximately 1 nanosecond to make the conversion 1:1 and fulfill the purpose of the code. The minimum time step is (1/4) the frequency, so this would make the maximum 4 nanoseconds to justify the 200 number in the code. Thus, 2 nanoseconds is the most representative default timestep and each file return can be assumed to be in this number as a placeholder, even as intervals of 10 picoseconds. It should be noted that Xanadu architecture is limited to 10's of nanoseconds as identified limitation in their Transition Edge Sensors. Thus, the iteration count infrastructure was set to multiply by 2, as changing the scope of the code minimally.

No artificial intelligence was used in the generation of these changes or in the writing of this description. In the interest of clarification, AI was only used in my previous pull request to understand syntax while I went line by line asking what qutip.py does.

References: Bourassa, J. E.; Alexander, R. N.; Vasmer, M.; Patil, A.; Tzitrin, I.; Matsuura, T.; Su, D.; Baragiola, B. Q.; Guha, S.; Dauphinais, G.; Sabapathy, K. K.; Menicucci, N. C.; Dhand, I. Blueprint for a Scalable Photonic Fault-Tolerant Quantum Computer. Quantum 2021, 5, 392. DOI:10.22331/q-2021-02-04-392. 

Checklist:
- [x] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
