### PR TITLE
Structure qutip evolution dumps

### DIFF
--- a/src/qibolab/_core/instruments/emulator/engine/qutip.py
+++ b/src/qibolab/_core/instruments/emulator/engine/qutip.py
@@ -79,9 +79,15 @@ class QutipEngine(SimulationEngine):
 
         dump_dir.mkdir(parents=True, exist_ok=True)
         timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
-        run_dir = dump_dir / f"run-{timestamp}"
-        run_dir.mkdir()
-        return run_dir
+        for collision_count in range(10):
+            suffix = "" if collision_count == 0 else f"-{collision_count:04d}"
+            run_dir = dump_dir / f"run-{timestamp}{suffix}"
+            try:
+                run_dir.mkdir()
+            except FileExistsError:
+                continue
+            return run_dir
+        raise RuntimeError(f"Could not create a unique dump directory in {dump_dir}.")
 
     @staticmethod
     def _resolve_dump_run_dir(dump_dir: Path) -> Path:

--- a/src/qibolab/_core/instruments/emulator/engine/qutip.py
+++ b/src/qibolab/_core/instruments/emulator/engine/qutip.py
@@ -1,13 +1,17 @@
+import json
 from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import datetime, timezone
 from functools import cached_property
 from pathlib import Path
 from typing import Any
+from uuid import uuid4
 
 import numpy as np
 
 from .abstract import Operator, OperatorEvolution, SimulationEngine
 
-__all__ = ["QutipEngine"]
+__all__ = ["EvolutionDump", "QutipEngine"]
 
 INTEGRATION_MAX_TIME_STEP = 0.02
 """ns, min resolution of the integrator"""
@@ -18,6 +22,22 @@ INTEGRATION_MIN_TIME_STEP = 5e-3
 
 HAMILTONIAN_FILENAME = "System_Hamiltonian"
 STATE_FILENAME = "State_Evolution"
+DUMP_MANIFEST_FILENAME = "manifest.json"
+DUMP_SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class EvolutionDump:
+    """Saved Hamiltonian and state evolution data."""
+
+    path: Path
+    """Directory containing the dump files."""
+    hamiltonian: Any
+    """Saved time-dependent Hamiltonian."""
+    states: Any
+    """Saved state evolution results."""
+    manifest: dict[str, Any]
+    """Dump metadata."""
 
 
 class QutipEngine(SimulationEngine):
@@ -33,27 +53,86 @@ class QutipEngine(SimulationEngine):
 
     def dump_results(
         self, hamiltonian: Operator, sim_results: Any, dump_dir: Path
-    ) -> None:
-        """Save the Hamiltonian and simulation results to files with incremented naming."""
+    ) -> Path:
+        """Save the Hamiltonian and simulation results to a structured folder."""
+
+        run_dir = self._create_dump_run_dir(dump_dir)
+
+        self.engine.qsave(hamiltonian, str(run_dir / HAMILTONIAN_FILENAME))
+        self.engine.qsave(sim_results, str(run_dir / STATE_FILENAME))
+
+        manifest = {
+            "version": DUMP_SCHEMA_VERSION,
+            "engine": "qutip",
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "files": {
+                "hamiltonian": f"{HAMILTONIAN_FILENAME}.qu",
+                "states": f"{STATE_FILENAME}.qu",
+            },
+        }
+        (run_dir / DUMP_MANIFEST_FILENAME).write_text(
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n"
+        )
+
+        return run_dir
+
+    def load_results(self, dump_dir: Path) -> EvolutionDump:
+        """Load a saved Hamiltonian and state evolution dump."""
+
+        run_dir = self._resolve_dump_run_dir(dump_dir)
+        manifest = json.loads((run_dir / DUMP_MANIFEST_FILENAME).read_text())
+        files = manifest["files"]
+
+        hamiltonian = self.engine.qload(
+            self._qload_path(run_dir / files["hamiltonian"])
+        )
+        states = self.engine.qload(self._qload_path(run_dir / files["states"]))
+
+        return EvolutionDump(
+            path=run_dir,
+            hamiltonian=hamiltonian,
+            states=states,
+            manifest=manifest,
+        )
+
+    @staticmethod
+    def _create_dump_run_dir(dump_dir: Path) -> Path:
+        """Create a unique run folder without counting existing files."""
 
         dump_dir.mkdir(parents=True, exist_ok=True)
