### PR TITLE
fix: export locate_platform

### DIFF
--- a/src/qibolab/_core/platform/load.py
+++ b/src/qibolab/_core/platform/load.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from .components import Hardware
 from .platform import Platform
 
-__all__ = ["create_platform"]
+__all__ = ["create_platform", "locate_platform"]
 
 PLATFORM = "platform.py"
 """Conventional name of the file containing the platform definition.


### PR DESCRIPTION
I was running into this error since qibocal relies on `locate_platform`
```
(qpu165) roy.stegeman@dalma:~/calibration$ python -c 'from qibolab import locate_platform'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "<frozen importlib._bootstrap>", line 1075, in _handle_fromlist
  File "qibolab/src/qibolab/__init__.py", line 38, in __getattr__
    return globals()[name]
KeyError: 'locate_platform'
```

I noticed there are further functions in qibolab/_core/platform/load.py whose name suggests they are public (no prepended underscore), but that are not exported either: `load_hardware` and `available_platforms`.