### PR TITLE
adding CR primitives in Platform object as a 2q natives.

### DIFF
--- a/src/qibolab/_core/native.py
+++ b/src/qibolab/_core/native.py
@@ -107,6 +107,7 @@ class TwoQubitNatives(NativeContainer):
 
     CZ: Annotated[Native | None, {"symmetric": True}] = None
     CNOT: Annotated[Native | None, {"symmetric": False}] = None
+    CR: Annotated[Native | None, {"symmetric": False}] = None
     iSWAP: Annotated[Native | None, {"symmetric": True}] = None
 
     @property

--- a/src/qibolab/_core/pulses/pulse.py
+++ b/src/qibolab/_core/pulses/pulse.py
@@ -85,12 +85,12 @@ class Pulse(_PulseLike):
 
     def i(self, sampling_rate: float) -> Waveform:
         """Compute the envelope of the waveform i component."""
-        samples = int(self.duration * sampling_rate)
+        samples = np.ceil(self.duration * sampling_rate).astype(int)
         return self.amplitude * self.envelope.i(samples)
 
     def q(self, sampling_rate: float) -> Waveform:
         """Compute the envelope of the waveform q component."""
-        samples = int(self.duration * sampling_rate)
+        samples = np.ceil(self.duration * sampling_rate).astype(int)
         return self.amplitude * self.envelope.q(samples)
 
     def envelopes(self, sampling_rate: float) -> IqWaveform:

--- a/tests/instruments/emulator/platforms/fixed-frequency-qutrits/parameters.json
+++ b/tests/instruments/emulator/platforms/fixed-frequency-qutrits/parameters.json
@@ -295,33 +295,27 @@
                         "0/drive1",
                         {
                             "kind": "pulse",
-                            "duration": 56.0,
+                            "duration": 56.95794434760026,
                             "amplitude": 0.1,
                             "envelope": {
                                 "kind": "rectangular"
                             },
-                            "relative_phase": 0.0,
+                            "relative_phase": 6.268132788666496,
                             "chirp": null
                         }
                     ],
                     [
                         "1/drive",
                         {
-                            "kind": "pulse",
-                            "duration": 56.0,
-                            "amplitude": 0.0,
-                            "envelope": {
-                                "kind": "rectangular"
-                            },
-                            "relative_phase": 0.0,
-                            "chirp": null
+                            "kind": "delay",
+                            "duration": 56.95794434760026
                         }
                     ],
                     [
                         "0/drive",
                         {
                             "kind": "delay",
-                            "duration": 56.0
+                            "duration": 56.95794434760026
                         }
                     ],
                     [
@@ -357,33 +351,27 @@
                         "0/drive1",
                         {
                             "kind": "pulse",
-                            "duration": 56.0,
-                            "amplitude": 0.1,
+                            "duration": 56.95794434760026,
+                            "amplitude": -0.1,
                             "envelope": {
                                 "kind": "rectangular"
                             },
-                            "relative_phase": 3.141592653589793,
+                            "relative_phase": 6.268132788666496,
                             "chirp": null
                         }
                     ],
                     [
                         "1/drive",
                         {
-                            "kind": "pulse",
-                            "duration": 56.0,
-                            "amplitude": 0.0,
-                            "envelope": {
-                                "kind": "rectangular"
-                            },
-                            "relative_phase": 3.141592653589793,
-                            "chirp": null
+                            "kind": "delay",
+                            "duration": 56.95794434760026
                         }
                     ],
                     [
                         "0/drive",
                         {
                             "kind": "delay",
-                            "duration": 56.0
+                            "duration": 56.95794434760026
                         }
                     ],
                     [
@@ -413,6 +401,34 @@
                         {
                             "kind": "delay",
                             "duration": 20.0
+                        }
+                    ]
+                ],
+                "CR": [
+                    [
+                        "0/drive1",
+                        {
+                            "kind": "pulse",
+                            "duration": 56.95794434760026,
+                            "amplitude": 0.1,
+                            "envelope": {
+                                "kind": "rectangular"
+                            },
+                            "relative_phase": 6.268132788666496,
+                            "chirp": null
+                        }
+                    ],
+                    [
+                        "1/drive",
+                        {
+                            "kind": "pulse",
+                            "duration": 56.95794434760026,
+                            "amplitude": 0.0,
+                            "envelope": {
+                                "kind": "rectangular"
+                            },
+                            "relative_phase": 1.4847118315619126,
+                            "chirp": null
                         }
                     ]
                 ],


### PR DESCRIPTION
In this small PR we are inserting Cross resonance and cancellation pulses in `Platform` class, so user can set better the initial parameters and the envelope of the 2 pulses used for cross resonance.


Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
