### PR TITLE
Improve Qblox execution timeout handling and time logging

### DIFF
--- a/src/qibolab/_core/instruments/qblox/cluster.py
+++ b/src/qibolab/_core/instruments/qblox/cluster.py
@@ -1,10 +1,11 @@
-import time
+import logging
 import warnings
 from collections import defaultdict
 from functools import cached_property
 from itertools import groupby
 from typing import cast
 
+import numpy as np
 import qblox_instruments as qblox
 from qblox_instruments.qcodes_drivers.module import Module
 from qcodes.instrument import find_or_create_instrument
@@ -292,6 +293,7 @@ class Cluster(Controller):
 
                 # finally execute the experiment, and fetch results
                 duration = _compute_duration(ps, sweepers_, options_, configs)
+                logging.info(f"Qblox expected execution time: {duration:.3f} s")
                 data = self._execute(
                     sequencers, sequences_, duration, options_.acquisition_type
                 )
@@ -441,15 +443,15 @@ class Cluster(Controller):
                 module.arm_sequencer(seq)
             module.start_sequencer()
 
-        # wait for experiment completion
-        time.sleep(duration)
+        # sequencer timeout is in minutes: round up duration (s) + 1 min buffer
+        timeout = np.ceil(duration / 60) + 1
 
         # fetch acquired results
         acquisitions = {}
         for slot, seqs in sequencers.items():
             for ch, seq in seqs.items():
                 # wait all sequencers
-                status = self.cluster.get_sequencer_status(slot, seq, timeout=1)
+                status = self.cluster.get_sequencer_status(slot, seq, timeout=timeout)
                 if status.status is qblox.SequencerStatuses.ERROR:
                     raise RuntimeError(f"slot: {slot}, seq: {seq}\n{status}")
                 if status.status is qblox.SequencerStatuses.WARNING:

--- a/src/qibolab/_core/instruments/qblox/cluster.py
+++ b/src/qibolab/_core/instruments/qblox/cluster.py
@@ -1,11 +1,11 @@
 import logging
+import time
 import warnings
 from collections import defaultdict
 from functools import cached_property
 from itertools import groupby
 from typing import cast
 
-import numpy as np
 import qblox_instruments as qblox
 from qblox_instruments.qcodes_drivers.module import Module
 from qcodes.instrument import find_or_create_instrument
@@ -72,8 +72,8 @@ def _compute_duration(
     # TODO: wait_sync duration is determined as explained in this comment
     # https://github.com/qiboteam/qibolab/pull/1389#issuecomment-3884129213.
     # It should be checked with Qblox if the sync time can indeed be of the
-    # order of 1000 ns.
-    wait_sync_duration = 1000
+    # order of 900 ns.
+    wait_sync_duration = 900
     duration = options.estimate_duration(
         [ps], sweepers, time_of_flight + wait_sync_duration
     )
@@ -443,15 +443,15 @@ class Cluster(Controller):
                 module.arm_sequencer(seq)
             module.start_sequencer()
 
-        # sequencer timeout is in minutes: round up duration (s) + 1 min buffer
-        timeout = np.ceil(duration / 60) + 1
+        # wait for experiment completion
+        time.sleep(duration)
 
         # fetch acquired results
         acquisitions = {}
         for slot, seqs in sequencers.items():
             for ch, seq in seqs.items():
                 # wait all sequencers
-                status = self.cluster.get_sequencer_status(slot, seq, timeout=timeout)
+                status = self.cluster.get_sequencer_status(slot, seq, timeout=1)
                 if status.status is qblox.SequencerStatuses.ERROR:
                     raise RuntimeError(f"slot: {slot}, seq: {seq}\n{status}")
                 if status.status is qblox.SequencerStatuses.WARNING:

--- a/src/qibolab/_core/platform/platform.py
+++ b/src/qibolab/_core/platform/platform.py
@@ -270,7 +270,7 @@ class Platform:
         options = self.settings.fill(ExecutionParameters(**options))
 
         time = options.estimate_duration(sequences, sweepers)
-        log.info(f"Minimal execution time: {time:.3f} s")
+        log.info(f"Pulse execution time: {time:.3f} s")
 
         configs = self.parameters.configs.copy()
         update_configs(configs, options.updates)


### PR DESCRIPTION
Make the estimated `wait_sync_duration` less conservative by reducing it, to avoid unnecessary waiting in case the duration is signficantly overestimated. 

For short relaxation times the delays introduced in the Qblox driver may dominate the acquisition time making the pulse time a very poor estimate for total execution time of the protocol. Here we improve execution time logging by reporting the estimated Qblox execution time and renaming the platform log message to Pulse execution time.
