### PR TITLE
Add Dynamiqs simulation engine for emulator

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -97,7 +97,7 @@ version = "3.0.1"
 description = "Annotate AST trees with source code positions"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev", "docs", "tests"]
+groups = ["main", "dev", "docs", "tests"]
 files = [
     {file = "asttokens-3.0.1-py3-none-any.whl", hash = "sha256:15a3ebc0f43c2d0a50eeafea25e19046c68398e487b9f1f5b517f7c0f40f976a"},
     {file = "asttokens-3.0.1.tar.gz", hash = "sha256:71a4ee5de0bde6a31d64f6b13f2293ac190344478f081c3d1bccfcf5eacb0cb7"},
@@ -668,6 +668,22 @@ constrained-solution-tracking = ["moarchiving"]
 plotting = ["matplotlib"]
 
 [[package]]
+name = "cmap"
+version = "0.7.2"
+description = "Scientific colormaps for python, without dependencies"
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "extra == \"emulator\""
+files = [
+    {file = "cmap-0.7.2-py3-none-any.whl", hash = "sha256:ad85bcc2327351bb72ff41516d4116d74b0af89258b35a323fcccb655a64f1f2"},
+    {file = "cmap-0.7.2.tar.gz", hash = "sha256:9501cec4d5c2b7a821479aec3282b3d8b42fda983bad055e0f9dbc19cf7bc5b1"},
+]
+
+[package.dependencies]
+numpy = "*"
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
@@ -678,7 +694,7 @@ files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "(platform_system == \"Windows\" or sys_platform == \"win32\") and extra == \"backend\"", dev = "sys_platform == \"win32\"", docs = "platform_system == \"Windows\" or sys_platform == \"win32\"", tests = "platform_system == \"Windows\" or sys_platform == \"win32\""}
+markers = {main = "(platform_system == \"Windows\" or sys_platform == \"win32\") and (extra == \"backend\" or extra == \"emulator\" or sys_platform == \"win32\")", dev = "sys_platform == \"win32\"", docs = "platform_system == \"Windows\" or sys_platform == \"win32\"", tests = "platform_system == \"Windows\" or sys_platform == \"win32\""}
 
 [[package]]
 name = "colorlog"
@@ -735,8 +751,7 @@ version = "1.3.2"
 description = "Python library for calculating contours of 2D quadrilateral grids"
 optional = false
 python-versions = ">=3.10"
