### PR TITLE
adding CR primitives in Platform

### DIFF
--- a/src/qibolab/_core/native.py
+++ b/src/qibolab/_core/native.py
@@ -107,6 +107,7 @@ class TwoQubitNatives(NativeContainer):
 
     CZ: Annotated[Native | None, {"symmetric": True}] = None
     CNOT: Annotated[Native | None, {"symmetric": False}] = None
+    CR: Annotated[Native | None, {"symmetric": False}] = None
     iSWAP: Annotated[Native | None, {"symmetric": True}] = None
 
     @property

--- a/tests/instruments/emulator/platforms/fixed-frequency-qutrits/parameters.json
+++ b/tests/instruments/emulator/platforms/fixed-frequency-qutrits/parameters.json
@@ -416,6 +416,34 @@
                         }
                     ]
                 ],
+                "CR": [
+                    [
+                        "0/drive1",
+                        {
+                            "kind": "pulse",
+                            "duration": 56.95794434760026,
+                            "amplitude": 0.1,
+                            "envelope": {
+                                "kind": "rectangular"
+                            },
+                            "relative_phase": 6.268132788666496,
+                            "chirp": null
+                        }
+                    ],
+                    [
+                        "1/drive",
+                        {
+                            "kind": "pulse",
+                            "duration": 56.95794434760026,
+                            "amplitude": 0.0,
+                            "envelope": {
+                                "kind": "rectangular"
+                            },
+                            "relative_phase": 1.4847118315619126,
+                            "chirp": null
+                        }
+                    ]
+                ],
                 "iSWAP": null
             }
         }


### PR DESCRIPTION
In this small PR we are inserting Cross resonance and cancellation pulses in Platform class, so user can set better the initial parameters and the envelope of the 2 pulses used for cross resonance.

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
