### PR TITLE
fix: use id to distinguish swept pulses

### DIFF
--- a/src/qibolab/_core/instruments/qblox/sequence/sequence.py
+++ b/src/qibolab/_core/instruments/qblox/sequence/sequence.py
@@ -79,16 +79,19 @@ class Q1Sequence(Model):
             duration
             - sum(p.duration if not isinstance(p, Align) else 0 for p in sequence)
         ) * sampling_rate
+        pulse_and_readout_ids = {
+            pulse.id for pulse in sequence if isinstance(pulse, (Pulse, Readout))
+        }
         waveform_specs, indices_map = waveforms(
             sequence,
             sampling_rate,
-            amplitude_swept={
-                p.id for p in swept_pulses(sweepers, {Parameter.amplitude})
-            },
+            amplitude_swept=set(swept_pulses(sweepers, {Parameter.amplitude})),
             duration_swept={
-                k.id: v
-                for k, v in swept_pulses(sweepers, {Parameter.duration}).items()
-                if isinstance(k, (Pulse, Readout)) and k in sequence
+                pulse_id: sweeper
+                for pulse_id, sweeper in swept_pulses(
+                    sweepers, {Parameter.duration}
+                ).items()
+                if pulse_id in pulse_and_readout_ids
             },
         )
         sequence, sweepers = _apply_sampling_rate(sequence, sweepers, sampling_rate)

--- a/src/qibolab/_core/sweeper.py
+++ b/src/qibolab/_core/sweeper.py
@@ -9,7 +9,7 @@ from pydantic import model_validator
 
 from .components.configs import OscillatorConfig
 from .identifier import ChannelId
-from .pulses import PulseLike, VirtualZ
+from .pulses import PulseId, PulseLike, VirtualZ
 from .serialize import Model, eq
 
 __all__ = ["Parameter", "ParallelSweepers", "Sweeper"]
@@ -201,7 +201,7 @@ def iteration_length(sweepers: ParallelSweepers) -> int:
 def swept_pulses(
     sweepers: list[ParallelSweepers],
     parameters: Collection[Parameter] = frozenset(Parameter),
-) -> dict[PulseLike, Sweeper]:
+) -> dict[PulseId, Sweeper]:
     """Associate pulses swept to sweepers.
 
     Essentially, it produces a reverse index from `sweepers`.
@@ -212,7 +212,7 @@ def swept_pulses(
     # TODO: this is assuming a pulse is only swept by a single sweeper. Which is not
     # always the case. A list of `Sweeper` objects should be returned instead
     return {
-        p: sweep
+        p.id: sweep
         for parsweep in sweepers
         for sweep in parsweep
         if sweep.parameter in parameters and sweep.pulses is not None


### PR DESCRIPTION
The `swept_pulses` function built a dict of `PulseLike` to `Sweeper`. In `from_pulses` this function is called and the pulse id was extracted from the swept pulses. However, this results in a bug in the case where multiple of the same pulses are swept. Namely, since `PulseLIke.__eq__` explicitly ignores the .id attribute, the dict returned by `swept_pulses` only contains a single pulse for each set of equivalent pulses, but since later the pulse id was used to identify the relevant swept pulse, this missed any pulses that are equivalent up to the id.

It is fixed by making `swept_pulses` return not a dict with `PulseLike` keys, but rather with `PulseId` keys.
