### PR TITLE
Expose channel identifier

### DIFF
--- a/src/qibolab/_core/identifier.py
+++ b/src/qibolab/_core/identifier.py
@@ -4,7 +4,7 @@ import numpy as np
 import numpy.typing as npt
 from pydantic import BeforeValidator, Field, PlainSerializer
 
-__all__ = ["Result"]
+__all__ = ["ChannelId", "Result"]
 
 QubitId = Annotated[Union[int, str], Field(union_mode="left_to_right")]
 """Qubit name."""

--- a/src/qibolab/_core/platform/platform.py
+++ b/src/qibolab/_core/platform/platform.py
@@ -4,7 +4,7 @@ import logging
 import signal
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 from ..components import Config
 from ..components.channels import Channel
@@ -213,7 +213,7 @@ class Platform:
         self,
         sequences: list[PulseSequence],
         sweepers: list[ParallelSweepers] | None = None,
-        **options,
+        **options: Any,
     ) -> dict[PulseId, Result]:
         """Execute pulse sequences.
 


### PR DESCRIPTION
As part of other public classes and functions, it should have already been exposed before.
