### PR TITLE
Check for the existence of channels used in pulse sequence

### DIFF
--- a/doc/source/main-documentation/experiment.rst
+++ b/doc/source/main-documentation/experiment.rst
@@ -91,12 +91,13 @@ To organize pulses into sequences, Qibolab provides the :class:`qibolab.PulseSeq
         relative_phase=0,  # phases are in radians
         envelope=Rectangular(),
     )
+    drive_channel_qubit0 = platform.qubits[0].drive
     sequence = PulseSequence(
         [
-            ("qubit/drive", pulse1),
-            ("qubit/drive", pulse2),
-            ("qubit/drive", pulse3),
-            ("qubit/drive", pulse4),
+            (drive_channel_qubit0, pulse1),
+            (drive_channel_qubit0, pulse2),
+            (drive_channel_qubit0, pulse3),
+            (drive_channel_qubit0, pulse4),
         ],
     )
 

--- a/doc/source/main-documentation/platform.rst
+++ b/doc/source/main-documentation/platform.rst
@@ -182,6 +182,19 @@ E.g. a :class:`.DcChannel` is distinguished from an :class:`.IqChannel`
 because of modulation, which potentially requires to coordinate the operation of such a
 channel with an external mixer (identified by :attr:`.IqChannel.mixer`).
 
+.. note::
+
+  Qibolab enforces strict channel validation during :meth:`.Platform.execute`.
+  If a pulse sequence references a channel that is not declared in the platform,
+  execution fails with an error.
+
+  This is a deliberate design choice: pulses with undeclared channels are not silently
+  ignored, because that can hide mistakes in the platform setup and produce misleading
+  experimental outcomes.
+
+  If a workflow needs a channel-like placeholder with no physical output, this should be
+  introduced through a dummy instrument/channel in the platform.
+
 Configurations
 ~~~~~~~~~~~~~~
 

--- a/doc/source/tutorials/emulator.rst
+++ b/doc/source/tutorials/emulator.rst
@@ -125,7 +125,15 @@ We are now going to give an example on how to setup the `platform.py` file.
 
 .. testcode::  python
 
-    from qibolab import ConfigKinds, DcChannel, IqChannel, Platform, Qubit, Hardware
+    from qibolab import (
+        AcquisitionChannel,
+        ConfigKinds,
+        DcChannel,
+        Hardware,
+        IqChannel,
+        Platform,
+        Qubit,
+    )
     from qibolab.instruments.emulator import (
         DriveEmulatorConfig,
         EmulatorController,
@@ -144,6 +152,8 @@ We are now going to give an example on how to setup the `platform.py` file.
         for q in range(1):
             qubits[q] = qubit = Qubit.default(q)
             channels |= {
+                qubit.probe: IqChannel(mixer=None, lo=None),
+                qubit.acquisition: AcquisitionChannel(probe=qubit.probe),
                 qubit.drive: IqChannel(mixer=None, lo=None),
                 qubit.flux: DcChannel(),
             }

--- a/src/qibolab/_core/platform/platform.py
+++ b/src/qibolab/_core/platform/platform.py
@@ -258,7 +258,7 @@ class Platform:
                 channel
                 for sequence in sequences
                 for channel in sequence.channels
-                if channel not in self.channels
+                if channel not in available_channels
             }
         )
         if missing_channels:

--- a/src/qibolab/_core/platform/platform.py
+++ b/src/qibolab/_core/platform/platform.py
@@ -252,13 +252,12 @@ class Platform:
                 "The acquisitions' identifiers have to be unique across all sequences."
             )
 
-        available_channels = self.channels
         missing_channels = sorted(
             {
                 channel
                 for sequence in sequences
                 for channel in sequence.channels
-                if channel not in available_channels
+                if channel not in self.channels
             }
         )
         if missing_channels:

--- a/src/qibolab/_core/platform/platform.py
+++ b/src/qibolab/_core/platform/platform.py
@@ -252,6 +252,21 @@ class Platform:
                 "The acquisitions' identifiers have to be unique across all sequences."
             )
 
+        available_channels = self.channels
+        missing_channels = sorted(
+            {
+                channel
+                for sequence in sequences
+                for channel in sequence.channels
+                if channel not in available_channels
+            }
+        )
+        if missing_channels:
+            raise ValueError(
+                f"Unknown channel(s) in pulse sequence: {', '.join(missing_channels)}. "
+                "Check that they are declared in the platform initialization script."
+            )
+
         options = self.settings.fill(ExecutionParameters(**options))
 
         time = options.estimate_duration(sequences, sweepers)

--- a/src/qibolab/_core/platform/platform.py
+++ b/src/qibolab/_core/platform/platform.py
@@ -252,6 +252,7 @@ class Platform:
                 "The acquisitions' identifiers have to be unique across all sequences."
             )
 
+        available_channels = self.channels
         missing_channels = sorted(
             {
                 channel
@@ -263,7 +264,9 @@ class Platform:
         if missing_channels:
             raise ValueError(
                 f"Unknown channel(s) in pulse sequence: {', '.join(missing_channels)}. "
-                "Check that they are declared in the platform initialization script."
+                "Please ensure that all channels used in pulse sequences are declared "
+                "in the platform initialization script. "
+                f"Available channels: {', '.join(available_channels)}"
             )
 
         options = self.settings.fill(ExecutionParameters(**options))

--- a/tests/instruments/emulator/platforms/fixed-frequency-qutrits/platform.py
+++ b/tests/instruments/emulator/platforms/fixed-frequency-qutrits/platform.py
@@ -21,14 +21,14 @@ def create() -> Hardware:
     channels |= {
         qubit.acquisition: AcquisitionChannel(probe=qubit.probe),
         qubit.drive: IqChannel(mixer=None, lo=None),
-        qubits[0].drive_extra[1, 2]: IqChannel(mixer=None, lo=None),
-        qubits[0].drive_extra[1]: IqChannel(mixer=None, lo=None),
+        qubit.drive_extra[1, 2]: IqChannel(mixer=None, lo=None),
+        qubit.drive_extra[1]: IqChannel(mixer=None, lo=None),
     }
     qubits[1] = qubit = Qubit.default(1, drive_extra={(1, 2): "1/drive12"})
     channels |= {
         qubit.acquisition: AcquisitionChannel(probe=qubit.probe),
         qubit.drive: IqChannel(mixer=None, lo=None),
-        qubits[1].drive_extra[1, 2]: IqChannel(mixer=None, lo=None),
+        qubit.drive_extra[1, 2]: IqChannel(mixer=None, lo=None),
     }
 
     dump_dir = "qutip_data"

--- a/tests/instruments/emulator/platforms/fixed-frequency-qutrits/platform.py
+++ b/tests/instruments/emulator/platforms/fixed-frequency-qutrits/platform.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from qibolab import ConfigKinds, Hardware, IqChannel, Qubit
+from qibolab import AcquisitionChannel, ConfigKinds, Hardware, IqChannel, Qubit
 from qibolab.instruments.emulator import (
     DriveEmulatorConfig,
     EmulatorController,
@@ -19,12 +19,14 @@ def create() -> Hardware:
         0, drive_extra={(1, 2): "0/drive12", 1: "0/drive1"}
     )
     channels |= {
+        qubit.acquisition: AcquisitionChannel(probe=qubit.probe),
         qubit.drive: IqChannel(mixer=None, lo=None),
         qubits[0].drive_extra[1, 2]: IqChannel(mixer=None, lo=None),
         qubits[0].drive_extra[1]: IqChannel(mixer=None, lo=None),
     }
     qubits[1] = qubit = Qubit.default(1, drive_extra={(1, 2): "1/drive12"})
     channels |= {
+        qubit.acquisition: AcquisitionChannel(probe=qubit.probe),
         qubit.drive: IqChannel(mixer=None, lo=None),
         qubits[1].drive_extra[1, 2]: IqChannel(mixer=None, lo=None),
     }

--- a/tests/instruments/emulator/platforms/qubit/platform.py
+++ b/tests/instruments/emulator/platforms/qubit/platform.py
@@ -1,6 +1,13 @@
 import pathlib
 
-from qibolab import ConfigKinds, DcChannel, IqChannel, Platform, Qubit
+from qibolab import (
+    AcquisitionChannel,
+    ConfigKinds,
+    DcChannel,
+    IqChannel,
+    Platform,
+    Qubit,
+)
 from qibolab.instruments.emulator import (
     DriveEmulatorConfig,
     EmulatorController,
@@ -23,6 +30,7 @@ def create() -> Platform:
         channels |= {
             qubit.drive: IqChannel(mixer=None, lo=None),
             qubit.flux: DcChannel(),
+            qubit.acquisition: AcquisitionChannel(probe=qubit.probe),
         }
 
     # register the instruments

--- a/tests/instruments/emulator/platforms/qubit/platform.py
+++ b/tests/instruments/emulator/platforms/qubit/platform.py
@@ -7,6 +7,7 @@ from qibolab import (
     IqChannel,
     Platform,
     Qubit,
+    QubitMap,
 )
 from qibolab.instruments.emulator import (
     DriveEmulatorConfig,
@@ -22,15 +23,15 @@ ConfigKinds.extend([HamiltonianConfig, DriveEmulatorConfig, FluxEmulatorConfig])
 
 def create() -> Platform:
     """Create emulator platform with one qubit."""
-    qubits = {}
+    qubits: QubitMap = {}
     channels = {}
 
     for q in range(1):
-        qubits[q] = qubit = Qubit.default(q)
+        qubits[q] = Qubit.default(q)
         channels |= {
-            qubit.drive: IqChannel(mixer=None, lo=None),
-            qubit.flux: DcChannel(),
-            qubit.acquisition: AcquisitionChannel(probe=qubit.probe),
+            qubits[q].drive: IqChannel(mixer=None, lo=None),
+            qubits[q].flux: DcChannel(),
+            qubits[q].acquisition: AcquisitionChannel(probe=qubits[q].probe),
         }
 
     # register the instruments

--- a/tests/instruments/emulator/platforms/qubit/platform.py
+++ b/tests/instruments/emulator/platforms/qubit/platform.py
@@ -27,11 +27,11 @@ def create() -> Platform:
     channels = {}
 
     for q in range(1):
-        qubits[q] = Qubit.default(q)
+        qubits[q] = qubit = Qubit.default(q)
         channels |= {
-            qubits[q].drive: IqChannel(mixer=None, lo=None),
-            qubits[q].flux: DcChannel(),
-            qubits[q].acquisition: AcquisitionChannel(probe=qubits[q].probe),
+            qubit.drive: IqChannel(mixer=None, lo=None),
+            qubit.flux: DcChannel(),
+            qubit.acquisition: AcquisitionChannel(probe=qubit.probe),
         }
 
     # register the instruments

--- a/tests/instruments/emulator/platforms/qutrit/platform.py
+++ b/tests/instruments/emulator/platforms/qutrit/platform.py
@@ -1,6 +1,13 @@
 import pathlib
 
-from qibolab import ConfigKinds, DcChannel, IqChannel, Platform, Qubit
+from qibolab import (
+    AcquisitionChannel,
+    ConfigKinds,
+    DcChannel,
+    IqChannel,
+    Platform,
+    Qubit,
+)
 from qibolab.instruments.emulator import (
     DriveEmulatorConfig,
     EmulatorController,
@@ -19,9 +26,11 @@ def create() -> Platform:
     channels = {}
 
     for q in range(1):
-        qubits[q] = qubit = Qubit.default(q)
+        qubits[q] = qubit = Qubit.default(q, drive_extra={(1, 2): f"{q}/drive12"})
         channels |= {
+            qubit.acquisition: AcquisitionChannel(probe=qubit.probe),
             qubit.drive: IqChannel(mixer=None, lo=None),
+            qubit.drive_extra[1, 2]: IqChannel(mixer=None, lo=None),
             qubit.flux: DcChannel(),
         }
 

--- a/tests/instruments/emulator/platforms/qutrit/platform.py
+++ b/tests/instruments/emulator/platforms/qutrit/platform.py
@@ -7,6 +7,7 @@ from qibolab import (
     IqChannel,
     Platform,
     Qubit,
+    QubitMap,
 )
 from qibolab.instruments.emulator import (
     DriveEmulatorConfig,
@@ -22,16 +23,16 @@ ConfigKinds.extend([HamiltonianConfig, DriveEmulatorConfig, FluxEmulatorConfig])
 
 def create() -> Platform:
     """Create emulator platform with one qutrit."""
-    qubits = {}
+    qubits: QubitMap = {}
     channels = {}
 
     for q in range(1):
-        qubits[q] = qubit = Qubit.default(q, drive_extra={(1, 2): f"{q}/drive12"})
+        qubits[q] = Qubit.default(q, drive_extra={(1, 2): f"{q}/drive12"})
         channels |= {
-            qubit.acquisition: AcquisitionChannel(probe=qubit.probe),
-            qubit.drive: IqChannel(mixer=None, lo=None),
-            qubit.drive_extra[1, 2]: IqChannel(mixer=None, lo=None),
-            qubit.flux: DcChannel(),
+            qubits[q].acquisition: AcquisitionChannel(probe=qubits[q].probe),
+            qubits[q].drive: IqChannel(mixer=None, lo=None),
+            qubits[q].drive_extra[1, 2]: IqChannel(mixer=None, lo=None),
+            qubits[q].flux: DcChannel(),
         }
 
     # register the instruments

--- a/tests/instruments/emulator/platforms/qutrit/platform.py
+++ b/tests/instruments/emulator/platforms/qutrit/platform.py
@@ -27,12 +27,12 @@ def create() -> Platform:
     channels = {}
 
     for q in range(1):
-        qubits[q] = Qubit.default(q, drive_extra={(1, 2): f"{q}/drive12"})
+        qubits[q] = qubit = Qubit.default(q, drive_extra={(1, 2): f"{q}/drive12"})
         channels |= {
-            qubits[q].acquisition: AcquisitionChannel(probe=qubits[q].probe),
-            qubits[q].drive: IqChannel(mixer=None, lo=None),
-            qubits[q].drive_extra[1, 2]: IqChannel(mixer=None, lo=None),
-            qubits[q].flux: DcChannel(),
+            qubit.acquisition: AcquisitionChannel(probe=qubit.probe),
+            qubit.drive: IqChannel(mixer=None, lo=None),
+            qubit.drive_extra[1, 2]: IqChannel(mixer=None, lo=None),
+            qubit.flux: DcChannel(),
         }
 
     # register the instruments

--- a/tests/instruments/emulator/platforms/split-transmon-coupler/platform.py
+++ b/tests/instruments/emulator/platforms/split-transmon-coupler/platform.py
@@ -24,12 +24,12 @@ def create() -> Hardware:
     channels = {}
 
     for q in range(2):
-        qubits[q] = Qubit.default(q, drive_extra={(1, 2): f"{q}/drive12"})
+        qubits[q] = qubit = Qubit.default(q, drive_extra={(1, 2): f"{q}/drive12"})
         channels |= {
-            qubits[q].acquisition: AcquisitionChannel(probe=qubits[q].probe),
-            qubits[q].drive: IqChannel(mixer=None, lo=None),
-            qubits[q].flux: DcChannel(),
-            qubits[q].drive_extra[1, 2]: IqChannel(mixer=None, lo=None),
+            qubit.acquisition: AcquisitionChannel(probe=qubit.probe),
+            qubit.drive: IqChannel(mixer=None, lo=None),
+            qubit.flux: DcChannel(),
+            qubit.drive_extra[1, 2]: IqChannel(mixer=None, lo=None),
         }
 
     couplers[0] = Qubit.coupler(2)

--- a/tests/instruments/emulator/platforms/split-transmon-coupler/platform.py
+++ b/tests/instruments/emulator/platforms/split-transmon-coupler/platform.py
@@ -1,4 +1,11 @@
-from qibolab import ConfigKinds, DcChannel, Hardware, IqChannel, Qubit
+from qibolab import (
+    AcquisitionChannel,
+    ConfigKinds,
+    DcChannel,
+    Hardware,
+    IqChannel,
+    Qubit,
+)
 from qibolab.instruments.emulator import (
     DriveEmulatorConfig,
     EmulatorController,
@@ -18,6 +25,7 @@ def create() -> Hardware:
     for q in range(2):
         qubits[q] = qubit = Qubit.default(q, drive_extra={(1, 2): f"{q}/drive12"})
         channels |= {
+            qubit.acquisition: AcquisitionChannel(probe=qubit.probe),
             qubit.drive: IqChannel(mixer=None, lo=None),
             qubit.flux: DcChannel(),
             qubits[q].drive_extra[1, 2]: IqChannel(mixer=None, lo=None),

--- a/tests/instruments/emulator/platforms/split-transmon-coupler/platform.py
+++ b/tests/instruments/emulator/platforms/split-transmon-coupler/platform.py
@@ -5,6 +5,7 @@ from qibolab import (
     Hardware,
     IqChannel,
     Qubit,
+    QubitMap,
 )
 from qibolab.instruments.emulator import (
     DriveEmulatorConfig,
@@ -18,16 +19,16 @@ ConfigKinds.extend([HamiltonianConfig, DriveEmulatorConfig, FluxEmulatorConfig])
 
 def create() -> Hardware:
     """Create platform with two split-transmons coupled."""
-    qubits = {}
+    qubits: QubitMap = {}
     couplers = {}
     channels = {}
 
     for q in range(2):
-        qubits[q] = qubit = Qubit.default(q, drive_extra={(1, 2): f"{q}/drive12"})
+        qubits[q] = Qubit.default(q, drive_extra={(1, 2): f"{q}/drive12"})
         channels |= {
-            qubit.acquisition: AcquisitionChannel(probe=qubit.probe),
-            qubit.drive: IqChannel(mixer=None, lo=None),
-            qubit.flux: DcChannel(),
+            qubits[q].acquisition: AcquisitionChannel(probe=qubits[q].probe),
+            qubits[q].drive: IqChannel(mixer=None, lo=None),
+            qubits[q].flux: DcChannel(),
             qubits[q].drive_extra[1, 2]: IqChannel(mixer=None, lo=None),
         }
 

--- a/tests/instruments/emulator/platforms/split-transmons/platform.py
+++ b/tests/instruments/emulator/platforms/split-transmons/platform.py
@@ -1,4 +1,11 @@
-from qibolab import ConfigKinds, DcChannel, Hardware, IqChannel, Qubit
+from qibolab import (
+    AcquisitionChannel,
+    ConfigKinds,
+    DcChannel,
+    Hardware,
+    IqChannel,
+    Qubit,
+)
 from qibolab.instruments.emulator import (
     DriveEmulatorConfig,
     EmulatorController,
@@ -17,6 +24,7 @@ def create() -> Hardware:
     for q in range(2):
         qubits[q] = qubit = Qubit.default(q, drive_extra={(1, 2): f"{q}/drive12"})
         channels |= {
+            qubit.acquisition: AcquisitionChannel(probe=qubit.probe),
             qubit.drive: IqChannel(mixer=None, lo=None),
             qubit.flux: DcChannel(),
             qubits[q].drive_extra[1, 2]: IqChannel(mixer=None, lo=None),

--- a/tests/instruments/emulator/platforms/split-transmons/platform.py
+++ b/tests/instruments/emulator/platforms/split-transmons/platform.py
@@ -5,6 +5,7 @@ from qibolab import (
     Hardware,
     IqChannel,
     Qubit,
+    QubitMap,
 )
 from qibolab.instruments.emulator import (
     DriveEmulatorConfig,
@@ -18,15 +19,15 @@ ConfigKinds.extend([HamiltonianConfig, DriveEmulatorConfig, FluxEmulatorConfig])
 
 def create() -> Hardware:
     """Create platform with two split-transmons coupled."""
-    qubits = {}
+    qubits: QubitMap = {}
     channels = {}
 
     for q in range(2):
-        qubits[q] = qubit = Qubit.default(q, drive_extra={(1, 2): f"{q}/drive12"})
+        qubits[q] = Qubit.default(q, drive_extra={(1, 2): f"{q}/drive12"})
         channels |= {
-            qubit.acquisition: AcquisitionChannel(probe=qubit.probe),
-            qubit.drive: IqChannel(mixer=None, lo=None),
-            qubit.flux: DcChannel(),
+            qubits[q].acquisition: AcquisitionChannel(probe=qubits[q].probe),
+            qubits[q].drive: IqChannel(mixer=None, lo=None),
+            qubits[q].flux: DcChannel(),
             qubits[q].drive_extra[1, 2]: IqChannel(mixer=None, lo=None),
         }
     # register the instruments

--- a/tests/instruments/emulator/platforms/split-transmons/platform.py
+++ b/tests/instruments/emulator/platforms/split-transmons/platform.py
@@ -23,12 +23,12 @@ def create() -> Hardware:
     channels = {}
 
     for q in range(2):
-        qubits[q] = Qubit.default(q, drive_extra={(1, 2): f"{q}/drive12"})
+        qubits[q] = qubit = Qubit.default(q, drive_extra={(1, 2): f"{q}/drive12"})
         channels |= {
-            qubits[q].acquisition: AcquisitionChannel(probe=qubits[q].probe),
-            qubits[q].drive: IqChannel(mixer=None, lo=None),
-            qubits[q].flux: DcChannel(),
-            qubits[q].drive_extra[1, 2]: IqChannel(mixer=None, lo=None),
+            qubit.acquisition: AcquisitionChannel(probe=qubit.probe),
+            qubit.drive: IqChannel(mixer=None, lo=None),
+            qubit.flux: DcChannel(),
+            qubit.drive_extra[1, 2]: IqChannel(mixer=None, lo=None),
         }
     # register the instruments
     instruments = {

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -158,7 +158,7 @@ def test_unknown_channel_raises_helpful_error():
     with pytest.raises(
         ValueError, match=r"Unknown channel\(s\) in pulse sequence: missing/channel"
     ):
-        _ = platform.execute([sequence])
+        platform.execute([sequence])
 
 
 def test_update_configs(platform):

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -151,6 +151,16 @@ def test_duplicated_acquisition():
         _ = platform.execute([sequence, sequence.copy()])
 
 
+def test_unknown_channel_raises_helpful_error():
+    platform = create_platform("dummy")
+    sequence = PulseSequence([("missing/channel", Delay(duration=10))])
+
+    with pytest.raises(
+        ValueError, match=r"Unknown channel\(s\) in pulse sequence: missing/channel"
+    ):
+        _ = platform.execute([sequence])
+
+
 def test_update_configs(platform):
     drive_name = "q0/drive"
     pump_name = "twpa_pump"


### PR DESCRIPTION
Raise a `ValueError` with a helpful message in the case where a pulse sequence references channels that are not defined in the platform.py. This is a user-input error since there is no scenario in which a pulse should be played in a channel that does not exist in an instrument, and therefore the error should not result in an over-constraint of a desired feature. 

This PR also adds a corresponding regression test, and explicitly mention this constraint in the the documentation.

The main change is in [src/qibolab/_core/platform/platform.py](https://github.com/qiboteam/qibolab/pull/1512/changes#diff-7776500ed73ecb3700b7d9fcfda08834decc4aae4b53d5d71378ca617f9d6c1f), the other diffs are to support the change that file. 

@jevillegasd it seems I cannot put you as a reviewer in this repo, but this should raise a more helpful error for the issue you had.