### PR TITLE
Fix emulator evolution compatibility after dump and GPU changes

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1335,7 +1335,6 @@ description = "Backport of PEP 654 (exception groups)"
 optional = false
 python-versions = ">=3.7"
 groups = ["main", "dev", "docs", "tests"]
-markers = "python_version == \"3.10\""
 files = [
     {file = "exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598"},
     {file = "exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219"},
@@ -3283,7 +3282,6 @@ description = "Pexpect allows easy control of interactive console applications."
 optional = false
 python-versions = "*"
 groups = ["main", "dev", "docs", "tests"]
-markers = "sys_platform != \"win32\" and sys_platform != \"emscripten\""
 files = [
     {file = "pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523"},
     {file = "pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f"},
@@ -3489,7 +3487,6 @@ description = "Run a subprocess in a pseudo terminal"
 optional = false
 python-versions = "*"
 groups = ["main", "dev", "docs", "tests"]
-markers = "sys_platform != \"win32\" and sys_platform != \"emscripten\""
 files = [
     {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
     {file = "ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220"},

--- a/src/qibolab/_core/instruments/emulator/engine/dynamiqs.py
+++ b/src/qibolab/_core/instruments/emulator/engine/dynamiqs.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 import numpy as np
+from scipy.interpolate import make_interp_spline
 
 from .abstract import (
     HAMILTONIAN_FILENAME,
@@ -20,6 +21,8 @@ from .abstract import (
 )
 
 __all__ = ["DynamiqsEngine"]
+
+SPLINE_INTERP_ORDER = 3
 
 
 @dataclass
@@ -204,6 +207,16 @@ class DynamiqsEngine(SimulationEngine):
         states = dict(np.load(dump_dir / f"{STATE_FILENAME}_{count}.npz"))
         return hamiltonians, states
 
+    def save_operators(self, operators, dump_dir: Path) -> None:
+        """Persist static operators once per experiment."""
+        np.savez(
+            dump_dir / "operators.npz",
+            **{
+                f"operator_{index}": np.asarray(_unwrap(operator).to_jax())
+                for index, operator in enumerate(operators)
+            },
+        )
+
     def evolve(
         self,
         hamiltonian: Operator,
@@ -220,7 +233,14 @@ class DynamiqsEngine(SimulationEngine):
 
         hamiltonian = self.engine.constant(_unwrap(hamiltonian))
         if time_hamiltonian is not None:
-            for operator, coefficient in time_hamiltonian.operators:
+            times = time_hamiltonian.times
+            coefficients = [
+                make_interp_spline(times, coefficient, k=SPLINE_INTERP_ORDER)
+                for coefficient in time_hamiltonian.coefficients
+            ]
+            for operator, coefficient in zip(
+                time_hamiltonian.operators, coefficients, strict=True
+            ):
                 hamiltonian += self.engine.modulated(
                     _spline_function(coefficient), _unwrap(operator)
                 )

--- a/src/qibolab/_core/instruments/emulator/engine/qutip.py
+++ b/src/qibolab/_core/instruments/emulator/engine/qutip.py
@@ -2,16 +2,14 @@ from collections.abc import Iterable
 from functools import cached_property
 from importlib import import_module
 from pathlib import Path
-from typing import Any, Literal
+from typing import Literal
 
 import numpy as np
 from scipy.interpolate import make_interp_spline
 
 from .abstract import (
-    HAMILTONIAN_FILENAME,
     INTEGRATION_MIN_TIME_STEP,
     INTEGRATION_MULTIPLIER,
-    STATE_FILENAME,
     Operator,
     OperatorEvolution,
     SimulationEngine,
@@ -95,7 +93,6 @@ class QutipEngine(SimulationEngine):
         """Persist the static operators once per experiment."""
         self.engine.qsave(operators, str(dump_dir / "operators"))
 
-
     def evolve(
         self,
         hamiltonian: Operator,
@@ -135,9 +132,10 @@ class QutipEngine(SimulationEngine):
             }
 
         if time_hamiltonian is not None:
-<<<<<<< emulator-gpu-1414
+            times = time_hamiltonian.times
             coefficients = [
-                coefficient for _, coefficient in time_hamiltonian.operators
+                make_interp_spline(times, coefficient, k=SPLINE_INTERP_ORDER)
+                for coefficient in time_hamiltonian.coefficients
             ]
             if "method" in options:
                 # diffrax jits over the coefficients, and the spline objects
@@ -150,22 +148,12 @@ class QutipEngine(SimulationEngine):
                 ]
             hamiltonian = [self._to_device(hamiltonian)] + [
                 [self._to_device(operator), coefficient]
-                for (operator, _), coefficient in zip(
+                for operator, coefficient in zip(
                     time_hamiltonian.operators, coefficients, strict=True
                 )
             ]
         else:
             hamiltonian = self._to_device(hamiltonian)
-=======
-            times = time_hamiltonian.times
-            pairs = [
-                [op, make_interp_spline(times, coeff, k=SPLINE_INTERP_ORDER)]
-                for op, coeff in zip(
-                    time_hamiltonian.operators, time_hamiltonian.coefficients
-                )
-            ]
-            hamiltonian = [hamiltonian] + pairs
->>>>>>> main
 
         sim_results = self.engine.mesolve(
             hamiltonian,

--- a/tests/instruments/emulator/test_dynamiqs.py
+++ b/tests/instruments/emulator/test_dynamiqs.py
@@ -123,7 +123,9 @@ def _driven_evolution(engine, **kwargs):
         * np.cos(2 * np.pi * 0.2 * times)
     )
     evolution = OperatorEvolution(
-        operators=[[a + a.dag(), make_interp_spline(times, coefficient, k=3)]]
+        operators=[a + a.dag()],
+        coefficients=np.stack([coefficient]),
+        times=times,
     )
     result = engine.evolve(
         hamiltonian=hamiltonian,


### PR DESCRIPTION
## Summary

This is a small maintenance follow-up, **not a unitaryHACK bounty submission.**

While reviewing the emulator dump work around #1415 after #1467 was merged, I noticed that current `main` now contains a merge interaction between two recent changes:

- #1467 changed emulator evolution storage so `OperatorEvolution` carries static operators, raw coefficient arrays, and their time grid separately.
- #1480 added the QuTiP GPU path, including JAX/diffrax handling for spline coefficients.

Both changes are useful, but their final integration left two concrete breakages in the emulator engine layer:

- `QutipEngine.evolve` still had unresolved conflict markers and mixed the old and new `OperatorEvolution` shapes.
- `DynamiqsEngine` still consumed `time_hamiltonian.operators` as `(operator, spline)` pairs and did not implement the new abstract `save_operators()` method.

This PR keeps the accepted storage model from #1467 and adapts the engine-specific execution paths to rebuild splines locally when needed.

## Key Change

The previous Dynamiqs path expected each time-dependent term to already contain its spline coefficient:

```python
for operator, coefficient in time_hamiltonian.operators:
    hamiltonian += self.engine.modulated(
        _spline_function(coefficient), _unwrap(operator)
    )
```

After #1467, the shared representation is instead:

```python
OperatorEvolution(
    operators=[operator_0, operator_1, ...],
    coefficients=np.stack([coefficients_0, coefficients_1, ...]),
    times=times,
)
```

So both engines now reconstruct the spline from the stored coefficient array and time grid at the backend boundary:

```python
times = time_hamiltonian.times
coefficients = [
    make_interp_spline(times, coefficient, k=SPLINE_INTERP_ORDER)
    for coefficient in time_hamiltonian.coefficients
]

for operator, coefficient in zip(
    time_hamiltonian.operators, coefficients, strict=True
):
    ...
```

For the QuTiP JAX/diffrax path, the rebuilt spline is still converted to a JAX-traceable callable before being passed to the solver:

```python
if "method" in options:
    from jax import jit

    coefficients = [
        jit(_spline_function(coefficient)) for coefficient in coefficients
    ]
```

This keeps the GPU behavior from #1480 while matching the raw-coefficient dump format from #1467.

## Other Fixes

- removed the unresolved conflict markers from `src/qibolab/_core/instruments/emulator/engine/qutip.py`
- removed stale unused imports left by that conflict
- added `DynamiqsEngine.save_operators()` so the class satisfies the `SimulationEngine` abstract interface
- updated the driven-evolution regression helper to construct `OperatorEvolution` using the current `operators`, `coefficients`, and `times` fields

## Validation

```text
.venv/bin/ruff check src/qibolab/_core/instruments/emulator tests/instruments/emulator
.venv/bin/ruff format --check src/qibolab/_core/instruments/emulator/engine/qutip.py src/qibolab/_core/instruments/emulator/engine/dynamiqs.py tests/instruments/emulator/test_dynamiqs.py
.venv/bin/python -m pytest tests/instruments/emulator/test_dynamiqs.py tests/instruments/emulator/test_gpu.py -q
# 21 passed, 3 skipped
```