-groups = ["docs", "tests"]
-markers = "python_version == \"3.10\""
+groups = ["main", "docs", "tests"]
 files = [
     {file = "contourpy-1.3.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ba38e3f9f330af820c4b27ceb4b9c7feee5fe0493ea53a8720f4792667465934"},
     {file = "contourpy-1.3.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:dc41ba0714aa2968d1f8674ec97504a8f7e334f48eeacebcaa6256213acb0989"},
@@ -796,6 +811,7 @@ files = [
     {file = "contourpy-1.3.2-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:8c5acb8dddb0752bf252e01a3035b21443158910ac16a3b0d20e7fed7d534ce5"},
     {file = "contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54"},
 ]
+markers = {main = "python_version == \"3.10\" and extra == \"emulator\"", docs = "python_version == \"3.10\"", tests = "python_version == \"3.10\""}
 
 [package.dependencies]
 numpy = ">=1.23"
@@ -813,8 +829,7 @@ version = "1.3.3"
 description = "Python library for calculating contours of 2D quadrilateral grids"
 optional = false
 python-versions = ">=3.11"
-groups = ["docs", "tests"]
-markers = "python_version >= \"3.11\""
+groups = ["main", "docs", "tests"]
 files = [
     {file = "contourpy-1.3.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:709a48ef9a690e1343202916450bc48b9e51c049b089c7f79a267b46cffcdaa1"},
     {file = "contourpy-1.3.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:23416f38bfd74d5d28ab8429cc4d63fa67d5068bd711a85edb1c3fb0c3e2f381"},
@@ -889,6 +904,7 @@ files = [
     {file = "contourpy-1.3.3-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:3d1a3799d62d45c18bafd41c5fa05120b96a28079f2393af559b843d1a966a77"},
     {file = "contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880"},
 ]
+markers = {main = "extra == \"emulator\" and python_version >= \"3.11\"", docs = "python_version >= \"3.11\"", tests = "python_version >= \"3.11\""}
 
 [package.dependencies]
 numpy = ">=1.25"
@@ -1101,11 +1117,12 @@ version = "0.12.1"
 description = "Composable style cycles"
 optional = false
 python-versions = ">=3.8"
-groups = ["docs", "tests"]
+groups = ["main", "docs", "tests"]
 files = [
     {file = "cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30"},
     {file = "cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c"},
 ]
+markers = {main = "extra == \"emulator\""}
 
 [package.extras]
 docs = ["ipython", "matplotlib", "numpydoc", "sphinx"]
@@ -1187,7 +1204,7 @@ version = "5.2.1"
 description = "Decorators for Humans"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev", "docs", "tests"]
+groups = ["main", "dev", "docs", "tests"]
 files = [
     {file = "decorator-5.2.1-py3-none-any.whl", hash = "sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a"},
     {file = "decorator-5.2.1.tar.gz", hash = "sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360"},
@@ -1206,6 +1223,55 @@ files = [
 ]
 
 [[package]]
+name = "diffrax"
+version = "0.7.0"
+description = "GPU+autodiff-capable ODE/SDE/CDE solvers written in JAX."
+optional = true
+python-versions = "<4.0,>=3.10"
+groups = ["main"]
+markers = "python_version == \"3.10\" and extra == \"emulator\""
+files = [
+    {file = "diffrax-0.7.0-py3-none-any.whl", hash = "sha256:aa9645c40552f11a2d32042ef6b9fcd53c1f0f6bdbe32d37cb788669ca9910be"},
+    {file = "diffrax-0.7.0.tar.gz", hash = "sha256:f3bcc578cd92a9ca86fc6f5a54c1de76c1ba62f74de69b56002624bf205316f1"},
+]
+
+[package.dependencies]
+equinox = ">=0.11.10"
+jax = ">=0.4.38"
+jaxtyping = ">=0.2.24"
+lineax = ">=0.0.5"
+optimistix = ">=0.0.10"
+typing-extensions = ">=4.5.0"
+wadler-lindig = ">=0.1.1"
+
+[[package]]
+name = "diffrax"
+version = "0.7.2"
+description = "GPU+autodiff-capable ODE/SDE/CDE solvers written in JAX."
+optional = true
+python-versions = ">=3.11"
+groups = ["main"]
+markers = "extra == \"emulator\" and python_version >= \"3.11\""
+files = [
+    {file = "diffrax-0.7.2-py3-none-any.whl", hash = "sha256:1beee2f991cd049962fe3c89da28f933753aa66d80bef857533276c9f23301ed"},
+    {file = "diffrax-0.7.2.tar.gz", hash = "sha256:9adc70fe90dba83f7dd839845839b2531a3dd736a3944fe1aa26598507cfb48e"},
+]
+
+[package.dependencies]
+equinox = ">=0.11.10"
+jax = ">=0.4.38"
+jaxtyping = ">=0.2.24"
+lineax = ">=0.0.5"
+optimistix = ">=0.1.0"
+typing-extensions = ">=4.5.0"
+wadler-lindig = ">=0.1.1"
+
+[package.extras]
+dev = ["pre-commit"]
+docs = ["griffe (==1.7.3)", "hippogriffe (==0.2.2)", "mkdocs (==1.6.1)", "mkdocs-include-exclude-files (==0.1.0)", "mkdocs-ipynb (==0.1.1)", "mkdocs-material (==9.6.7)", "mkdocstrings (==0.28.3)", "mkdocstrings-python (==1.16.8)", "pymdown-extensions (==10.14.3)"]
+tests = ["beartype", "jaxlib", "optax", "pytest", "scipy", "tqdm"]
+
+[[package]]
 name = "docutils"
 version = "0.21.2"
 description = "Docutils -- Python Documentation Utilities"
@@ -1218,12 +1284,62 @@ files = [
 ]
 
 [[package]]
+name = "dynamiqs"
+version = "0.3.4"
+description = "High-performance quantum systems simulation with JAX (GPU-accelerated & differentiable solvers)."
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"emulator\""
+files = [
+    {file = "dynamiqs-0.3.4-py3-none-any.whl", hash = "sha256:70a0c5d7fc092573423424f4f734e8002fbed45182c5f50f5ccb4ad76fc7f9ce"},
+    {file = "dynamiqs-0.3.4.tar.gz", hash = "sha256:3af0bbc90d3b48ba725cda3ea6040a548f69a6c7e4e52041439e9e9f951893b1"},
+]
+
+[package.dependencies]
+cmap = "*"
+diffrax = ">=0.6.1"
+equinox = "*"
+ipython = "*"
+jax = ">=0.4.36,<0.7"
+jaxtyping = "*"
+matplotlib = "*"
+numpy = "*"
+optimistix = "*"
+pillow = "*"
+qutip = ">=4.7.5"
+scipy = "*"
+tqdm = "*"
+
+[package.extras]
+dev = ["black", "codespell", "flit", "mike", "mkdocs-exclude", "mkdocs-gen-files", "mkdocs-glightbox", "mkdocs-literate-nav", "mkdocs-material", "mkdocs-section-index", "mkdocs-simple-hooks", "mkdocstrings[python] (!=1.12.0)", "optax", "pytest (>=8.0)", "pytest-ordering", "pytest-sugar", "pytest-xdist", "ruff (>=0.8)", "sybil (>=6)", "taskipy"]
+
+[[package]]
+name = "equinox"
+version = "0.13.8"
+description = "Elegant easy-to-use neural networks in JAX."
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"emulator\""
+files = [
+    {file = "equinox-0.13.8-py3-none-any.whl", hash = "sha256:ca004348533cc30a63ebe8823d7dd4bb626dce17743d40bbddb89b402ef2a240"},
+    {file = "equinox-0.13.8.tar.gz", hash = "sha256:dd075050018e2dd02e252e9d29d3060f7e67f085622d8d27a8e89e24bb8523db"},
+]
+
+[package.dependencies]
+jax = ">=0.4.38,<0.7.0 || >0.7.0,<0.7.1 || >0.7.1"
+jaxtyping = ">=0.2.20"
+typing-extensions = ">=4.5.0"
+wadler-lindig = ">=0.1.0"
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.1"
 description = "Backport of PEP 654 (exception groups)"
 optional = false
 python-versions = ">=3.7"
-groups = ["dev", "docs", "tests"]
+groups = ["main", "dev", "docs", "tests"]
 markers = "python_version == \"3.10\""
 files = [
     {file = "exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598"},
@@ -1242,7 +1358,7 @@ version = "2.2.1"
 description = "Get the currently executing AST node of a frame, and other information"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev", "docs", "tests"]
+groups = ["main", "dev", "docs", "tests"]
 files = [
     {file = "executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017"},
     {file = "executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4"},
@@ -1272,7 +1388,7 @@ version = "4.62.1"
 description = "Tools to manipulate font files"
 optional = false
 python-versions = ">=3.10"
-groups = ["docs", "tests"]
+groups = ["main", "docs", "tests"]
 files = [
     {file = "fonttools-4.62.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ad5cca75776cd453b1b035b530e943334957ae152a36a88a320e779d61fc980c"},
     {file = "fonttools-4.62.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0b3ae47e8636156a9accff64c02c0924cbebad62854c4a6dbdc110cd5b4b341a"},
@@ -1325,6 +1441,7 @@ files = [
     {file = "fonttools-4.62.1-py3-none-any.whl", hash = "sha256:7487782e2113861f4ddcc07c3436450659e3caa5e470b27dc2177cade2d8e7fd"},
     {file = "fonttools-4.62.1.tar.gz", hash = "sha256:e54c75fd6041f1122476776880f7c3c3295ffa31962dc6ebe2543c00dca58b5d"},
 ]
+markers = {main = "extra == \"emulator\""}
 
 [package.extras]
 all = ["brotli (>=1.0.1) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=0.8.0) ; platform_python_implementation != \"CPython\"", "lxml (>=4.0)", "lz4 (>=1.7.4.2)", "matplotlib", "munkres ; platform_python_implementation == \"PyPy\"", "pycairo", "scipy ; platform_python_implementation != \"PyPy\"", "skia-pathops (>=0.5.0)", "sympy", "uharfbuzz (>=0.45.0)", "unicodedata2 (>=17.0.0) ; python_version <= \"3.14\"", "xattr ; sys_platform == \"darwin\"", "zopfli (>=0.1.4)"]
@@ -1667,7 +1784,7 @@ version = "8.39.0"
 description = "IPython: Productive Interactive Computing"
 optional = false
 python-versions = ">=3.10"
-groups = ["dev", "docs", "tests"]
+groups = ["main", "dev", "docs", "tests"]
 files = [
     {file = "ipython-8.39.0-py3-none-any.whl", hash = "sha256:bb3c51c4fa8148ab1dea07a79584d1c854e234ea44aa1283bcb37bc75054651f"},
     {file = "ipython-8.39.0.tar.gz", hash = "sha256:4110ae96012c379b8b6db898a07e186c40a2a1ef5d57a7fa83166047d9da7624"},
@@ -1723,12 +1840,114 @@ widgetsnbextension = ">=4.0.14,<4.1.0"
 test = ["ipykernel", "jsonschema", "pytest (>=3.6.0)", "pytest-cov", "pytz"]
 
 [[package]]
+name = "jax"
+version = "0.6.2"
+description = "Differentiate, compile, and transform Numpy code."
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"emulator\""
+files = [
+    {file = "jax-0.6.2-py3-none-any.whl", hash = "sha256:bb24a82dc60ccf704dcaf6dbd07d04957f68a6c686db19630dd75260d1fb788c"},
+    {file = "jax-0.6.2.tar.gz", hash = "sha256:a437d29038cbc8300334119692744704ca7941490867b9665406b7f90665cd96"},
+]
+
+[package.dependencies]
+jaxlib = "0.6.2"
+ml_dtypes = ">=0.5.0"
+numpy = ">=1.26"
+opt_einsum = "*"
+scipy = ">=1.12"
+
+[package.extras]
+ci = ["jaxlib (==0.6.1)"]
+cuda = ["jax-cuda12-plugin[with-cuda] (==0.6.2)", "jaxlib (==0.6.2)"]
+cuda12 = ["jax-cuda12-plugin[with-cuda] (==0.6.2)", "jaxlib (==0.6.2)"]
+cuda12-local = ["jax-cuda12-plugin (==0.6.2)", "jaxlib (==0.6.2)"]
+k8s = ["kubernetes"]
+minimum-jaxlib = ["jaxlib (==0.6.2)"]
+rocm = ["jax-rocm60-plugin (==0.6.2)", "jaxlib (==0.6.2)"]
+tpu = ["jaxlib (==0.6.2)", "libtpu (==0.0.17.*)", "requests"]
+xprof = ["xprof"]
+
+[[package]]
+name = "jaxlib"
+version = "0.6.2"
+description = "XLA library for JAX"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"emulator\""
+files = [
+    {file = "jaxlib-0.6.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:da4601b2b5dc8c23d6afb293eacfb9aec4e1d1871cb2f29c5a151d103e73b0f8"},
+    {file = "jaxlib-0.6.2-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:4205d098ce8efb5f7fe2fe5098bae6036094dc8d8829f5e0e0d7a9b155326336"},
+    {file = "jaxlib-0.6.2-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:c087a0eb6fb7f6f8f54d56f4730328dfde5040dd3b5ddfa810e7c28ea7102b42"},
+    {file = "jaxlib-0.6.2-cp310-cp310-win_amd64.whl", hash = "sha256:153eaa51f778b60851720729d4f461a91edd9ba3932f6f3bc598d4413870038b"},
+    {file = "jaxlib-0.6.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a208ff61c58128d306bb4e5ad0858bd2b0960f2c1c10ad42c548f74a60c0020e"},
+    {file = "jaxlib-0.6.2-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:11eae7e05bc5a79875da36324afb9eddd4baeaef2a0386caf6d4f3720b9aef28"},
+    {file = "jaxlib-0.6.2-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:335d7e3515ce78b52a410136f46aa4a7ea14d0e7d640f34e1e137409554ad0ac"},
+    {file = "jaxlib-0.6.2-cp311-cp311-win_amd64.whl", hash = "sha256:c6815509997d6b05e5c9daa7994b9ad473ce3e8c8a17bdbbcacc3c744f76f7a0"},
+    {file = "jaxlib-0.6.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:34d8a684a8be949dd87dd4acc97101b4106a0dc9ad151ec891da072319a57b99"},
+    {file = "jaxlib-0.6.2-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:87ec2dc9c3ed9ab936eec8535160c5fbd2c849948559f1c5daa75f63fabe5942"},
+    {file = "jaxlib-0.6.2-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:f1dd09b481a93c1d4c750013f467f74194493ba7bd29fcd4d1cec16e3a214f65"},
+    {file = "jaxlib-0.6.2-cp312-cp312-win_amd64.whl", hash = "sha256:921dbd4db214eba19a29ba9f2450d880e08b2b2c7b968f28cc89da3e62366af4"},
+    {file = "jaxlib-0.6.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bff67b188133ce1f0111c7b163ac321fd646b59ed221ea489063e2e0f85cb967"},
+    {file = "jaxlib-0.6.2-cp313-cp313-manylinux2014_aarch64.whl", hash = "sha256:70498837caf538bd458ff6858c8bfd404db82015aba8f663670197fa9900ff02"},
+    {file = "jaxlib-0.6.2-cp313-cp313-manylinux2014_x86_64.whl", hash = "sha256:f94163f14c8fd3ba93ae14b631abacf14cb031bba0b59138869984b4d10375f8"},
+    {file = "jaxlib-0.6.2-cp313-cp313-win_amd64.whl", hash = "sha256:b977604cd36c74b174d25ed685017379468138eb747d865f75e466cb273c801d"},
+    {file = "jaxlib-0.6.2-cp313-cp313t-manylinux2014_aarch64.whl", hash = "sha256:39cf9555f85ae1ce2e2c1a59fc71f2eca4f9867a7cb934fef881ba56b11371d1"},
+    {file = "jaxlib-0.6.2-cp313-cp313t-manylinux2014_x86_64.whl", hash = "sha256:3abd536e44b05fb1657507e3ff1fc3691f99613bae3921ecab9e82f27255f784"},
+]
+
+[package.dependencies]
+ml_dtypes = ">=0.5.0"
+numpy = ">=1.26"
+scipy = ">=1.12"
+
+[[package]]
+name = "jaxtyping"
+version = "0.3.7"
+description = "Type annotations and runtime checking for shape and dtype of JAX/NumPy/PyTorch/etc. arrays."
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "python_version == \"3.10\" and extra == \"emulator\""
+files = [
+    {file = "jaxtyping-0.3.7-py3-none-any.whl", hash = "sha256:303ab8599edf412eeb40bf06c863e3168fa186cf0e7334703fa741ddd7046e66"},
+    {file = "jaxtyping-0.3.7.tar.gz", hash = "sha256:3bd7d9beb7d3cb01a89f93f90581c6f4fff3e5c5dc3c9307e8f8687a040d10c4"},
+]
+
+[package.dependencies]
+wadler-lindig = ">=0.1.3"
+
+[package.extras]
+dev = ["pre-commit (>=4.3.0)"]
+docs = ["griffe (==1.7.3)", "hippogriffe (==0.2.2)", "mkdocs (==1.6.1)", "mkdocs-include-exclude-files (==0.1.0)", "mkdocs-ipynb (==0.1.1)", "mkdocs-material (==9.6.7)", "mkdocstrings (==0.28.3)", "mkdocstrings-python (==1.16.8)", "pymdown-extensions (==10.14.3)"]
+tests = ["beartype (>=0.21.0)", "cloudpickle (>=3.1.1)", "equinox (>=0.13.1)", "ipython (>=8.37.0)", "jax (>=0.5.3)", "mlx[cpu] (>=0.29.1)", "numpy (<2)", "pytest (>=8.4.2)", "pytest-asyncio (>=1.2.0)", "tensorflow (>=2.18.1)", "typeguard (==2.13.3)"]
+
+[[package]]
+name = "jaxtyping"
+version = "0.3.10"
+description = "Type annotations and runtime checking for shape and dtype of JAX/NumPy/PyTorch/etc. arrays."
+optional = true
+python-versions = ">=3.11"
+groups = ["main"]
+markers = "extra == \"emulator\" and python_version >= \"3.11\""
+files = [
+    {file = "jaxtyping-0.3.10-py3-none-any.whl", hash = "sha256:e611a2b0a2fc3f867f01ceb3769dee6909a6d2075625dad07d3877e9e1297188"},
+    {file = "jaxtyping-0.3.10.tar.gz", hash = "sha256:7e79b050257bb1c757ee2c3d4ba246bd54422dc785b25f24797a8ce014f6daca"},
+]
+
+[package.dependencies]
+wadler-lindig = ">=0.1.3"
+
+[[package]]
 name = "jedi"
 version = "0.19.2"
 description = "An autocompletion tool for Python that can be used for text editors."
 optional = false
 python-versions = ">=3.6"
-groups = ["dev", "docs", "tests"]
+groups = ["main", "dev", "docs", "tests"]
 files = [
     {file = "jedi-0.19.2-py2.py3-none-any.whl", hash = "sha256:a8ef22bde8490f57fe5c7681a3c83cb58874daf72b4784de3cce5b6ef6edb5b9"},
     {file = "jedi-0.19.2.tar.gz", hash = "sha256:4770dc3de41bde3966b02eb84fbcf557fb33cce26ad23da12c742fb50ecb11f0"},
@@ -1884,7 +2103,7 @@ version = "1.5.0"
 description = "A fast implementation of the Cassowary constraint solver"
 optional = false
 python-versions = ">=3.10"
-groups = ["docs", "tests"]
+groups = ["main", "docs", "tests"]
 files = [
     {file = "kiwisolver-1.5.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:32cc0a5365239a6ea0c6ed461e8838d053b57e397443c0ca894dcc8e388d4374"},
     {file = "kiwisolver-1.5.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:cc0b66c1eec9021353a4b4483afb12dfd50e3669ffbb9152d6842eb34c7e29fd"},
@@ -2004,6 +2223,7 @@ files = [
     {file = "kiwisolver-1.5.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:59cd8683f575d96df5bb48f6add94afc055012c29e28124fcae2b63661b9efb1"},
     {file = "kiwisolver-1.5.0.tar.gz", hash = "sha256:d4193f3d9dc3f6f79aaed0e5637f45d98850ebf01f7ca20e69457f3e8946b66a"},
 ]
+markers = {main = "extra == \"emulator\""}
 
 [[package]]
 name = "latexcodec"
@@ -2016,6 +2236,30 @@ files = [
     {file = "latexcodec-3.0.1-py3-none-any.whl", hash = "sha256:a9eb8200bff693f0437a69581f7579eb6bca25c4193515c09900ce76451e452e"},
     {file = "latexcodec-3.0.1.tar.gz", hash = "sha256:e78a6911cd72f9dec35031c6ec23584de6842bfbc4610a9678868d14cdfb0357"},
 ]
+
+[[package]]
+name = "lineax"
+version = "0.1.0"
+description = "Linear solvers in JAX and Equinox."
+optional = true
+python-versions = "~=3.10"
+groups = ["main"]
+markers = "extra == \"emulator\""
+files = [
+    {file = "lineax-0.1.0-py3-none-any.whl", hash = "sha256:f00911c6b07d427c4835db46856970c8348bc82a035b51f4386ad09382af957a"},
+    {file = "lineax-0.1.0.tar.gz", hash = "sha256:5f1a8f060142af2cdbf7d66b99e8d3071c3aa734b677df6339df4b4c4c0554d2"},
+]
+
+[package.dependencies]
+equinox = ">=0.11.10"
+jax = ">=0.6.1"
+jaxtyping = ">=0.2.24"
+typing-extensions = ">=4.5.0"
+
+[package.extras]
+dev = ["pre-commit"]
+docs = ["griffe (==1.7.3)", "hippogriffe (==0.2.2)", "mkdocs (==1.6.1)", "mkdocs-include-exclude-files (==0.1.0)", "mkdocs-ipynb (==0.1.1)", "mkdocs-material (==9.6.7)", "mkdocstrings (==0.28.3)", "mkdocstrings-python (==1.16.8)", "pymdown-extensions (==10.14.3)"]
+tests = ["beartype", "equinox", "jaxlib", "pytest", "pytest-xdist"]
 
 [[package]]
 name = "locket"
@@ -2172,7 +2416,7 @@ version = "3.10.8"
 description = "Python plotting package"
 optional = false
 python-versions = ">=3.10"
-groups = ["docs", "tests"]
+groups = ["main", "docs", "tests"]
 files = [
     {file = "matplotlib-3.10.8-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:00270d217d6b20d14b584c521f810d60c5c78406dc289859776550df837dcda7"},
     {file = "matplotlib-3.10.8-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:37b3c1cc42aa184b3f738cfa18c1c1d72fd496d85467a6cf7b807936d39aa656"},
@@ -2230,6 +2474,7 @@ files = [
     {file = "matplotlib-3.10.8-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ae029229a57cd1e8fe542485f27e7ca7b23aa9e8944ddb4985d0bc444f1eca2"},
     {file = "matplotlib-3.10.8.tar.gz", hash = "sha256:2299372c19d56bcd35cf05a2738308758d32b9eaed2371898d8f5bd33f084aa3"},
 ]
+markers = {main = "extra == \"emulator\""}
 
 [package.dependencies]
 contourpy = ">=1.0.1"
@@ -2251,7 +2496,7 @@ version = "0.2.1"
 description = "Inline Matplotlib backend for Jupyter"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev", "docs", "tests"]
+groups = ["main", "dev", "docs", "tests"]
 files = [
     {file = "matplotlib_inline-0.2.1-py3-none-any.whl", hash = "sha256:d56ce5156ba6085e00a9d54fead6ed29a9c47e215cd1bba2e976ef39f5710a76"},
     {file = "matplotlib_inline-0.2.1.tar.gz", hash = "sha256:e1ee949c340d771fc39e241ea75683deb94762c8fa5f2927ec57c83c4dffa9fe"},
@@ -2279,6 +2524,67 @@ files = [
 typing-extensions = {version = "*", markers = "python_version < \"3.11\""}
 
 [[package]]
+name = "ml-dtypes"
+version = "0.5.4"
+description = "ml_dtypes is a stand-alone implementation of several NumPy dtype extensions used in machine learning."
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "extra == \"emulator\""
+files = [
+    {file = "ml_dtypes-0.5.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b95e97e470fe60ed493fd9ae3911d8da4ebac16bd21f87ffa2b7c588bf22ea2c"},
+    {file = "ml_dtypes-0.5.4-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b4b801ebe0b477be666696bda493a9be8356f1f0057a57f1e35cd26928823e5a"},
+    {file = "ml_dtypes-0.5.4-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:388d399a2152dd79a3f0456a952284a99ee5c93d3e2f8dfe25977511e0515270"},
+    {file = "ml_dtypes-0.5.4-cp310-cp310-win_amd64.whl", hash = "sha256:4ff7f3e7ca2972e7de850e7b8fcbb355304271e2933dd90814c1cb847414d6e2"},
+    {file = "ml_dtypes-0.5.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6c7ecb74c4bd71db68a6bea1edf8da8c34f3d9fe218f038814fd1d310ac76c90"},
+    {file = "ml_dtypes-0.5.4-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bc11d7e8c44a65115d05e2ab9989d1e045125d7be8e05a071a48bc76eb6d6040"},
+    {file = "ml_dtypes-0.5.4-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:19b9a53598f21e453ea2fbda8aa783c20faff8e1eeb0d7ab899309a0053f1483"},
+    {file = "ml_dtypes-0.5.4-cp311-cp311-win_amd64.whl", hash = "sha256:7c23c54a00ae43edf48d44066a7ec31e05fdc2eee0be2b8b50dd1903a1db94bb"},
+    {file = "ml_dtypes-0.5.4-cp311-cp311-win_arm64.whl", hash = "sha256:557a31a390b7e9439056644cb80ed0735a6e3e3bb09d67fd5687e4b04238d1de"},
+    {file = "ml_dtypes-0.5.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a174837a64f5b16cab6f368171a1a03a27936b31699d167684073ff1c4237dac"},
+    {file = "ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a7f7c643e8b1320fd958bf098aa7ecf70623a42ec5154e3be3be673f4c34d900"},
+    {file = "ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9ad459e99793fa6e13bd5b7e6792c8f9190b4e5a1b45c63aba14a4d0a7f1d5ff"},
+    {file = "ml_dtypes-0.5.4-cp312-cp312-win_amd64.whl", hash = "sha256:c1a953995cccb9e25a4ae19e34316671e4e2edaebe4cf538229b1fc7109087b7"},
+    {file = "ml_dtypes-0.5.4-cp312-cp312-win_arm64.whl", hash = "sha256:9bad06436568442575beb2d03389aa7456c690a5b05892c471215bfd8cf39460"},
+    {file = "ml_dtypes-0.5.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8c760d85a2f82e2bed75867079188c9d18dae2ee77c25a54d60e9cc79be1bc48"},
+    {file = "ml_dtypes-0.5.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce756d3a10d0c4067172804c9cc276ba9cc0ff47af9078ad439b075d1abdc29b"},
+    {file = "ml_dtypes-0.5.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:533ce891ba774eabf607172254f2e7260ba5f57bdd64030c9a4fcfbd99815d0d"},
+    {file = "ml_dtypes-0.5.4-cp313-cp313-win_amd64.whl", hash = "sha256:f21c9219ef48ca5ee78402d5cc831bd58ea27ce89beda894428bc67a52da5328"},
+    {file = "ml_dtypes-0.5.4-cp313-cp313-win_arm64.whl", hash = "sha256:35f29491a3e478407f7047b8a4834e4640a77d2737e0b294d049746507af5175"},
+    {file = "ml_dtypes-0.5.4-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:304ad47faa395415b9ccbcc06a0350800bc50eda70f0e45326796e27c62f18b6"},
+    {file = "ml_dtypes-0.5.4-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6a0df4223b514d799b8a1629c65ddc351b3efa833ccf7f8ea0cf654a61d1e35d"},
+    {file = "ml_dtypes-0.5.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:531eff30e4d368cb6255bc2328d070e35836aa4f282a0fb5f3a0cd7260257298"},
+    {file = "ml_dtypes-0.5.4-cp313-cp313t-win_amd64.whl", hash = "sha256:cb73dccfc991691c444acc8c0012bee8f2470da826a92e3a20bb333b1a7894e6"},
+    {file = "ml_dtypes-0.5.4-cp313-cp313t-win_arm64.whl", hash = "sha256:3bbbe120b915090d9dd1375e4684dd17a20a2491ef25d640a908281da85e73f1"},
+    {file = "ml_dtypes-0.5.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:2b857d3af6ac0d39db1de7c706e69c7f9791627209c3d6dedbfca8c7e5faec22"},
+    {file = "ml_dtypes-0.5.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:805cef3a38f4eafae3a5bf9ebdcdb741d0bcfd9e1bd90eb54abd24f928cd2465"},
+    {file = "ml_dtypes-0.5.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14a4fd3228af936461db66faccef6e4f41c1d82fcc30e9f8d58a08916b1d811f"},
+    {file = "ml_dtypes-0.5.4-cp314-cp314-win_amd64.whl", hash = "sha256:8c6a2dcebd6f3903e05d51960a8058d6e131fe69f952a5397e5dbabc841b6d56"},
+    {file = "ml_dtypes-0.5.4-cp314-cp314-win_arm64.whl", hash = "sha256:5a0f68ca8fd8d16583dfa7793973feb86f2fbb56ce3966daf9c9f748f52a2049"},
+    {file = "ml_dtypes-0.5.4-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:bfc534409c5d4b0bf945af29e5d0ab075eae9eecbb549ff8a29280db822f34f9"},
+    {file = "ml_dtypes-0.5.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2314892cdc3fcf05e373d76d72aaa15fda9fb98625effa73c1d646f331fcecb7"},
+    {file = "ml_dtypes-0.5.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0d2ffd05a2575b1519dc928c0b93c06339eb67173ff53acb00724502cda231cf"},
+    {file = "ml_dtypes-0.5.4-cp314-cp314t-win_amd64.whl", hash = "sha256:4381fe2f2452a2d7589689693d3162e876b3ddb0a832cde7a414f8e1adf7eab1"},
+    {file = "ml_dtypes-0.5.4-cp314-cp314t-win_arm64.whl", hash = "sha256:11942cbf2cf92157db91e5022633c0d9474d4dfd813a909383bd23ce828a4b7d"},
+    {file = "ml_dtypes-0.5.4-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:d81fdb088defa30eb37bf390bb7dde35d3a83ec112ac8e33d75ab28cc29dd8b0"},
+    {file = "ml_dtypes-0.5.4-cp39-cp39-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:88c982aac7cb1cbe8cbb4e7f253072b1df872701fcaf48d84ffbb433b6568f24"},
+    {file = "ml_dtypes-0.5.4-cp39-cp39-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9b61c19040397970d18d7737375cffd83b1f36a11dd4ad19f83a016f736c3ef"},
+    {file = "ml_dtypes-0.5.4-cp39-cp39-win_amd64.whl", hash = "sha256:3d277bf3637f2a62176f4575512e9ff9ef51d00e39626d9fe4a161992f355af2"},
+    {file = "ml_dtypes-0.5.4.tar.gz", hash = "sha256:8ab06a50fb9bf9666dd0fe5dfb4676fa2b0ac0f31ecff72a6c3af8e22c063453"},
+]
+
+[package.dependencies]
+numpy = [
+    {version = ">=1.21.2", markers = "python_version >= \"3.10\""},
+    {version = ">=1.23.3", markers = "python_version >= \"3.11\""},
+    {version = ">=2.1.0", markers = "python_version >= \"3.13\""},
+    {version = ">=1.26.0", markers = "python_version == \"3.12\""},
+]
+
+[package.extras]
+dev = ["absl-py", "pyink", "pylint (>=2.6.0)", "pytest", "pytest-xdist"]
+
+[[package]]
 name = "mpmath"
 version = "1.3.0"
 description = "Python library for arbitrary-precision floating-point arithmetic"
@@ -2304,7 +2610,7 @@ description = "MessagePack serializer"
 optional = false
 python-versions = ">=3.9"
 groups = ["docs", "tests"]
-markers = "python_version >= \"3.11\" and platform_python_implementation == \"CPython\""
+markers = "platform_python_implementation == \"CPython\" and python_version >= \"3.11\""
 files = [
     {file = "msgpack-1.1.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0051fffef5a37ca2cd16978ae4f0aef92f164df86823871b5162812bebecd8e2"},
     {file = "msgpack-1.1.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a605409040f2da88676e9c9e5853b3449ba8011973616189ea5ee55ddbc5bc87"},
@@ -2512,7 +2818,7 @@ description = "Python package for creating and manipulating graphs and networks"
 optional = true
 python-versions = "!=3.14.1,>=3.11"
 groups = ["main"]
-markers = "python_version >= \"3.11\" and extra == \"backend\""
+markers = "extra == \"backend\" and python_version >= \"3.11\""
 files = [
     {file = "networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762"},
     {file = "networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509"},
@@ -2630,6 +2936,69 @@ files = [
 [package.dependencies]
 importlib-metadata = ">=6.0,<8.8.0"
 typing-extensions = ">=4.5.0"
+
+[[package]]
+name = "opt-einsum"
+version = "3.4.0"
+description = "Path optimization of einsum functions."
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "extra == \"emulator\""
+files = [
+    {file = "opt_einsum-3.4.0-py3-none-any.whl", hash = "sha256:69bb92469f86a1565195ece4ac0323943e83477171b91d24c35afe028a90d7cd"},
+    {file = "opt_einsum-3.4.0.tar.gz", hash = "sha256:96ca72f1b886d148241348783498194c577fa30a8faac108586b14f1ba4473ac"},
+]
+
+[[package]]
+name = "optimistix"
+version = "0.0.11"
+description = "Nonlinear optimisation in JAX and Equinox."
+optional = true
+python-versions = "~=3.10"
+groups = ["main"]
+markers = "python_version == \"3.10\" and extra == \"emulator\""
+files = [
+    {file = "optimistix-0.0.11-py3-none-any.whl", hash = "sha256:acb4fb23b598db03e376900fcb61aee8dd511de41411e849661c0ffe9e4cd1c6"},
+    {file = "optimistix-0.0.11.tar.gz", hash = "sha256:cfce0de98e7e9fdbcc2ce6d49a9f82cd3166fd0eee29c0c7a1983f8aefd37757"},
+]
+
+[package.dependencies]
+equinox = ">=0.11.11"
+jax = ">=0.4.38,<0.7.0 || >0.7.0,<0.7.1 || >0.7.1"
+jaxtyping = ">=0.2.24"
+lineax = ">=0.0.6"
+typing-extensions = ">=4.5.0"
+
+[package.extras]
+dev = ["pre-commit"]
+docs = ["griffe (==1.7.3)", "hippogriffe (==0.2.2)", "mkdocs (==1.6.1)", "mkdocs-include-exclude-files (==0.1.0)", "mkdocs-ipynb (==0.1.1)", "mkdocs-material (==9.6.7)", "mkdocstrings (==0.28.3)", "mkdocstrings-python (==1.16.8)", "pymdown-extensions (==10.14.3)"]
+tests = ["beartype (>=0.20.2)", "diffrax (>=0.7.0)", "jaxlib", "optax (>=0.2.4)", "pytest (>=8.3.5)"]
+
+[[package]]
+name = "optimistix"
+version = "0.1.0"
+description = "Nonlinear optimisation in JAX and Equinox."
+optional = true
+python-versions = "~=3.11"
+groups = ["main"]
+markers = "extra == \"emulator\" and python_version >= \"3.11\""
+files = [
+    {file = "optimistix-0.1.0-py3-none-any.whl", hash = "sha256:c8edda7bf7fe48839c93fcd72bce750c950ed9f7033158303150b7ab395add81"},
+    {file = "optimistix-0.1.0.tar.gz", hash = "sha256:f05c9104748e87e1dc10a0b4a2be94e427f98c3eab0b1d41ea24a593d76be03d"},
+]
+
+[package.dependencies]
+equinox = ">=0.11.11"
+jax = ">=0.4.38,<0.7.0 || >0.7.0,<0.7.1 || >0.7.1"
+jaxtyping = ">=0.2.24"
+lineax = ">=0.0.6"
+typing-extensions = ">=4.5.0"
+
+[package.extras]
+dev = ["pre-commit"]
+docs = ["griffe (==1.7.3)", "hippogriffe (==0.2.2)", "mkdocs (==1.6.1)", "mkdocs-include-exclude-files (==0.1.0)", "mkdocs-ipynb (==0.1.1)", "mkdocs-material (==9.6.7)", "mkdocstrings (==0.28.3)", "mkdocstrings-python (==1.16.8)", "pymdown-extensions (==10.14.3)"]
+tests = ["beartype (>=0.20.2)", "diffrax (>=0.7.0)", "fire", "jaxlib", "matplotlib", "optax (>=0.2.4)", "pytest (>=8.3.5)", "sif2jax"]
 
 [[package]]
 name = "optuna"
@@ -2876,7 +3245,7 @@ version = "0.8.6"
 description = "A Python Parser"
 optional = false
 python-versions = ">=3.6"
-groups = ["dev", "docs", "tests"]
+groups = ["main", "dev", "docs", "tests"]
 files = [
     {file = "parso-0.8.6-py2.py3-none-any.whl", hash = "sha256:2c549f800b70a5c4952197248825584cb00f033b29c692671d3bf08bf380baff"},
     {file = "parso-0.8.6.tar.gz", hash = "sha256:2b9a0332696df97d454fa67b81618fd69c35a7b90327cbe6ba5c92d2c68a7bfd"},
@@ -2911,7 +3280,7 @@ version = "4.9.0"
 description = "Pexpect allows easy control of interactive console applications."
 optional = false
 python-versions = "*"
-groups = ["dev", "docs", "tests"]
+groups = ["main", "dev", "docs", "tests"]
 markers = "sys_platform != \"win32\" and sys_platform != \"emscripten\""
 files = [
     {file = "pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523"},
@@ -2927,7 +3296,7 @@ version = "12.2.0"
 description = "Python Imaging Library (fork)"
 optional = false
 python-versions = ">=3.10"
-groups = ["docs", "tests"]
+groups = ["main", "docs", "tests"]
 files = [
     {file = "pillow-12.2.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:a4e8f36e677d3336f35089648c8955c51c6d386a13cf6ee9c189c5f5bd713a9f"},
     {file = "pillow-12.2.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2e589959f10d9824d39b350472b92f0ce3b443c0a3442ebf41c40cb8361c5b97"},
@@ -3021,6 +3390,7 @@ files = [
     {file = "pillow-12.2.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:bfa9c230d2fe991bed5318a5f119bd6780cda2915cca595393649fc118ab895e"},
     {file = "pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5"},
 ]
+markers = {main = "extra == \"emulator\""}
 
 [package.extras]
 docs = ["furo", "olefile", "sphinx (>=8.2)", "sphinx-autobuild", "sphinx-copybutton", "sphinx-inline-tabs", "sphinxext-opengraph"]
@@ -3064,7 +3434,7 @@ version = "3.0.52"
 description = "Library for building powerful interactive command lines in Python"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev", "docs", "tests"]
+groups = ["main", "dev", "docs", "tests"]
 files = [
     {file = "prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955"},
     {file = "prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855"},
@@ -3114,7 +3484,7 @@ version = "0.7.0"
 description = "Run a subprocess in a pseudo terminal"
 optional = false
 python-versions = "*"
-groups = ["dev", "docs", "tests"]
+groups = ["main", "dev", "docs", "tests"]
 markers = "sys_platform != \"win32\" and sys_platform != \"emscripten\""
 files = [
     {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
@@ -3150,7 +3520,7 @@ version = "0.2.3"
 description = "Safely evaluate AST nodes without side effects"
 optional = false
 python-versions = "*"
-groups = ["dev", "docs", "tests"]
+groups = ["main", "dev", "docs", "tests"]
 files = [
     {file = "pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0"},
     {file = "pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42"},
@@ -3441,7 +3811,7 @@ version = "2.20.0"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
 python-versions = ">=3.9"
-groups = ["dev", "docs", "tests"]
+groups = ["main", "dev", "docs", "tests"]
 files = [
     {file = "pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"},
     {file = "pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"},
@@ -3456,11 +3826,12 @@ version = "3.3.2"
 description = "pyparsing - Classes and methods to define and execute parsing grammars"
 optional = false
 python-versions = ">=3.9"
-groups = ["docs", "tests"]
+groups = ["main", "docs", "tests"]
 files = [
     {file = "pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d"},
     {file = "pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc"},
 ]
+markers = {main = "extra == \"emulator\""}
 
 [package.extras]
 diagrams = ["jinja2", "railroad-diagrams"]
@@ -3568,11 +3939,12 @@ version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
-groups = ["docs", "tests"]
+groups = ["main", "docs", "tests"]
 files = [
     {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
     {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
 ]
+markers = {main = "extra == \"emulator\""}
 
 [package.dependencies]
 six = ">=1.5"
@@ -4320,11 +4692,12 @@ version = "1.17.0"
 description = "Python 2 and 3 compatibility utilities"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
-groups = ["docs", "tests"]
+groups = ["main", "docs", "tests"]
 files = [
     {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
     {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
 ]
+markers = {main = "extra == \"emulator\""}
 
 [[package]]
 name = "snowballstemmer"
@@ -4732,7 +5105,7 @@ version = "0.6.3"
 description = "Extract data from python stack frames and tracebacks for informative displays"
 optional = false
 python-versions = "*"
-groups = ["dev", "docs", "tests"]
+groups = ["main", "dev", "docs", "tests"]
 files = [
     {file = "stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695"},
     {file = "stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9"},
@@ -4901,7 +5274,7 @@ files = [
     {file = "tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf"},
     {file = "tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb"},
 ]
-markers = {main = "extra == \"backend\""}
+markers = {main = "extra == \"backend\" or extra == \"emulator\""}
 
 [package.dependencies]
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
@@ -4919,7 +5292,7 @@ version = "5.14.3"
 description = "Traitlets Python configuration system"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev", "docs", "tests"]
+groups = ["main", "dev", "docs", "tests"]
 files = [
     {file = "traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f"},
     {file = "traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7"},
@@ -5013,7 +5386,7 @@ description = "A portable, lightweight MessagePack serializer and deserializer w
 optional = false
 python-versions = "*"
 groups = ["docs", "tests"]
-markers = "python_version >= \"3.11\" and platform_python_implementation != \"CPython\""
+markers = "platform_python_implementation != \"CPython\" and python_version >= \"3.11\""
 files = [
     {file = "u-msgpack-python-2.8.0.tar.gz", hash = "sha256:b801a83d6ed75e6df41e44518b4f2a9c221dc2da4bcd5380e3a0feda520bc61a"},
     {file = "u_msgpack_python-2.8.0-py2.py3-none-any.whl", hash = "sha256:1d853d33e78b72c4228a2025b4db28cda81214076e5b0422ed0ae1b1b2bb586a"},
@@ -5132,7 +5505,7 @@ version = "2.7.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.10"
-groups = ["dev", "docs", "tests"]
+groups = ["docs", "tests"]
 files = [
     {file = "urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"},
     {file = "urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"},
@@ -5203,12 +5576,29 @@ packaging = ">=17.1"
 tomli = {version = ">=1.2,<3.0", markers = "python_version < \"3.11\""}
 
 [[package]]
+name = "wadler-lindig"
+version = "0.1.7"
+description = "A Wadler–Lindig pretty-printer for Python."
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"emulator\""
+files = [
+    {file = "wadler_lindig-0.1.7-py3-none-any.whl", hash = "sha256:e3ec83835570fd0a9509f969162aeb9c65618f998b1f42918cfc8d45122fe953"},
+    {file = "wadler_lindig-0.1.7.tar.gz", hash = "sha256:81d14d3fe77d441acf3ebd7f4aefac20c74128bf460e84b512806dccf7b2cd55"},
+]
+
+[package.extras]
+dev = ["numpy", "pre-commit", "pytest"]
+docs = ["hippogriffe (==0.1.0)", "mkdocs (==1.6.1)", "mkdocs-include-exclude-files (==0.1.0)", "mkdocs-ipynb (==0.1.0)", "mkdocs-material (==9.6.7)", "mkdocstrings[python] (==0.28.3)", "pymdown-extensions (==10.14.3)"]
+
+[[package]]
 name = "wcwidth"
 version = "0.6.0"
 description = "Measures the displayed width of unicode strings in a terminal"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev", "docs", "tests"]
+groups = ["main", "dev", "docs", "tests"]
 files = [
     {file = "wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad"},
     {file = "wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159"},
@@ -5488,10 +5878,10 @@ type = ["pytest-mypy"]
 
 [extras]
 backend = ["qibo"]
-emulator = ["qutip"]
+emulator = ["dynamiqs", "qutip"]
 qrng = ["pyserial"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.14"
-content-hash = "0a48f27e369469e9031408f49bafdf82076e1333751768d043a1c1220ce9d3cd"
+content-hash = "c2ce1cad8d25e6c861a11035798d99442418fbd4ea799184c5b4cd6ded54bf19"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ scipy = "^1.13.0"
 pydantic = "^2.4.0"
 qibo = { version = "^0.3.0" , optional = true }
 qutip = { version = "^5.0.2", optional = true }
+dynamiqs = { version = "^0.3.4", optional = true }
 pyserial = { version = "^3.5", optional = true }
 
 [tool.poetry.group.dev]
@@ -74,7 +75,7 @@ ruff = "^0.9.1"
 
 [tool.poetry.extras]
 backend = ["qibo"]
-emulator = ["qutip"]
+emulator = ["qutip", "dynamiqs"]
 qrng = ["pyserial"]
 
 [tool.poe.tasks]

--- a/src/qibolab/_core/instruments/emulator/engine/__init__.py
+++ b/src/qibolab/_core/instruments/emulator/engine/__init__.py
@@ -1,7 +1,9 @@
-from . import abstract, qutip
+from . import abstract, dynamiqs, qutip
 from .abstract import *
+from .dynamiqs import *
 from .qutip import *
 
 __all__ = []
 __all__.extend(abstract.__all__)
+__all__.extend(dynamiqs.__all__)
 __all__.extend(qutip.__all__)

--- a/src/qibolab/_core/instruments/emulator/engine/dynamiqs.py
+++ b/src/qibolab/_core/instruments/emulator/engine/dynamiqs.py
@@ -127,9 +127,7 @@ def _bspline_prefactor(spline: BSpline):
         return jnp.where(denominator == 0, 0, numerator / denominator)
 
     def prefactor(time):
-        basis = ((knots[:-1] <= time) & (time < knots[1:])).astype(
-            coefficients.dtype
-        )
+        basis = ((knots[:-1] <= time) & (time < knots[1:])).astype(coefficients.dtype)
 
         for order in range(1, degree + 1):
             size = knots.size - 1 - order
@@ -311,9 +309,13 @@ class DynamiqsEngine(SimulationEngine):
         permutation = [position[i] for i in range(len(dims))] + [
             len(dims) + position[i] for i in range(len(dims))
         ]
-        expanded = compact.reshape(shape).transpose(permutation).reshape(
-            np.prod(dims, dtype=int),
-            np.prod(dims, dtype=int),
+        expanded = (
+            compact.reshape(shape)
+            .transpose(permutation)
+            .reshape(
+                np.prod(dims, dtype=int),
+                np.prod(dims, dtype=int),
+            )
         )
 
         return self._wrap(self.engine.asqarray(expanded, dims=tuple(dims)))

--- a/src/qibolab/_core/instruments/emulator/engine/dynamiqs.py
+++ b/src/qibolab/_core/instruments/emulator/engine/dynamiqs.py
@@ -1,0 +1,325 @@
+"""Dynamiqs engine for platform emulation."""
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from functools import cached_property
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from scipy.interpolate import BSpline
+
+from .abstract import Operator, OperatorEvolution, SimulationEngine
+from .qutip import (
+    HAMILTONIAN_FILENAME,
+    INTEGRATION_MIN_TIME_STEP,
+    INTEGRATION_MULTIPLIER,
+    STATE_FILENAME,
+)
+
+__all__ = ["DynamiqsEngine"]
+
+
+@dataclass(frozen=True)
+class DynamiqsOperator:
+    """QuTiP-compatible wrapper over a Dynamiqs qarray."""
+
+    raw: Any
+
+    @property
+    def n(self) -> int:
+        """Dimension of the Hilbert space."""
+        return max(self.raw.shape[-2:])
+
+    @property
+    def dims(self):
+        """Hilbert space dimensions."""
+        return self.raw.dims
+
+    @property
+    def shape(self):
+        """Operator shape."""
+        return self.raw.shape
+
+    def dag(self) -> "DynamiqsOperator":
+        """Return the adjoint of the operator."""
+        return type(self)(self.raw.dag())
+
+    def full(self) -> np.ndarray:
+        """Return a dense NumPy representation."""
+        import dynamiqs as dq
+
+        return dq.to_numpy(self.raw)
+
+    def __array__(self, dtype=None):
+        array = self.full()
+        return array.astype(dtype) if dtype is not None else array
+
+    @staticmethod
+    def _unwrap(other: Any) -> Any:
+        return other.raw if isinstance(other, DynamiqsOperator) else other
+
+    @staticmethod
+    def _is_zero(other: Any) -> bool:
+        return isinstance(other, (int, float, complex)) and other == 0
+
+    def __add__(self, other: Any) -> "DynamiqsOperator":
+        if self._is_zero(other):
+            return self
+        return type(self)(self.raw + self._unwrap(other))
+
+    def __radd__(self, other: Any) -> "DynamiqsOperator":
+        if self._is_zero(other):
+            return self
+        return type(self)(self._unwrap(other) + self.raw)
+
+    def __sub__(self, other: Any) -> "DynamiqsOperator":
+        return type(self)(self.raw - self._unwrap(other))
+
+    def __rsub__(self, other: Any) -> "DynamiqsOperator":
+        return type(self)(self._unwrap(other) - self.raw)
+
+    def __neg__(self) -> "DynamiqsOperator":
+        return type(self)(-self.raw)
+
+    def __mul__(self, other: Any) -> "DynamiqsOperator":
+        if isinstance(other, DynamiqsOperator):
+            return type(self)(self.raw @ other.raw)
+        return type(self)(self.raw * other)
+
+    def __rmul__(self, other: Any) -> "DynamiqsOperator":
+        if isinstance(other, DynamiqsOperator):
+            return type(self)(other.raw @ self.raw)
+        return type(self)(other * self.raw)
+
+    def __matmul__(self, other: Any) -> "DynamiqsOperator":
+        return type(self)(self.raw @ self._unwrap(other))
+
+    def __rmatmul__(self, other: Any) -> "DynamiqsOperator":
+        return type(self)(self._unwrap(other) @ self.raw)
+
+    def __truediv__(self, other: Any) -> "DynamiqsOperator":
+        return type(self)(self.raw / other)
+
+
+@dataclass(frozen=True)
+class DynamiqsEvolutionResult:
+    """QuTiP-compatible result wrapper for Dynamiqs evolutions."""
+
+    raw: Any
+    states: list[DynamiqsOperator]
+
+
+def unwrap(operator: Any) -> Any:
+    """Return the native Dynamiqs object for wrapped operators."""
+    return operator.raw if isinstance(operator, DynamiqsOperator) else operator
+
+
+def _bspline_prefactor(spline: BSpline):
+    """Convert a SciPy B-spline into a JAX-compatible scalar function."""
+    import jax.numpy as jnp
+
+    knots = jnp.asarray(spline.t)
+    coefficients = jnp.asarray(spline.c)
+    degree = spline.k
+
+    def safe_divide(numerator, denominator):
+        return jnp.where(denominator == 0, 0, numerator / denominator)
+
+    def prefactor(time):
+        basis = ((knots[:-1] <= time) & (time < knots[1:])).astype(
+            coefficients.dtype
+        )
+
+        for order in range(1, degree + 1):
+            size = knots.size - 1 - order
+            left = safe_divide(
+                time - knots[:size],
+                knots[order : order + size] - knots[:size],
+            )
+            right = safe_divide(
+                knots[order + 1 : order + 1 + size] - time,
+                knots[order + 1 : order + 1 + size] - knots[1 : 1 + size],
+            )
+            basis = left * basis[:size] + right * basis[1 : size + 1]
+
+        value = basis @ coefficients[: basis.size]
+        return jnp.where(time == knots[-1], coefficients[-1], value)
+
+    return prefactor
+
+
+class DynamiqsEngine(SimulationEngine):
+    """Dynamiqs simulation engine."""
+
+    @cached_property
+    def engine(self):
+        """Return the Dynamiqs engine."""
+        import dynamiqs as dq
+
+        dq.set_precision("double")
+        return dq
+
+    def _wrap(self, operator: Any) -> DynamiqsOperator:
+        return DynamiqsOperator(operator)
+
+    def _time_hamiltonian(
+        self, hamiltonian: Operator, time_hamiltonian: OperatorEvolution | None
+    ):
+        hamiltonian = self.engine.constant(unwrap(hamiltonian))
+        if time_hamiltonian is None:
+            return hamiltonian
+
+        for operator, time in time_hamiltonian.operators:
+            hamiltonian += self.engine.modulated(
+                _bspline_prefactor(time),
+                unwrap(operator),
+            )
+
+        return hamiltonian
+
+    def dump_results(
+        self,
+        hamiltonian: Any,
+        sim_results: Any,
+        time: np.ndarray,
+        dump_dir: Path,
+    ) -> None:
+        """Save the Hamiltonian and simulation results to NumPy files."""
+        dump_dir.mkdir(parents=True, exist_ok=True)
+
+        count_1 = sum(
+            1
+            for file in dump_dir.iterdir()
+            if file.is_file() and HAMILTONIAN_FILENAME in file.name
+        )
+        count_2 = sum(
+            1
+            for file in dump_dir.iterdir()
+            if file.is_file() and STATE_FILENAME in file.name
+        )
+        count = max(count_1, count_2)
+
+        hamiltonian_values = np.stack(
+            [self.engine.to_numpy(hamiltonian(t)) for t in time]
+        )
+        np.savez(
+            dump_dir / f"{HAMILTONIAN_FILENAME}_{count}.npz",
+            time=time,
+            hamiltonian=hamiltonian_values,
+        )
+        np.savez(
+            dump_dir / f"{STATE_FILENAME}_{count}.npz",
+            time=np.asarray(sim_results.tsave),
+            states=self.engine.to_numpy(sim_results.states),
+        )
+
+    def evolve(
+        self,
+        hamiltonian: Operator,
+        initial_state: Operator,
+        time: Iterable[float],
+        time_hamiltonian: OperatorEvolution = None,
+        collapse_operators: list[Operator] = None,
+        save_evolution: Path | None = None,
+        **kwargs,
+    ) -> DynamiqsEvolutionResult:
+        """Evolve the system."""
+        time = np.asarray(list(time), dtype=float)
+        time_diff = np.diff(time)
+        nsteps = int(
+            max(time_diff, default=INTEGRATION_MIN_TIME_STEP)
+            / INTEGRATION_MIN_TIME_STEP
+            * INTEGRATION_MULTIPLIER
+        )
+        method = kwargs.pop(
+            "method",
+            self.engine.method.Tsit5(
+                rtol=1e-8,
+                atol=1e-8,
+                max_steps=max(nsteps, 100000),
+            ),
+        )
+        options = kwargs.pop(
+            "options",
+            self.engine.Options(progress_meter=False),
+        )
+
+        hamiltonian = self._time_hamiltonian(hamiltonian, time_hamiltonian)
+        collapse_operators = [unwrap(op) for op in (collapse_operators or [])]
+
+        sim_results = self.engine.mesolve(
+            hamiltonian,
+            collapse_operators,
+            self.engine.todm(unwrap(initial_state)),
+            time,
+            method=method,
+            options=options,
+            **kwargs,
+        )
+
+        if save_evolution is not None:
+            self.dump_results(
+                hamiltonian=hamiltonian,
+                sim_results=sim_results,
+                time=time,
+                dump_dir=save_evolution,
+            )
+
+        states = [self._wrap(sim_results.states[i]) for i in range(len(time))]
+        return DynamiqsEvolutionResult(raw=sim_results, states=states)
+
+    def create(self, n: int) -> DynamiqsOperator:
+        """Create operator for n levels system."""
+        return self._wrap(self.engine.create(n))
+
+    def destroy(self, n: int) -> DynamiqsOperator:
+        """Destroy operator for n levels system."""
+        return self._wrap(self.engine.destroy(n))
+
+    def identity(self, n: int) -> DynamiqsOperator:
+        """Identity operator for n levels system."""
+        return self._wrap(self.engine.eye(n))
+
+    def tensor(self, operators: list[Operator]) -> DynamiqsOperator:
+        """Tensor product of a list of operators."""
+        return self._wrap(self.engine.tensor(*(unwrap(op) for op in operators)))
+
+    def expand(
+        self, op: Operator, dims: list[int], targets: int | list[int]
+    ) -> DynamiqsOperator:
+        """Expand operator in larger Hilbert space."""
+        dims = list(dims)
+        targets = [targets] if isinstance(targets, int) else list(targets)
+        target_dims = [dims[target] for target in targets]
+        untouched = [i for i in range(len(dims)) if i not in targets]
+        untouched_dims = [dims[target] for target in untouched]
+
+        operator = self.engine.to_numpy(unwrap(op)).reshape(
+            np.prod(target_dims, dtype=int),
+            np.prod(target_dims, dtype=int),
+        )
+
+        if untouched_dims:
+            compact = np.kron(operator, np.eye(np.prod(untouched_dims, dtype=int)))
+        else:
+            compact = operator
+
+        order = targets + untouched
+        position = {target: i for i, target in enumerate(order)}
+        shape = [dims[i] for i in order] + [dims[i] for i in order]
+        permutation = [position[i] for i in range(len(dims))] + [
+            len(dims) + position[i] for i in range(len(dims))
+        ]
+        expanded = compact.reshape(shape).transpose(permutation).reshape(
+            np.prod(dims, dtype=int),
+            np.prod(dims, dtype=int),
+        )
+
+        return self._wrap(self.engine.asqarray(expanded, dims=tuple(dims)))
+
+    def basis(self, dim: int | list[int], state: int | list[int]) -> DynamiqsOperator:
+        """Basis operator for n levels system."""
+        if isinstance(dim, list):
+            dim = tuple(dim)
+        return self._wrap(self.engine.basis(dim, state))

--- a/tests/instruments/emulator/test_dynamiqs.py
+++ b/tests/instruments/emulator/test_dynamiqs.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import qibolab
+from qibolab._core.execution_parameters import AveragingMode
+from qibolab._core.instruments.emulator.engine import DynamiqsEngine, QutipEngine
+
+pytest.importorskip("dynamiqs")
+
+HERE = Path(__file__).parent
+
+
+def test_dynamiqs_operator_arithmetic():
+    engine = DynamiqsEngine()
+
+    projector = engine.basis(2, 0) * engine.basis(2, 0).dag()
+    np.testing.assert_allclose(projector.full(), np.diag([1, 0]))
+
+    number = engine.create(3) * engine.destroy(3)
+    np.testing.assert_allclose(number.full(), np.diag([0, 1, 2]), atol=1e-15)
+
+
+def test_dynamiqs_expand_matches_qutip():
+    dynamiqs = DynamiqsEngine()
+    qutip = QutipEngine()
+
+    dynamiqs_operator = dynamiqs.tensor([dynamiqs.destroy(2), dynamiqs.create(2)])
+    qutip_operator = qutip.tensor([qutip.destroy(2), qutip.create(2)])
+
+    np.testing.assert_allclose(
+        dynamiqs.expand(dynamiqs_operator, [2, 3, 2], [0, 2]).full(),
+        qutip.expand(qutip_operator, [2, 3, 2], [0, 2]).full(),
+        atol=1e-15,
+    )
+
+
+def test_dynamiqs_engine_sequence(monkeypatch):
+    monkeypatch.setenv("QIBOLAB_PLATFORMS", str(HERE / "platforms"))
+    platform = qibolab.create_platform("qubit")
+    platform.instruments["dummy"].engine = DynamiqsEngine()
+
+    q0 = platform.natives.single_qubit[0]
+    seq = q0.RX() | q0.MZ()
+    acq_handle = list(seq.channel(platform.qubits[0].acquisition))[-1].id
+
+    result = platform.execute(
+        [seq],
+        averaging_mode=AveragingMode.CYCLIC,
+    )
+
+    assert pytest.approx(result[acq_handle], abs=5e-2) == 1


### PR DESCRIPTION
## Summary

This PR adds a Dynamiqs-based simulation engine for the Qibolab emulator, following the existing QuTiP engine interface.

The goal is to make Dynamiqs available as an additional simulation backend without changing the emulator/Hamiltonian code outside the engine boundary. The default emulator engine remains QuTiP; this PR only adds `DynamiqsEngine` as an opt-in engine.

Closes #1411.

## What changed

- Added `DynamiqsEngine` under `qibolab._core.instruments.emulator.engine`.
- Added a small `DynamiqsOperator` wrapper so Dynamiqs `QArray` objects match the operator surface currently expected by the emulator:
  - `dag()`
  - `full()`
  - QuTiP-style matrix multiplication through `*`
  - scalar multiplication/division
  - addition/subtraction
- Converted emulator B-spline pulse coefficients into a JAX-compatible prefactor for `dq.modulated`.
  - This is needed because SciPy `BSpline.__call__` cannot be traced directly by JAX.
- Implemented `evolve()` using `dynamiqs.mesolve`.
- Implemented `create`, `destroy`, `identity`, `tensor`, `expand`, and `basis`.
- Added Dynamiqs to the optional `emulator` extra.
- Refreshed `poetry.lock`.
- Added focused tests for:
  - Dynamiqs operator arithmetic
  - `expand()` parity with the existing QuTiP engine
  - a real one-qubit emulator RX/MZ sequence using `DynamiqsEngine`

## Notes for reviewers

The main compatibility issue is that Qibolab's current Hamiltonian code assumes QuTiP semantics, especially `*` as matrix multiplication. Dynamiqs intentionally uses `@` for matrix multiplication, so this PR keeps that adaptation inside the new engine wrapper instead of changing the Hamiltonian layer.

Time-dependent pulse coefficients also need special handling. The emulator builds SciPy B-splines, but Dynamiqs/JAX needs a traceable function. The helper in the new engine evaluates the B-spline basis using `jax.numpy`, preserving the existing pulse interpolation path while making it usable by Dynamiqs.

No changes were needed outside the `engine` package except dependency metadata and tests.

## Testing

Locally run:

```bash
.venv/bin/poetry check --lock
.venv/bin/ruff check
MPLBACKEND=Agg MPLCONFIGDIR=/Users/denniswayo/unitaryHACK/qibolab/.tmp/matplotlib .venv/bin/python -m pytest
```

Results:

```text
poetry check --lock: passed, with existing Poetry metadata deprecation warnings
ruff check: All checks passed
pytest: 226 passed, 36 skipped, 22 deselected, 1 xpassed
```

Note: the first full pytest attempt without `MPLBACKEND=Agg` aborted in the local headless session when Matplotlib selected the macOS GUI backend for `tests/pulses/test_plot.py`. Re-running with the non-GUI Agg backend passed.
