### PR TITLE
Avoid stacking unused emulator coefficients

### DIFF
--- a/src/qibolab/_core/instruments/emulator/emulator.py
+++ b/src/qibolab/_core/instruments/emulator/emulator.py
@@ -140,7 +140,7 @@ class EmulatorController(Controller):
         configs: dict[str, Config],
         sweepers: list[ParallelSweepers],
         updates: dict | None = None,
-    ) -> NDArray:
+    ) -> tuple[NDArray, NDArray | None]:
         """Sweep over sequence.
 
         This function invokes itself recursively, adding an array
@@ -155,7 +155,7 @@ class EmulatorController(Controller):
             return self._evolve(sequence, configs, updates)
 
         state_slices: list[NDArray] = []
-        coeff_slices = []
+        coeff_slices = [] if self.save_dir is not None else None
         parsweep = sweepers[0]
         # execute once for each parallel value
         for values in zip(*(s.values for s in parsweep)):
@@ -169,14 +169,18 @@ class EmulatorController(Controller):
                         updates[channel].update({sweeper.parameter.name: value})
             states, coeffs = self._sweep(sequence, configs, sweepers[1:], updates)
             state_slices.append(states)
-            coeff_slices.append(coeffs)
+            if coeff_slices is not None:
+                coeff_slices.append(coeffs)
 
         # stack all slices in a single array, along the current outermost dimension
-        return np.stack(state_slices), np.stack(coeff_slices)
+        return (
+            np.stack(state_slices),
+            np.stack(coeff_slices) if coeff_slices is not None else None,
+        )
 
     def _evolve(
         self, sequence: PulseSequence, configs: dict[str, Config], updates: dict
-    ) -> NDArray:
+    ) -> tuple[NDArray, NDArray | None]:
         """Evolve a pulse sequence on the quantum emulator.
 
         This method updates the sequence parameters, generates the time grid, constructs

--- a/tests/instruments/emulator/test_emulator.py
+++ b/tests/instruments/emulator/test_emulator.py
@@ -4,6 +4,8 @@ import numpy as np
 import pytest
 
 from qibolab._core.execution_parameters import AcquisitionType, AveragingMode
+from qibolab._core.pulses import Delay
+from qibolab._core.sequence import PulseSequence
 from qibolab._core.sweeper import Parameter, Sweeper
 
 NSHOTS = 1000
@@ -50,4 +52,24 @@ def test_sweepers(platform):
     )
     acq_handle = list(seq.channel(platform.qubits[0].acquisition))[-1].id
     res = platform.execute([seq], [[sweeper]], nshots=NSHOTS)
+    assert res[acq_handle].shape == (NSHOTS, 2)
+
+
+def test_duration_sweeper_with_variable_sequence_length(platform):
+    q0 = platform.natives.single_qubit[0]
+    delay = Delay(duration=0)
+    seq = q0.RX() | PulseSequence([(platform.qubits[0].acquisition, delay)]) | q0.MZ()
+    sweeper = Sweeper(
+        parameter=Parameter.duration, values=np.array([0, 2000]), pulses=[delay]
+    )
+    acq_handle = list(seq.channel(platform.qubits[0].acquisition))[-1].id
+
+    res = platform.execute(
+        [seq],
+        [[sweeper]],
+        nshots=NSHOTS,
+        acquisition_type=AcquisitionType.DISCRIMINATION,
+        averaging_mode=AveragingMode.SINGLESHOT,
+    )
+
     assert res[acq_handle].shape == (NSHOTS, 2)


### PR DESCRIPTION
### Summary

This PR fixes an emulator execution failure for swept-duration workflows where the pulse sequence length changes between sweep points.

The issue appeared while validating Qibocal T1 workflows on the emulator after the recent result-handling fixes. A T1 delay sweep changes the duration of the sequence, so the pulse-Hamiltonian coefficient arrays can have different lengths for each sweep value. The emulator was stacking those coefficient arrays unconditionally:

```python
return np.stack(state_slices), np.stack(coeff_slices)
```

That raises:

```text
ValueError: all input arrays must have the same shape
```

For normal execution, these coefficients are not used. They are only needed when `EmulatorController.save_dir` is enabled for dumping the simulated evolution. This PR therefore keeps stacking the states as before, but only collects/stacks coefficient arrays when `save_dir` is set.

### Change

The sweep code now treats coefficient stacking as part of the simulation-dump path:

```python
coeff_slices = [] if self.save_dir is not None else None
...
if coeff_slices is not None:
    coeff_slices.append(coeffs)
...
return (
    np.stack(state_slices),
    np.stack(coeff_slices) if coeff_slices is not None else None,
)
```

This keeps ordinary emulator execution from failing on variable-duration sweeps while preserving the existing behavior for saved simulations.

### Test

I added a regression test that sweeps a `Delay.duration` before measurement. This reproduces the variable sequence-length case that triggered the Qibocal T1 failure.

### Validation

Focused checks:

```bash
pytest tests/instruments/emulator/test_emulator.py -k variable_sequence_length -q
pytest tests/instruments/emulator/test_emulator.py tests/instruments/emulator/test_results.py -q
ruff check src/qibolab/_core/instruments/emulator/emulator.py tests/instruments/emulator/test_emulator.py
ruff format --check src/qibolab/_core/instruments/emulator/emulator.py tests/instruments/emulator/test_emulator.py
```

All passed locally.

Qibocal T1 smoke after this patch:

| Workflow | Engine | Status | Acquisition time | Fitted T1 |
|---|---|---|---:|---:|
| `t1` on `qubit` | QuTiP | acquisition + fit passed | 5.99 s | 982.869 ns |
| `t1` on `qubit` | Dynamiqs | acquisition + fit passed | 19.25 s | 987.984 ns |

The Dynamiqs and QuTiP fitted T1 values agree closely for this smoke workflow.

### Scope

This is intentionally limited to ordinary emulator execution with swept sequence durations. It does not attempt to redesign the saved-evolution dump format for variable-length coefficient arrays.
