### PR TITLE
Batch-store emulator evolution dumps with loaders

### DIFF
--- a/src/qibolab/_core/instruments/emulator/emulator.py
+++ b/src/qibolab/_core/instruments/emulator/emulator.py
@@ -91,7 +91,9 @@ class EmulatorController(Controller):
         time_hamiltonian = self._pulse_hamiltonian(sequence, configs)
         time_ops = time_hamiltonian.operators if time_hamiltonian is not None else []
         operators = [static] + time_ops
-        time_grid = time_hamiltonian.times if time_hamiltonian is not None else np.array([])
+        time_grid = (
+            time_hamiltonian.times if time_hamiltonian is not None else np.array([])
+        )
 
         self.engine.dump_evolution(
             dump_dir,

--- a/src/qibolab/_core/instruments/emulator/emulator.py
+++ b/src/qibolab/_core/instruments/emulator/emulator.py
@@ -9,10 +9,9 @@ from typing import cast
 
 import numpy as np
 from numpy.typing import NDArray
-from scipy.interpolate import BSpline, make_interp_spline
 
 from qibolab._core.components import Config
-from qibolab._core.components.configs import AcquisitionConfig
+from qibolab._core.components.configs import AcquisitionConfig, LogConfig
 from qibolab._core.execution_parameters import AveragingMode, ExecutionParameters
 from qibolab._core.identifier import Result
 from qibolab._core.instruments.abstract import Controller
@@ -33,8 +32,6 @@ from .hamiltonians import (
 )
 from .results import acquisitions, index, results
 
-SPLINE_INTERP_ORDER = 3
-"""Polynomial order used for interpolating the pulses with a spline function."""
 NYQUIST_FREQUENCY = 20
 """GHz, Nyquist frequency used for computing the solution and resolve qubit oscillations."""
 SAMPLING_INTERVAL = 1 / (2 * NYQUIST_FREQUENCY)
@@ -68,6 +65,41 @@ class EmulatorController(Controller):
 
     def disconnect(self):
         """Dummy disconnect method."""
+
+    def _evolution_dump_path(self, configs: dict[str, Config]) -> Path | None:
+        """Resolve the dump directory from ``LogConfig`` or ``save_dir``."""
+        if "log" in configs:
+            log = configs["log"]
+            if isinstance(log, LogConfig):
+                return log.path / "evolution"
+        return self.save_dir
+
+    def _dump_simulation(
+        self,
+        sequence: PulseSequence,
+        configs: dict[str, Config],
+        states: NDArray,
+        coefficients: NDArray | None,
+    ) -> None:
+        """Write operators once and batch store coefficients and density matrices."""
+        dump_dir = self._evolution_dump_path(configs)
+        if dump_dir is None:
+            return
+
+        config = cast(HamiltonianConfig, configs["hamiltonian"])
+        static = config.hamiltonian(config=configs, engine=self.engine)
+        time_hamiltonian = self._pulse_hamiltonian(sequence, configs)
+        time_ops = time_hamiltonian.operators if time_hamiltonian is not None else []
+        operators = [static] + time_ops
+        time_grid = time_hamiltonian.times if time_hamiltonian is not None else np.array([])
+
+        self.engine.dump_evolution(
+            dump_dir,
+            operators=operators,
+            time_grid=time_grid,
+            time_coefficients=coefficients,
+            density_matrices=states,
+        )
 
     def play(
         self,
@@ -106,11 +138,13 @@ class EmulatorController(Controller):
         into a structured results object containing quantum states and measurement data.
         """
 
-        sweep_results = self._sweep(sequence, configs, sweepers)
+        sweep_states, sweep_coefficients = self._sweep(sequence, configs, sweepers)
+        if self._evolution_dump_path(configs) is not None:
+            self._dump_simulation(sequence, configs, sweep_states, sweep_coefficients)
         hamiltonian = cast(HamiltonianConfig, configs["hamiltonian"])
         return results(
             # states in computational basis
-            states=sweep_results,
+            states=sweep_states,
             sequence=sequence,
             hamiltonian=hamiltonian,
             options=options,
@@ -136,9 +170,9 @@ class EmulatorController(Controller):
         if len(sweepers) == 0:
             return self._evolve(sequence, configs, updates)
 
+        state_slices: list[NDArray] = []
+        coeff_slices = []
         parsweep = sweepers[0]
-        # collect slices of results, corresponding to the current iteration
-        results = []
         # execute once for each parallel value
         for values in zip(*(s.values for s in parsweep)):
             # update all parallel sweepers with the respective values
@@ -150,11 +184,14 @@ class EmulatorController(Controller):
                     for channel in sweeper.channels:
                         updates[channel].update({sweeper.parameter.name: value})
 
-            # append new slice for the current parallel value
-            results.append(self._sweep(sequence, configs, sweepers[1:], updates))
+            states, coeffs = self._sweep(sequence, configs, sweepers[1:], updates)
+            state_slices.append(states)
+            coeff_slices.append(coeffs)
 
-        # stack all slices in a single array, along the current outermost dimension
-        return np.stack(results)
+        stacked_states = np.stack(state_slices)
+        if coeff_slices[0] is None:
+            return stacked_states, None
+        return stacked_states, np.stack(coeff_slices)
 
     def _evolve(
         self, sequence: PulseSequence, configs: dict[str, Config], updates: dict
@@ -182,9 +219,12 @@ class EmulatorController(Controller):
             time=np.concatenate(([0], tlist_)),
             collapse_operators=config.dissipation(self.engine),
             time_hamiltonian=time_hamiltonian,
-            save_evolution=self.save_dir,
         )
-        return np.stack([s.full() for s in results.states[1:]])[index]
+        states = np.stack([s.full() for s in results.states[1:]])[index]
+        coefficients = (
+            time_hamiltonian.coefficients if time_hamiltonian is not None else None
+        )
+        return states, coefficients
 
     def _pulse_hamiltonian(
         self, sequence: PulseSequence, configs: dict[str, Config]
@@ -196,21 +236,25 @@ class EmulatorController(Controller):
         # the oscillation and correctly solve the system evolution, hence we
         # set a nyquist frequency to define the timesteps in order to compute the solution
         times = tlist(sequence)
-
-        channels = [
-            [
-                operator,
-                channel_coefficients(
-                    waveforms,
-                    sampling_rate=self.sampling_rate,
-                    times=times,
-                ),
-            ]
-            for operator, waveforms in hamiltonians(
-                sequence, configs, self.engine, self.sampling_rate
+        channels, raw_coefficients = [], []
+        for operator, waveforms in hamiltonians(
+            sequence, configs, self.engine, self.sampling_rate
+        ):
+            raw = channel_coefficients(
+                waveforms, sampling_rate=self.sampling_rate, times=times
             )
-        ]
-        return OperatorEvolution(channels) if len(channels) > 0 else None
+            channels.append(operator)
+            raw_coefficients.append(raw)
+
+        return (
+            OperatorEvolution(
+                operators=channels,
+                coefficients=np.stack(raw_coefficients),
+                times=times,
+            )
+            if len(channels) > 0
+            else None
+        )
 
 
 def update_sequence(sequence: PulseSequence, updates: dict) -> PulseSequence:
@@ -283,7 +327,7 @@ def channel_coefficients(
     waveforms: Iterable[Modulated],
     sampling_rate: int,
     times: NDArray,
-) -> BSpline:
+) -> NDArray:
     """
     Generate a B-spline interpolation of waveforms over a time evolution.
     This function processes a sequence of pulses, accumulating their waveforms
@@ -313,4 +357,4 @@ def channel_coefficients(
         cumulative_time = next_pulse_time
 
     # return pulse_waveforms
-    return make_interp_spline(times, pulse_waveforms, k=SPLINE_INTERP_ORDER)
+    return pulse_waveforms

--- a/src/qibolab/_core/instruments/emulator/engine/__init__.py
+++ b/src/qibolab/_core/instruments/emulator/engine/__init__.py
@@ -1,7 +1,9 @@
-from . import abstract, qutip
+from . import abstract, evolution_dump, qutip
 from .abstract import *
+from .evolution_dump import *
 from .qutip import *
 
 __all__ = []
 __all__.extend(abstract.__all__)
+__all__.extend(evolution_dump.__all__)
 __all__.extend(qutip.__all__)

--- a/src/qibolab/_core/instruments/emulator/engine/abstract.py
+++ b/src/qibolab/_core/instruments/emulator/engine/abstract.py
@@ -4,6 +4,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Protocol
 
+from numpy.typing import NDArray
 from scipy.interpolate import BSpline
 
 from ....serialize import Model
@@ -52,7 +53,9 @@ class EvolutionResult(Protocol):
 class OperatorEvolution:
     """Abstract operator evolution interface."""
 
-    operators: list[Operator | TimeDependentOperator] = field(default_factory=list)
+    operators: list[Operator] = field(default_factory=list)
+    coefficients: NDArray | None = None
+    times: NDArray | None = None
 
 
 class SimulationEngine(Model, ABC):
@@ -99,3 +102,7 @@ class SimulationEngine(Model, ABC):
     @abstractmethod
     def basis(self, n: int, state: int) -> Operator:
         """Basis operator for n levels system."""
+
+    @abstractmethod
+    def save_operators(self, operators, dump_dir) -> None:
+        """Persist static operators in the engine's native format."""

--- a/src/qibolab/_core/instruments/emulator/engine/evolution_dump.py
+++ b/src/qibolab/_core/instruments/emulator/engine/evolution_dump.py
@@ -1,0 +1,160 @@
+"""Utilities for storing and loading emulator evolution data."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+from scipy.interpolate import BSpline, make_interp_spline
+
+SPLINE_ORDER = 3
+
+__all__ = [
+    "DENSITY_MATRICES_FILENAME",
+    "DUMP_SCHEMA_VERSION",
+    "EvolutionDump",
+    "MANIFEST_FILENAME",
+    "OPERATORS_FILENAME",
+    "TIME_COEFFICIENTS_FILENAME",
+    "TIME_GRID_FILENAME",
+    "dump_evolution",
+    "load_evolution_dump",
+]
+
+DUMP_SCHEMA_VERSION = 1
+MANIFEST_FILENAME = "manifest.json"
+OPERATORS_FILENAME = "operators"
+TIME_GRID_FILENAME = "time_grid.npy"
+TIME_COEFFICIENTS_FILENAME = "time_coefficients.npy"
+DENSITY_MATRICES_FILENAME = "density_matrices.npy"
+SPLINE_ORDER = 3
+
+
+@dataclass(frozen=True)
+class EvolutionDump:
+    """Saved Hamiltonian operators, drive coefficients, and state traces."""
+
+    path: Path
+    """Directory containing the dump files."""
+    manifest: dict[str, Any]
+    """Dump metadata."""
+    operators: Any
+    """Static and time-dependent operators in the engine-native format."""
+    time_grid: NDArray
+    """Time samples used for the drive coefficients."""
+    time_coefficients: NDArray | None
+    """Drive coefficients with shape ``(*sweep_shape, n_channels, n_times)``."""
+    density_matrices: NDArray
+    """Density matrices with shape ``(*sweep_shape, n_measurements, dim, dim)``."""
+
+    def coefficient_splines(
+        self, sweep_index: tuple[int, ...] | int = ()
+    ) -> list[BSpline]:
+        """Build B-splines for a selected sweep point."""
+        if self.time_coefficients is None:
+            return []
+
+        if sweep_index == ():
+            coeffs = self.time_coefficients
+        elif isinstance(sweep_index, int):
+            coeffs = self.time_coefficients[sweep_index]
+        else:
+            coeffs = self.time_coefficients[sweep_index]
+        if coeffs.ndim == 1:
+            coeffs = coeffs[None]
+
+        return [
+            make_interp_spline(
+                self.time_grid,
+                channel_coeff,
+                k=min(SPLINE_ORDER, len(self.time_grid) - 1),
+            )
+            for channel_coeff in coeffs
+        ]
+
+    def density_matrices_at(self, sweep_index: tuple[int, ...] | int = ()) -> NDArray:
+        """Return density matrices for a selected sweep point."""
+        if sweep_index == ():
+            return self.density_matrices
+        if isinstance(sweep_index, int):
+            return self.density_matrices[sweep_index]
+        return self.density_matrices[sweep_index]
+
+
+def dump_evolution(
+    dump_dir: Path,
+    *,
+    engine: Any,
+    operators: Any,
+    time_grid: NDArray,
+    time_coefficients: NDArray | None,
+    density_matrices: NDArray,
+) -> Path:
+    """Persist a structured evolution dump for one experiment execution."""
+    dump_dir.mkdir(parents=True, exist_ok=True)
+
+    engine.qsave(operators, str(dump_dir / OPERATORS_FILENAME))
+    np.save(dump_dir / TIME_GRID_FILENAME, time_grid)
+    if time_coefficients is not None:
+        np.save(dump_dir / TIME_COEFFICIENTS_FILENAME, time_coefficients)
+    np.save(dump_dir / DENSITY_MATRICES_FILENAME, density_matrices)
+
+    manifest = {
+        "version": DUMP_SCHEMA_VERSION,
+        "engine": "qutip",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "files": {
+            "operators": f"{OPERATORS_FILENAME}.qu",
+            "time_grid": TIME_GRID_FILENAME,
+            "density_matrices": DENSITY_MATRICES_FILENAME,
+        },
+        "shapes": {
+            "time_grid": list(time_grid.shape),
+            "density_matrices": list(density_matrices.shape),
+        },
+    }
+    if time_coefficients is not None:
+        manifest["files"]["time_coefficients"] = TIME_COEFFICIENTS_FILENAME
+        manifest["shapes"]["time_coefficients"] = list(time_coefficients.shape)
+
+    (dump_dir / MANIFEST_FILENAME).write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n"
+    )
+    return dump_dir
+
+
+def load_evolution_dump(dump_dir: Path, *, engine: Any) -> EvolutionDump:
+    """Load a structured evolution dump written by :func:`dump_evolution`."""
+    if not (dump_dir / MANIFEST_FILENAME).is_file():
+        raise FileNotFoundError(f"No evolution dump manifest found in {dump_dir}.")
+
+    manifest = json.loads((dump_dir / MANIFEST_FILENAME).read_text())
+    files = manifest["files"]
+
+    operators = engine.qload(_qload_path(dump_dir / files["operators"]))
+    time_grid = np.load(dump_dir / files["time_grid"])
+    density_matrices = np.load(dump_dir / files["density_matrices"])
+    time_coefficients = None
+    if "time_coefficients" in files:
+        time_coefficients = np.load(dump_dir / files["time_coefficients"])
+
+    return EvolutionDump(
+        path=dump_dir,
+        manifest=manifest,
+        operators=operators,
+        time_grid=time_grid,
+        time_coefficients=time_coefficients,
+        density_matrices=density_matrices,
+    )
+
+
+def _qload_path(path: Path) -> str:
+    """Return the filename format expected by ``qutip.qload``."""
+    if path.suffix == ".qu":
+        return str(path.with_suffix(""))
+    return str(path)

--- a/src/qibolab/_core/instruments/emulator/engine/qutip.py
+++ b/src/qibolab/_core/instruments/emulator/engine/qutip.py
@@ -7,8 +7,8 @@ from scipy.interpolate import make_interp_spline
 
 from .abstract import Operator, OperatorEvolution, SimulationEngine
 from .evolution_dump import (
-    EvolutionDump,
     SPLINE_ORDER,
+    EvolutionDump,
     dump_evolution,
     load_evolution_dump,
 )

--- a/src/qibolab/_core/instruments/emulator/engine/qutip.py
+++ b/src/qibolab/_core/instruments/emulator/engine/qutip.py
@@ -1,13 +1,19 @@
 from collections.abc import Iterable
 from functools import cached_property
 from pathlib import Path
-from typing import Any
 
 import numpy as np
+from scipy.interpolate import make_interp_spline
 
 from .abstract import Operator, OperatorEvolution, SimulationEngine
+from .evolution_dump import (
+    EvolutionDump,
+    SPLINE_ORDER,
+    dump_evolution,
+    load_evolution_dump,
+)
 
-__all__ = ["QutipEngine"]
+__all__ = ["EvolutionDump", "QutipEngine"]
 
 INTEGRATION_MAX_TIME_STEP = 0.02
 """ns, min resolution of the integrator"""
@@ -15,9 +21,6 @@ INTEGRATION_MULTIPLIER = 200
 """factor for computing max number of steps for the ode solver"""
 INTEGRATION_MIN_TIME_STEP = 5e-3
 """ns, max resolution of the integrator"""
-
-HAMILTONIAN_FILENAME = "System_Hamiltonian"
-STATE_FILENAME = "State_Evolution"
 
 
 class QutipEngine(SimulationEngine):
@@ -31,29 +34,33 @@ class QutipEngine(SimulationEngine):
 
         return qt
 
-    def dump_results(
-        self, hamiltonian: Operator, sim_results: Any, dump_dir: Path
-    ) -> None:
-        """Save the Hamiltonian and simulation results to files with incremented naming."""
-
+    def save_operators(self, operators, dump_dir: Path) -> None:
+        """Persist Hamiltonian operators once per experiment."""
         dump_dir.mkdir(parents=True, exist_ok=True)
+        self.engine.qsave(operators, str(dump_dir / "operators"))
 
-        count_1 = sum(
-            1
-            for file in dump_dir.iterdir()
-            if file.is_file() and HAMILTONIAN_FILENAME in file.name
+    def dump_evolution(
+        self,
+        dump_dir: Path,
+        *,
+        operators,
+        time_grid: np.ndarray,
+        time_coefficients: np.ndarray | None,
+        density_matrices: np.ndarray,
+    ) -> Path:
+        """Save operators, coefficients, and density matrices in a structured dump."""
+        return dump_evolution(
+            dump_dir,
+            engine=self.engine,
+            operators=operators,
+            time_grid=time_grid,
+            time_coefficients=time_coefficients,
+            density_matrices=density_matrices,
         )
-        count_2 = sum(
-            1
-            for file in dump_dir.iterdir()
-            if file.is_file() and STATE_FILENAME in file.name
-        )
-        count = max(count_1, count_2)
 
-        self.engine.qsave(
-            hamiltonian, str(dump_dir) + f"/{HAMILTONIAN_FILENAME}_{count}"
-        )
-        self.engine.qsave(sim_results, str(dump_dir) + f"/{STATE_FILENAME}_{count}")
+    def load_evolution_dump(self, dump_dir: Path) -> EvolutionDump:
+        """Load a structured evolution dump."""
+        return load_evolution_dump(dump_dir, engine=self.engine)
 
     def evolve(
         self,
@@ -62,7 +69,6 @@ class QutipEngine(SimulationEngine):
         time: Iterable[float],
         time_hamiltonian: OperatorEvolution = None,
         collapse_operators: list[Operator] = None,
-        save_evolution: Path | None = None,
         **kwargs,
     ):
         """Evolve the system."""
@@ -74,9 +80,21 @@ class QutipEngine(SimulationEngine):
         options = {"max_step": INTEGRATION_MAX_TIME_STEP, "nsteps": nsteps}
 
         if time_hamiltonian is not None:
-            hamiltonian = [hamiltonian] + time_hamiltonian.operators
+            spline_order = min(SPLINE_ORDER, len(time_hamiltonian.times) - 1)
+            pairs = [
+                [
+                    operator,
+                    make_interp_spline(
+                        time_hamiltonian.times, coefficient, k=spline_order
+                    ),
+                ]
+                for operator, coefficient in zip(
+                    time_hamiltonian.operators, time_hamiltonian.coefficients
+                )
+            ]
+            hamiltonian = [hamiltonian] + pairs
 
-        sim_results = self.engine.mesolve(
+        return self.engine.mesolve(
             hamiltonian,
             initial_state,
             time,
@@ -84,15 +102,6 @@ class QutipEngine(SimulationEngine):
             options=options,
             **kwargs,
         )
-
-        if save_evolution is not None:
-            self.dump_results(
-                hamiltonian=hamiltonian,
-                sim_results=sim_results,
-                dump_dir=save_evolution,
-            )
-
-        return sim_results
 
     def create(self, n: int) -> Operator:
         """Create operator for n levels system."""

--- a/tests/instruments/emulator/test_evolution_dump.py
+++ b/tests/instruments/emulator/test_evolution_dump.py
@@ -13,7 +13,6 @@ from qibolab._core.instruments.emulator.engine.evolution_dump import (
     MANIFEST_FILENAME,
     TIME_COEFFICIENTS_FILENAME,
     TIME_GRID_FILENAME,
-    EvolutionDump,
     dump_evolution,
     load_evolution_dump,
 )

--- a/tests/instruments/emulator/test_evolution_dump.py
+++ b/tests/instruments/emulator/test_evolution_dump.py
@@ -1,0 +1,125 @@
+"""Testing structured emulator evolution dumps."""
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+from scipy.interpolate import BSpline
+
+from qibolab._core.instruments.emulator.engine.evolution_dump import (
+    DENSITY_MATRICES_FILENAME,
+    DUMP_SCHEMA_VERSION,
+    MANIFEST_FILENAME,
+    TIME_COEFFICIENTS_FILENAME,
+    TIME_GRID_FILENAME,
+    EvolutionDump,
+    dump_evolution,
+    load_evolution_dump,
+)
+
+
+class FakeQutip:
+    """Small qsave/qload stand-in used to test dump path handling."""
+
+    def qsave(self, obj, path: str) -> None:
+        Path(path).with_suffix(".qu").write_text(json.dumps(obj))
+
+    def qload(self, path: str):
+        return json.loads(Path(path).with_suffix(".qu").read_text())
+
+
+def test_dump_evolution_writes_manifest_and_arrays(tmp_path: Path):
+    engine = FakeQutip()
+    time_grid = np.linspace(0, 1, 4)
+    coefficients = np.ones((2, time_grid.size))
+    density_matrices = np.zeros((1, 2, 2, 2))
+
+    dump_dir = dump_evolution(
+        tmp_path,
+        engine=engine,
+        operators=[{"static": True}, {"drive": 1}],
+        time_grid=time_grid,
+        time_coefficients=coefficients,
+        density_matrices=density_matrices,
+    )
+
+    manifest = json.loads((dump_dir / MANIFEST_FILENAME).read_text())
+
+    assert manifest["version"] == DUMP_SCHEMA_VERSION
+    assert manifest["engine"] == "qutip"
+    assert manifest["files"]["time_grid"] == TIME_GRID_FILENAME
+    assert manifest["files"]["density_matrices"] == DENSITY_MATRICES_FILENAME
+    assert manifest["files"]["time_coefficients"] == TIME_COEFFICIENTS_FILENAME
+    assert np.allclose(np.load(dump_dir / TIME_GRID_FILENAME), time_grid)
+    assert np.allclose(np.load(dump_dir / TIME_COEFFICIENTS_FILENAME), coefficients)
+    assert np.allclose(np.load(dump_dir / DENSITY_MATRICES_FILENAME), density_matrices)
+
+
+def test_load_evolution_dump_round_trip(tmp_path: Path):
+    engine = FakeQutip()
+    time_grid = np.linspace(0, 1, 5)
+    coefficients = np.arange(10).reshape(2, 5)
+    density_matrices = np.arange(8).reshape(2, 2, 2)
+
+    dump_evolution(
+        tmp_path,
+        engine=engine,
+        operators=["static", "drive"],
+        time_grid=time_grid,
+        time_coefficients=coefficients,
+        density_matrices=density_matrices,
+    )
+
+    dump = load_evolution_dump(tmp_path, engine=engine)
+
+    assert dump.path == tmp_path
+    assert dump.operators == ["static", "drive"]
+    assert np.allclose(dump.time_grid, time_grid)
+    assert np.allclose(dump.time_coefficients, coefficients)
+    assert np.allclose(dump.density_matrices, density_matrices)
+
+
+def test_evolution_dump_reconstructs_splines(tmp_path: Path):
+    engine = FakeQutip()
+    time_grid = np.linspace(0, 1, 6)
+    coefficients = np.stack(
+        [np.sin(2 * np.pi * time_grid), np.cos(2 * np.pi * time_grid)]
+    )
+    density_matrices = np.zeros((2, 2, 2))
+
+    dump_evolution(
+        tmp_path,
+        engine=engine,
+        operators=["static", "drive_a", "drive_b"],
+        time_grid=time_grid,
+        time_coefficients=coefficients,
+        density_matrices=density_matrices,
+    )
+    dump = load_evolution_dump(tmp_path, engine=engine)
+
+    splines = dump.coefficient_splines()
+
+    assert len(splines) == 2
+    assert all(isinstance(spline, BSpline) for spline in splines)
+    assert pytest.approx(splines[0](time_grid[2]), abs=1e-6) == coefficients[0, 2]
+
+
+def test_evolution_dump_supports_sweep_indexing(tmp_path: Path):
+    engine = FakeQutip()
+    time_grid = np.linspace(0, 1, 3)
+    coefficients = np.arange(12).reshape(2, 2, 3)
+    density_matrices = np.arange(16).reshape(2, 2, 2, 2)
+
+    dump_evolution(
+        tmp_path,
+        engine=engine,
+        operators=["static"],
+        time_grid=time_grid,
+        time_coefficients=coefficients,
+        density_matrices=density_matrices,
+    )
+    dump = load_evolution_dump(tmp_path, engine=engine)
+
+    assert np.allclose(dump.coefficient_splines((1, 0))[0](0.5), 7.0)
+    assert np.allclose(dump.density_matrices_at((0, 1)), np.arange(4, 8).reshape(2, 2))


### PR DESCRIPTION
## Summary
- save Hamiltonian operators once per experiment instead of duplicating them for every sweep point
- persist drive coefficients and density matrices as structured numpy arrays with a `manifest.json`
- add `EvolutionDump` loaders to reconstruct time-dependent splines and state traces by sweep index
- enable dumps via `LogConfig.path / "evolution"` or the existing `EmulatorController.save_dir`

Closes #1415.

## Motivation
The previous qutip dump path wrote one Hamiltonian and one state file per sweep execution (e.g. 100 files for a 100-point Ramsey scan). This PR batches sweep data into n-dimensional arrays while keeping operators run-invariant, matching the storage model described in the issue.

## Test plan
- [x] `pytest tests/instruments/emulator/test_evolution_dump.py`
- [x] `pytest tests/instruments/emulator/test_emulator.py`
- [ ] Maintainer review of dump layout (`operators.qu`, `time_grid.npy`, `time_coefficients.npy`, `density_matrices.npy`, `manifest.json`)


Made with [Cursor](https://cursor.com)