### PR TITLE
Group singleshot emulator result extraction

### DIFF
--- a/src/qibolab/_core/instruments/emulator/results.py
+++ b/src/qibolab/_core/instruments/emulator/results.py
@@ -134,9 +134,6 @@ def _sampled_measurements(
     sampled: NDArray, dims: list[int], inverse_map: NDArray, indices: list[int]
 ) -> NDArray:
     """Extract measured subsystem states from sampled full-system states."""
-    if len(inverse_map) != len(indices):
-        raise ValueError("Measurement map and indices must have the same length.")
-
     indices = np.asarray(indices)
     res = np.empty((len(indices), *sampled.shape[1:]), dtype=sampled.dtype)
     for sample in np.unique(inverse_map):

--- a/src/qibolab/_core/instruments/emulator/results.py
+++ b/src/qibolab/_core/instruments/emulator/results.py
@@ -130,6 +130,19 @@ def _marginalize_probability(
     return np.stack(res)
 
 
+def _sampled_measurements(
+    sampled: NDArray, dims: list[int], inverse_map: NDArray, indices: list[int]
+) -> NDArray:
+    """Extract measured subsystem states from sampled full-system states."""
+    res = {}
+    for sample in np.unique(inverse_map):
+        states = np.stack(np.unravel_index(sampled[sample], dims))
+        for measurement in np.flatnonzero(inverse_map == sample):
+            res[measurement] = states[indices[measurement]]
+
+    return np.stack([res[measurement] for measurement in range(len(indices))])
+
+
 def select_acquisitions(
     states: list[Operator], acquisitions: Iterable[float], times: NDArray
 ) -> NDArray:
@@ -214,20 +227,15 @@ def _singleshot_results(
     # the shape now is: (M_unique, Nshots, *S, *H_dim)
     sampled = np.moveaxis(sampled, 1, 0)
 
-    acq_id = acquisitions(sequence).keys()
+    acq_id = list(acquisitions(sequence).keys())
     # from every acquisition pulse id we get the corresponding channel, and from the channel we get the
-    # corresponding qubit index, which is then used to correctly permute the rows of states_computational_idx.
+    # corresponding Hilbert-space index to extract from the sampled full-system state.
     qubit_indices = [
         index(sequence.pulse_channels(ro_id)[0], hamiltonian) for ro_id in acq_id
     ]
 
-    # we use inverse_map to expand back the sampled results
-    # res is a (M, M, Nshots, *S, ...) array
-    res = np.stack(np.unravel_index(sampled[inverse_map], hamiltonian.dims))[
-        qubit_indices
-    ]
-    # using np.einsum, so res is a (M, Nshots, *S, ...) array
-    res = np.einsum(res, np.array([0, 0] + [...]), np.array([0] + [...]))
+    # res is a (M, Nshots, *S, ...) array
+    res = _sampled_measurements(sampled, hamiltonian.dims, inverse_map, qubit_indices)
     res = np.clip(res, 0, 1)
 
     if options.acquisition_type is AcquisitionType.INTEGRATION:

--- a/src/qibolab/_core/instruments/emulator/results.py
+++ b/src/qibolab/_core/instruments/emulator/results.py
@@ -134,13 +134,17 @@ def _sampled_measurements(
     sampled: NDArray, dims: list[int], inverse_map: NDArray, indices: list[int]
 ) -> NDArray:
     """Extract measured subsystem states from sampled full-system states."""
-    res = {}
+    if len(inverse_map) != len(indices):
+        raise ValueError("Measurement map and indices must have the same length.")
+
+    indices = np.asarray(indices)
+    res = np.empty((len(indices), *sampled.shape[1:]), dtype=sampled.dtype)
     for sample in np.unique(inverse_map):
         states = np.stack(np.unravel_index(sampled[sample], dims))
-        for measurement in np.flatnonzero(inverse_map == sample):
-            res[measurement] = states[indices[measurement]]
+        measurements = np.flatnonzero(inverse_map == sample)
+        res[measurements] = states[indices[measurements]]
 
-    return np.stack([res[measurement] for measurement in range(len(indices))])
+    return res
 
 
 def select_acquisitions(

--- a/tests/instruments/emulator/test_results.py
+++ b/tests/instruments/emulator/test_results.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from qibolab._core.execution_parameters import (
     AcquisitionType,
@@ -85,6 +86,16 @@ def test_sampled_measurements_groups_acquisitions_by_sample():
     np.testing.assert_allclose(measured[0], [[0, 0], [1, 1]])
     np.testing.assert_allclose(measured[1], [[0, 1], [1, 2]])
     np.testing.assert_allclose(measured[2], [[2, 0], [1, 0]])
+
+
+def test_sampled_measurements_rejects_mismatched_measurements():
+    with pytest.raises(ValueError, match="same length"):
+        _sampled_measurements(
+            sampled=np.array([0]),
+            dims=[2],
+            inverse_map=np.array([0, 0]),
+            indices=[0],
+        )
 
 
 class _Sequence:

--- a/tests/instruments/emulator/test_results.py
+++ b/tests/instruments/emulator/test_results.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 from qibolab._core.execution_parameters import (
     AcquisitionType,
@@ -86,16 +85,6 @@ def test_sampled_measurements_groups_acquisitions_by_sample():
     np.testing.assert_allclose(measured[0], [[0, 0], [1, 1]])
     np.testing.assert_allclose(measured[1], [[0, 1], [1, 2]])
     np.testing.assert_allclose(measured[2], [[2, 0], [1, 0]])
-
-
-def test_sampled_measurements_rejects_mismatched_measurements():
-    with pytest.raises(ValueError, match="same length"):
-        _sampled_measurements(
-            sampled=np.array([0]),
-            dims=[2],
-            inverse_map=np.array([0, 0]),
-            indices=[0],
-        )
 
 
 class _Sequence:

--- a/tests/instruments/emulator/test_results.py
+++ b/tests/instruments/emulator/test_results.py
@@ -8,6 +8,7 @@ from qibolab._core.execution_parameters import (
 from qibolab._core.instruments.emulator.results import (
     _cyclic_results,
     _marginalize_probability,
+    _sampled_measurements,
 )
 from qibolab._core.pulses import Acquisition
 
@@ -63,6 +64,27 @@ def test_cyclic_integration_results_marginalize_probabilities(monkeypatch):
 
     np.testing.assert_allclose(results[acq0.id], [0.40, 0.0])
     np.testing.assert_allclose(results[acq1.id], [0.85, 0.0])
+
+
+def test_sampled_measurements_groups_acquisitions_by_sample():
+    sampled = np.array(
+        [
+            [[0, 1], [4, 5]],
+            [[2, 3], [1, 0]],
+        ]
+    )
+    inverse_map = np.array([0, 0, 1])
+
+    measured = _sampled_measurements(
+        sampled=sampled,
+        dims=[2, 3],
+        inverse_map=inverse_map,
+        indices=[0, 1, 1],
+    )
+
+    np.testing.assert_allclose(measured[0], [[0, 0], [1, 1]])
+    np.testing.assert_allclose(measured[1], [[0, 1], [1, 2]])
+    np.testing.assert_allclose(measured[2], [[2, 0], [1, 0]])
 
 
 class _Sequence:


### PR DESCRIPTION
## Summary

This is a follow-up to `qiboteam/qibolab` #1505 and addresses the singleshot result-handling cleanup described in `qiboteam/qibolab` #1223.

The change extracts measured subsystem states by grouping acquisitions that share the same sampled full-system state. For each unique measurement sample, the full-system state is unraveled once, then each acquisition reads only the subsystem index it needs.

This replaces the previous diagonal-style extraction through a larger temporary array:

```python
np.stack(np.unravel_index(sampled[inverse_map], dims))[qubit_indices]
```

with a more direct helper:

```python
_sampled_measurements(sampled, dims, inverse_map, qubit_indices)
```

The public result shape and clipping behavior are unchanged.

## Context

#1505 simplified the cyclic/non-shot probability path. This PR keeps the next result-handling step narrow by touching only the singleshot extraction path.

I kept this independent from #1413, because #1413 still depends on the confusion-matrix path from draft `qiboteam/qibolab` #1401.

## Follow-Up

If this PR lands, my next planned step is to use the merged Qibocal emulator platforms from `qiboteam/qibocal` #1551 to run Qibocal workflows with the Dynamiqs emulator engine and report concrete validation findings. That follow-up does not depend on #1401 or #1413 (unless @alecandido wants us to take a second look); those remain separate result/confusion-matrix work.

## Validation

- `pytest tests/instruments/emulator/test_results.py -q`
- `pytest tests/instruments/emulator/test_emulator.py tests/instruments/emulator/test_results.py -q`
- `pytest tests/instruments/emulator -q`
- `ruff check src/qibolab/_core/instruments/emulator/results.py tests/instruments/emulator/test_results.py`
- `ruff format --check src/qibolab/_core/instruments/emulator/results.py tests/instruments/emulator/test_results.py`
- Qibocal Rabi smoke on merged Qibocal platform: `qubit` acquisition + fit passed
- Qibocal Rabi smoke on merged Qibocal platform: `qutrit` acquisition + fit passed
