### PR TITLE
Upgrade QM driver

### DIFF
--- a/src/qibolab/_core/instruments/qm/components/configs.py
+++ b/src/qibolab/_core/instruments/qm/components/configs.py
@@ -1,4 +1,4 @@
-from typing import Literal, Union
+from typing import Any, Literal, Union
 
 import numpy as np
 
@@ -59,7 +59,7 @@ class OpxOutputConfig(Config):
 
     @property
     def filter(self):
-        return {"feedback": [], "feedforward": []}
+        return {"exponential": [], "feedforward": []}
         feedback_filters = [
             -i.feedback[1] for i in self.filters if isinstance(i, ExponentialFilter)
         ]
@@ -82,7 +82,7 @@ class OctaveOscillatorConfig(OscillatorConfig):
 
 
 class QmAcquisitionConfig(AcquisitionConfig):
-    """Acquisition config for QM OPX+."""
+    """Acquisition config for QM."""
 
     kind: Literal["qm-acquisition"] = "qm-acquisition"
 
@@ -93,6 +93,12 @@ class QmAcquisitionConfig(AcquisitionConfig):
     """
     offset: float = 0.0
     """Constant voltage to be applied on the input."""
+
+    def model_post_init(self, context: Any) -> None:
+        # The minimum time-of-flight for QM is 28 ns, so we need to ensure that
+        # the delay is at least 28 ns
+        if self.delay < 28:
+            object.__setattr__(self, "delay", 28)
 
 
 class MwFemOscillatorConfig(OscillatorConfig):

--- a/src/qibolab/_core/instruments/qm/components/configs.py
+++ b/src/qibolab/_core/instruments/qm/components/configs.py
@@ -109,7 +109,8 @@ class QmAcquisitionConfig(AcquisitionConfig):
 
     def model_post_init(self, context: Any) -> None:
         # The minimum time-of-flight for QM is 28 ns, so we need to ensure that
-        # the delay is at least 28 ns
+        # the delay is at least 28 ns (determined from QM error message during
+        # execution)
         if self.delay < 28:
             object.__setattr__(self, "delay", 28)
 

--- a/src/qibolab/_core/instruments/qm/components/configs.py
+++ b/src/qibolab/_core/instruments/qm/components/configs.py
@@ -71,7 +71,7 @@ class OpxOutputConfig(DcConfig):
         elif cluster in {"opx1000", "LF", "MW"}:
             iir = {
                 "exponential": [
-                    (None, None)
+                    (filt.amplitude, filt.tau)
                     for filt in self.filters
                     if isinstance(filt, ExponentialFilter)
                 ]

--- a/src/qibolab/_core/instruments/qm/components/configs.py
+++ b/src/qibolab/_core/instruments/qm/components/configs.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from qibolab._core.components import (
     AcquisitionConfig,
-    DcConfig,
+    Config,
     OscillatorConfig,
 )
 from qibolab._core.components.filters import ExponentialFilter
@@ -41,7 +41,7 @@ def normalize_feedback(taps: list[float], threshold: float) -> list[float]:
     return new_taps.tolist()
 
 
-class OpxOutputConfig(DcConfig):
+class OpxOutputConfig(Config):
     """DC channel config using QM OPX+."""
 
     kind: Literal["opx-output"] = "opx-output"
@@ -54,11 +54,12 @@ class OpxOutputConfig(DcConfig):
     output_mode: Literal["direct", "amplified"] = "direct"
     sampling_rate: float = DEFAULT_SAMPLING_RATE
     upsampling_mode: Literal["mw", "pulse"] = "mw"
-    feedback_max: float = DEFAULT_FEEDBACK_MAX
-    feedforward_max: float = DEFAULT_FEEDFORWARD_MAX
+    # feedback_max: float = DEFAULT_FEEDBACK_MAX
+    # feedforward_max: float = DEFAULT_FEEDFORWARD_MAX
 
     @property
     def filter(self):
+        return {"feedback": [], "feedforward": []}
         feedback_filters = [
             -i.feedback[1] for i in self.filters if isinstance(i, ExponentialFilter)
         ]

--- a/src/qibolab/_core/instruments/qm/components/configs.py
+++ b/src/qibolab/_core/instruments/qm/components/configs.py
@@ -42,9 +42,6 @@ def normalize_feedback(taps: list[float], threshold: float) -> list[float]:
     return new_taps.tolist()
 
 
-Cluster = Literal["OPX", "OPX+", "OPX1000"]
-
-
 class OpxOutputConfig(DcConfig):
     """DC channel config using QM OPX+."""
 
@@ -58,13 +55,11 @@ class OpxOutputConfig(DcConfig):
     output_mode: Literal["direct", "amplified"] = "direct"
     sampling_rate: float = DEFAULT_SAMPLING_RATE
     upsampling_mode: Literal["mw", "pulse"] = "mw"
-    cluster: Cluster = Field(exclude=True, default="OPX1000")
     feedback_max: float = Field(exclude=True, default=DEFAULT_FEEDBACK_MAX)
     feedforward_max: float = Field(exclude=True, default=DEFAULT_FEEDFORWARD_MAX)
 
-    @property
-    def filter(self):
-        if self.cluster == "OPX+":
+    def filter(self, cluster: str) -> dict[str, list[float]]:
+        if cluster == "opx1":
             feedback_filters = [
                 -i.feedback[1] for i in self.filters if isinstance(i, ExponentialFilter)
             ]
@@ -73,7 +68,7 @@ class OpxOutputConfig(DcConfig):
                 if len(feedback_filters) > 0
                 else []
             }
-        elif self.cluster == "OPX1000":
+        elif cluster in {"opx1000", "LF", "MW"}:
             iir = {
                 "exponential": [
                     (None, None)
@@ -82,7 +77,7 @@ class OpxOutputConfig(DcConfig):
                 ]
             }
         else:
-            raise NotImplementedError(f"Cluster type {self.cluster} not yet supported")
+            raise NotImplementedError(f"Cluster type {cluster} not yet supported")
 
         return {
             "feedforward": normalize_feedforward(self.feedforward, self.feedforward_max)

--- a/src/qibolab/_core/instruments/qm/components/configs.py
+++ b/src/qibolab/_core/instruments/qm/components/configs.py
@@ -1,10 +1,11 @@
 from typing import Any, Literal, Union
 
 import numpy as np
+from pydantic import Field
 
 from qibolab._core.components import (
     AcquisitionConfig,
-    Config,
+    DcConfig,
     OscillatorConfig,
 )
 from qibolab._core.components.filters import ExponentialFilter
@@ -41,7 +42,10 @@ def normalize_feedback(taps: list[float], threshold: float) -> list[float]:
     return new_taps.tolist()
 
 
-class OpxOutputConfig(Config):
+Cluster = Literal["OPX", "OPX+", "OPX1000"]
+
+
+class OpxOutputConfig(DcConfig):
     """DC channel config using QM OPX+."""
 
     kind: Literal["opx-output"] = "opx-output"
@@ -54,23 +58,37 @@ class OpxOutputConfig(Config):
     output_mode: Literal["direct", "amplified"] = "direct"
     sampling_rate: float = DEFAULT_SAMPLING_RATE
     upsampling_mode: Literal["mw", "pulse"] = "mw"
-    # feedback_max: float = DEFAULT_FEEDBACK_MAX
-    # feedforward_max: float = DEFAULT_FEEDFORWARD_MAX
+    cluster: Cluster = Field(exclude=True, default="OPX1000")
+    feedback_max: float = Field(exclude=True, default=DEFAULT_FEEDBACK_MAX)
+    feedforward_max: float = Field(exclude=True, default=DEFAULT_FEEDFORWARD_MAX)
 
     @property
     def filter(self):
-        return {"exponential": [], "feedforward": []}
-        feedback_filters = [
-            -i.feedback[1] for i in self.filters if isinstance(i, ExponentialFilter)
-        ]
+        if self.cluster == "OPX+":
+            feedback_filters = [
+                -i.feedback[1] for i in self.filters if isinstance(i, ExponentialFilter)
+            ]
+            iir = {
+                "feedback": normalize_feedback(feedback_filters, self.feedback_max)
+                if len(feedback_filters) > 0
+                else []
+            }
+        elif self.cluster == "OPX1000":
+            iir = {
+                "exponential": [
+                    (None, None)
+                    for filt in self.filters
+                    if isinstance(filt, ExponentialFilter)
+                ]
+            }
+        else:
+            raise NotImplementedError(f"Cluster type {self.cluster} not yet supported")
+
         return {
-            "feedback": normalize_feedback(feedback_filters, self.feedback_max)
-            if len(feedback_filters) > 0
-            else [],
             "feedforward": normalize_feedforward(self.feedforward, self.feedforward_max)
             if len(self.feedforward) > 0
-            else [],
-        }
+            else []
+        } | iir
 
 
 class OctaveOscillatorConfig(OscillatorConfig):

--- a/src/qibolab/_core/instruments/qm/components/configs.py
+++ b/src/qibolab/_core/instruments/qm/components/configs.py
@@ -58,7 +58,7 @@ class OpxOutputConfig(DcConfig):
     feedback_max: float = Field(exclude=True, default=DEFAULT_FEEDBACK_MAX)
     feedforward_max: float = Field(exclude=True, default=DEFAULT_FEEDFORWARD_MAX)
 
-    def filter(self, cluster: str) -> dict[str, list[float]]:
+    def filter(self, cluster: str) -> dict[str, list[float | tuple[float, float]]]:
         if cluster == "opx1":
             feedback_filters = [
                 -i.feedback[1] for i in self.filters if isinstance(i, ExponentialFilter)

--- a/src/qibolab/_core/instruments/qm/config/config.py
+++ b/src/qibolab/_core/instruments/qm/config/config.py
@@ -89,11 +89,12 @@ class Configuration:
         if controller.type == "opx1":
             keys = ["offset"]
         else:
-            keys = list(config.model_fields.keys())
+            keys = list(config.model_dump().keys())
             keys.remove("kind")
+            keys.remove("filters")
         config_values = config.model_dump()
         values = {k: config_values[k] for k in keys}
-        values.update({"filter": config.filter})
+        values.update({"filter": config.filter(controller.type)})
         if config.sampling_rate > 1e9:
             del values["upsampling_mode"]
         controller.analog_outputs[channel.port] = values

--- a/src/qibolab/_core/instruments/qm/program/loops.py
+++ b/src/qibolab/_core/instruments/qm/program/loops.py
@@ -32,7 +32,7 @@ def from_array(var: Variable, array: npt.NDArray | list):
     ):
         raise Exception("The array must be an array of python variables.")
     # Check array increment
-    if np.isclose(np.std(np.diff(array)), 0):
+    if np.isclose(np.diff(array).std() / np.abs(array).mean(), 0):
         increment = "lin"
     elif np.isclose(np.std(array[1:] / array[:-1]), 0, atol=1e-3):
         increment = "log"


### PR DESCRIPTION
At least the configurations generated seem to be incompatible with the current firmware (QOP 3.6.2), since some entries were flagged to be not recognized.

However, I'm not sure why this is generating an error only now: the properties responsible for the error (e.g. `feedback_max` and `feedforward_max`) did not exist even before, at least since quite a long time.

<details><summary>FEM configurations for <code>qm-qua</code> v1.2.1</summary>
<p align="center">
<img width="578" height="1078" alt="image" src="https://github.com/user-attachments/assets/8e284054-0c44-4a23-bf27-bc96d243445e" />
</p>
</details> 

So, I guess this was just ignored in the validation process. While now they require that  only the existing keys are populated.
But I've not been able to trace this in their changelog https://github.com/qm-labs/qm-qua-sdk-public/releases