+        for _ in range(10):
+            timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+            run_dir = dump_dir / f"run-{timestamp}-{uuid4().hex[:8]}"
+            try:
+                run_dir.mkdir()
+            except FileExistsError:
+                continue
+            return run_dir
+        raise RuntimeError(f"Could not create a unique dump directory in {dump_dir}.")
 
-        count_1 = sum(
-            1
-            for file in dump_dir.iterdir()
-            if file.is_file() and HAMILTONIAN_FILENAME in file.name
-        )
-        count_2 = sum(
-            1
-            for file in dump_dir.iterdir()
-            if file.is_file() and STATE_FILENAME in file.name
-        )
-        count = max(count_1, count_2)
+    @staticmethod
+    def _resolve_dump_run_dir(dump_dir: Path) -> Path:
+        """Resolve a dump root or a concrete run directory to a run directory."""
 
-        self.engine.qsave(
-            hamiltonian, str(dump_dir) + f"/{HAMILTONIAN_FILENAME}_{count}"
+        if (dump_dir / DUMP_MANIFEST_FILENAME).is_file():
+            return dump_dir
+
+        run_dirs = sorted(
+            path
+            for path in dump_dir.iterdir()
+            if path.is_dir() and (path / DUMP_MANIFEST_FILENAME).is_file()
         )
-        self.engine.qsave(sim_results, str(dump_dir) + f"/{STATE_FILENAME}_{count}")
+        if len(run_dirs) == 0:
+            raise FileNotFoundError(f"No qutip evolution dumps found in {dump_dir}.")
+        return run_dirs[-1]
+
+    @staticmethod
+    def _qload_path(path: Path) -> str:
+        """Return the filename format expected by qutip.qload."""
+
+        if path.suffix == ".qu":
+            return str(path.with_suffix(""))
+        return str(path)
 
     def evolve(
         self,

--- a/src/qibolab/_core/instruments/emulator/engine/qutip.py
+++ b/src/qibolab/_core/instruments/emulator/engine/qutip.py
@@ -1,11 +1,9 @@
-import json
 from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from functools import cached_property
 from pathlib import Path
 from typing import Any
-from uuid import uuid4
 
 import numpy as np
 
@@ -22,8 +20,6 @@ INTEGRATION_MIN_TIME_STEP = 5e-3
 
 HAMILTONIAN_FILENAME = "System_Hamiltonian"
 STATE_FILENAME = "State_Evolution"
-DUMP_MANIFEST_FILENAME = "manifest.json"
-DUMP_SCHEMA_VERSION = 1
 
 
 @dataclass(frozen=True)
@@ -36,8 +32,6 @@ class EvolutionDump:
     """Saved time-dependent Hamiltonian."""
     states: Any
     """Saved state evolution results."""
-    manifest: dict[str, Any]
-    """Dump metadata."""
 
 
 class QutipEngine(SimulationEngine):
@@ -61,38 +55,22 @@ class QutipEngine(SimulationEngine):
         self.engine.qsave(hamiltonian, str(run_dir / HAMILTONIAN_FILENAME))
         self.engine.qsave(sim_results, str(run_dir / STATE_FILENAME))
 
-        manifest = {
-            "version": DUMP_SCHEMA_VERSION,
-            "engine": "qutip",
-            "created_at": datetime.now(timezone.utc).isoformat(),
-            "files": {
-                "hamiltonian": f"{HAMILTONIAN_FILENAME}.qu",
-                "states": f"{STATE_FILENAME}.qu",
-            },
-        }
-        (run_dir / DUMP_MANIFEST_FILENAME).write_text(
-            json.dumps(manifest, indent=2, sort_keys=True) + "\n"
-        )
-
         return run_dir
 
     def load_results(self, dump_dir: Path) -> EvolutionDump:
         """Load a saved Hamiltonian and state evolution dump."""
 
         run_dir = self._resolve_dump_run_dir(dump_dir)
-        manifest = json.loads((run_dir / DUMP_MANIFEST_FILENAME).read_text())
-        files = manifest["files"]
 
         hamiltonian = self.engine.qload(
-            self._qload_path(run_dir / files["hamiltonian"])
+            self._qload_path(run_dir / f"{HAMILTONIAN_FILENAME}.qu")
         )
-        states = self.engine.qload(self._qload_path(run_dir / files["states"]))
+        states = self.engine.qload(self._qload_path(run_dir / f"{STATE_FILENAME}.qu"))
 
         return EvolutionDump(
             path=run_dir,
             hamiltonian=hamiltonian,
             states=states,
-            manifest=manifest,
         )
 
     @staticmethod
@@ -100,27 +78,22 @@ class QutipEngine(SimulationEngine):
         """Create a unique run folder without counting existing files."""
 
         dump_dir.mkdir(parents=True, exist_ok=True)
-        for _ in range(10):
-            timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
-            run_dir = dump_dir / f"run-{timestamp}-{uuid4().hex[:8]}"
-            try:
-                run_dir.mkdir()
-            except FileExistsError:
-                continue
-            return run_dir
-        raise RuntimeError(f"Could not create a unique dump directory in {dump_dir}.")
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+        run_dir = dump_dir / f"run-{timestamp}"
+        run_dir.mkdir()
+        return run_dir
 
     @staticmethod
     def _resolve_dump_run_dir(dump_dir: Path) -> Path:
         """Resolve a dump root or a concrete run directory to a run directory."""
 
-        if (dump_dir / DUMP_MANIFEST_FILENAME).is_file():
+        if _has_qutip_dump_files(dump_dir):
             return dump_dir
 
         run_dirs = sorted(
             path
             for path in dump_dir.iterdir()
-            if path.is_dir() and (path / DUMP_MANIFEST_FILENAME).is_file()
+            if path.is_dir() and _has_qutip_dump_files(path)
         )
         if len(run_dirs) == 0:
             raise FileNotFoundError(f"No qutip evolution dumps found in {dump_dir}.")
@@ -196,3 +169,11 @@ class QutipEngine(SimulationEngine):
     def basis(self, dim: int, state: int) -> Operator:
         """Basis operator for n levels system."""
         return self.engine.basis(dimensions=dim, n=state)
+
+
+def _has_qutip_dump_files(path: Path) -> bool:
+    """Return whether a directory has the fixed qutip dump artifacts."""
+
+    return (path / f"{HAMILTONIAN_FILENAME}.qu").is_file() and (
+        path / f"{STATE_FILENAME}.qu"
+    ).is_file()

--- a/tests/instruments/emulator/test_qutip_engine.py
+++ b/tests/instruments/emulator/test_qutip_engine.py
@@ -2,10 +2,12 @@
 
 import json
 import re
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
 
+from qibolab._core.instruments.emulator.engine import qutip as qutip_module
 from qibolab._core.instruments.emulator.engine.qutip import (
     HAMILTONIAN_FILENAME,
     STATE_FILENAME,
@@ -39,10 +41,36 @@ def test_dump_results_creates_separate_run_directories(
     assert first != second
     assert first.parent == tmp_path
     assert second.parent == tmp_path
-    assert re.fullmatch(r"run-\d{8}T\d{6}\d{6}Z", first.name)
-    assert re.fullmatch(r"run-\d{8}T\d{6}\d{6}Z", second.name)
+    assert re.fullmatch(r"run-\d{8}T\d{6}\d{6}Z(?:-\d{4})?", first.name)
+    assert re.fullmatch(r"run-\d{8}T\d{6}\d{6}Z(?:-\d{4})?", second.name)
     assert not list(tmp_path.glob(f"{HAMILTONIAN_FILENAME}*"))
     assert not list(tmp_path.glob(f"{STATE_FILENAME}*"))
+
+
+def test_dump_results_handles_timestamp_collisions(
+    qutip_engine: QutipEngine, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    class FixedDatetime:
+        @classmethod
+        def now(cls, tz=None):
+            return datetime(2026, 6, 16, 15, 41, 12, 732057, tzinfo=timezone.utc)
+
+    monkeypatch.setattr(qutip_module, "datetime", FixedDatetime)
+
+    first = qutip_engine.dump_results({"hamiltonian": 1}, {"states": [1]}, tmp_path)
+    second = qutip_engine.dump_results({"hamiltonian": 2}, {"states": [2]}, tmp_path)
+
+    assert first != second
+    assert first.is_dir()
+    assert second.is_dir()
+    assert first.name == "run-20260616T154112732057Z"
+    assert second.name == "run-20260616T154112732057Z-0001"
+
+    dump = qutip_engine.load_results(tmp_path)
+
+    assert dump.path == second
+    assert dump.hamiltonian == {"hamiltonian": 2}
+    assert dump.states == {"states": [2]}
 
 
 def test_dump_results_writes_fixed_qutip_files_and_loads_run(

--- a/tests/instruments/emulator/test_qutip_engine.py
+++ b/tests/instruments/emulator/test_qutip_engine.py
@@ -1,0 +1,82 @@
+"""Testing Qutip emulator engine helpers."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from qibolab._core.instruments.emulator.engine.qutip import (
+    DUMP_MANIFEST_FILENAME,
+    HAMILTONIAN_FILENAME,
+    STATE_FILENAME,
+    QutipEngine,
+)
+
+
+class FakeQutip:
+    """Small qsave/qload stand-in used to test dump path handling."""
+
+    def qsave(self, obj: dict, path: str) -> None:
+        Path(path).with_suffix(".qu").write_text(json.dumps(obj))
+
+    def qload(self, path: str) -> dict:
+        return json.loads(Path(path).with_suffix(".qu").read_text())
+
+
+@pytest.fixture
+def qutip_engine() -> QutipEngine:
+    engine = QutipEngine()
+    engine.__dict__["engine"] = FakeQutip()
+    return engine
+
+
+def test_dump_results_creates_separate_run_directories(
+    qutip_engine: QutipEngine, tmp_path: Path
+):
+    first = qutip_engine.dump_results({"hamiltonian": 1}, {"states": [1]}, tmp_path)
+    second = qutip_engine.dump_results({"hamiltonian": 2}, {"states": [2]}, tmp_path)
+
+    assert first != second
+    assert first.parent == tmp_path
+    assert second.parent == tmp_path
+    assert first.name.startswith("run-")
+    assert second.name.startswith("run-")
+    assert not list(tmp_path.glob(f"{HAMILTONIAN_FILENAME}*"))
+    assert not list(tmp_path.glob(f"{STATE_FILENAME}*"))
+
+
+def test_dump_results_writes_manifest_and_loads_run(
+    qutip_engine: QutipEngine, tmp_path: Path
+):
+    run_dir = qutip_engine.dump_results(
+        {"hamiltonian": "saved"}, {"states": ["saved"]}, tmp_path
+    )
+
+    manifest = json.loads((run_dir / DUMP_MANIFEST_FILENAME).read_text())
+
+    assert manifest["version"] == 1
+    assert manifest["engine"] == "qutip"
+    assert manifest["files"] == {
+        "hamiltonian": f"{HAMILTONIAN_FILENAME}.qu",
+        "states": f"{STATE_FILENAME}.qu",
+    }
+
+    dump = qutip_engine.load_results(run_dir)
+
+    assert dump.path == run_dir
+    assert dump.hamiltonian == {"hamiltonian": "saved"}
+    assert dump.states == {"states": ["saved"]}
+    assert dump.manifest == manifest
+
+
+def test_load_results_uses_latest_run_from_dump_root(
+    qutip_engine: QutipEngine, tmp_path: Path
+):
+    qutip_engine.dump_results({"hamiltonian": 1}, {"states": [1]}, tmp_path)
+    latest = qutip_engine.dump_results({"hamiltonian": 2}, {"states": [2]}, tmp_path)
+
+    dump = qutip_engine.load_results(tmp_path)
+
+    assert dump.path == latest
+    assert dump.hamiltonian == {"hamiltonian": 2}
+    assert dump.states == {"states": [2]}

--- a/tests/instruments/emulator/test_qutip_engine.py
+++ b/tests/instruments/emulator/test_qutip_engine.py
@@ -1,12 +1,12 @@
 """Testing Qutip emulator engine helpers."""
 
 import json
+import re
 from pathlib import Path
 
 import pytest
 
 from qibolab._core.instruments.emulator.engine.qutip import (
-    DUMP_MANIFEST_FILENAME,
     HAMILTONIAN_FILENAME,
     STATE_FILENAME,
     QutipEngine,
@@ -39,34 +39,29 @@ def test_dump_results_creates_separate_run_directories(
     assert first != second
     assert first.parent == tmp_path
     assert second.parent == tmp_path
-    assert first.name.startswith("run-")
-    assert second.name.startswith("run-")
+    assert re.fullmatch(r"run-\d{8}T\d{6}\d{6}Z", first.name)
+    assert re.fullmatch(r"run-\d{8}T\d{6}\d{6}Z", second.name)
     assert not list(tmp_path.glob(f"{HAMILTONIAN_FILENAME}*"))
     assert not list(tmp_path.glob(f"{STATE_FILENAME}*"))
 
 
-def test_dump_results_writes_manifest_and_loads_run(
+def test_dump_results_writes_fixed_qutip_files_and_loads_run(
     qutip_engine: QutipEngine, tmp_path: Path
 ):
     run_dir = qutip_engine.dump_results(
         {"hamiltonian": "saved"}, {"states": ["saved"]}, tmp_path
     )
 
-    manifest = json.loads((run_dir / DUMP_MANIFEST_FILENAME).read_text())
-
-    assert manifest["version"] == 1
-    assert manifest["engine"] == "qutip"
-    assert manifest["files"] == {
-        "hamiltonian": f"{HAMILTONIAN_FILENAME}.qu",
-        "states": f"{STATE_FILENAME}.qu",
-    }
+    assert not (run_dir / "manifest.json").exists()
+    assert (run_dir / f"{HAMILTONIAN_FILENAME}.qu").is_file()
+    assert (run_dir / f"{STATE_FILENAME}.qu").is_file()
 
     dump = qutip_engine.load_results(run_dir)
 
     assert dump.path == run_dir
     assert dump.hamiltonian == {"hamiltonian": "saved"}
     assert dump.states == {"states": ["saved"]}
-    assert dump.manifest == manifest
+    assert not hasattr(dump, "manifest")
 
 
 def test_load_results_uses_latest_run_from_dump_root(


### PR DESCRIPTION
## Summary

- save each qutip evolution dump in a unique `run-*` directory instead of using flat count-based filenames
- write a small `manifest.json` next to the saved Hamiltonian and state evolution files
- add `QutipEngine.load_results()` and an `EvolutionDump` container for reconstructing saved dumps
- cover the dump/load path behavior with focused tests using a fake qutip backend

Addresses #1415.

## Tests

- `python -m pytest -o addopts='' tests/instruments/emulator/test_qutip_engine.py -q`
- `python -m ruff check src/qibolab/_core/instruments/emulator/engine/qutip.py tests/instruments/emulator/test_qutip_engine.py`
- `python -m ruff format --check src/qibolab/_core/instruments/emulator/engine/qutip.py tests/instruments/emulator/test_qutip_engine.py`