### PR TITLE
Ruff v0.16 default rule changes and consolidate linting tools

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 ci:
-  autofix_prs: false
+  autofix_prs: true
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
@@ -12,34 +12,10 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.16.0
     hooks:
-      # Run the linter.
       - id: ruff
-        args: [--fix]
-      # Sort imports
-      - id: ruff
-        args: [--select, I, --fix]
-      # Run the formatter.
+        args: [--fix, --config=pyproject.toml]
       - id: ruff-format
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.21.2
-    hooks:
-      - id: pyupgrade
-        args:
-          - --py310-plus
-  - repo: https://github.com/hadialqattan/pycln
-    rev: v2.6.0
-    hooks:
-      - id: pycln
-        args:
-          - --config=pyproject.toml
   - repo: https://github.com/adamchainz/blacken-docs
     rev: 1.20.0
     hooks:
       - id: blacken-docs
-  - repo: https://github.com/pycqa/pydocstyle
-    rev: 6.3.0
-    hooks:
-      - id: pydocstyle
-        args:
-          - --select=D103,D200,D206,D300,D301
-        files: ^src/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 ci:
-  autofix_prs: true
+  autofix_prs: false
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/benchmarks/emulator_gpu.py
+++ b/benchmarks/emulator_gpu.py
@@ -70,7 +70,7 @@ def jax_devices() -> list[str]:
         import jax
 
         return [str(device) for device in jax.devices()]
-    except Exception as exc:  # pragma: no cover - diagnostic path
+    except Exception as exc:  # noqa: BLE001
         return [f"unavailable: {exc}"]
 
 
@@ -80,7 +80,7 @@ def cupy_device() -> str | None:
 
         device = cp.cuda.Device()
         return f"id={device.id}, memory={cp.cuda.runtime.memGetInfo()}"
-    except Exception:
+    except Exception:  # noqa: BLE001
         return None
 
 

--- a/benchmarks/emulator_gpu.py
+++ b/benchmarks/emulator_gpu.py
@@ -112,11 +112,11 @@ def benchmark(args: argparse.Namespace) -> dict[str, Any]:
     gates = platform.natives.single_qubit[0]
     sequence = gates.RX() | gates.MZ()
     acquisition = list(sequence.channel(platform.qubits[0].acquisition))[-1].id
-    execute_kwargs = dict(
-        nshots=args.nshots,
-        acquisition_type=AcquisitionType.INTEGRATION,
-        averaging_mode=AveragingMode.CYCLIC,
-    )
+    execute_kwargs = {
+        "nshots": args.nshots,
+        "acquisition_type": AcquisitionType.INTEGRATION,
+        "averaging_mode": AveragingMode.CYCLIC,
+    }
 
     for _ in range(args.warmups):
         platform.execute([sequence], **execute_kwargs)

--- a/benchmarks/engine_sweep.py
+++ b/benchmarks/engine_sweep.py
@@ -36,6 +36,7 @@ Examples:
 from __future__ import annotations
 
 import argparse
+import itertools
 import json
 import resource
 import subprocess
@@ -87,7 +88,7 @@ def chain_operators(engine, levels: int, n: int):
             * ANHARMONICITY
             * (lowering.dag() * lowering.dag() * lowering * lowering)
         )
-    for left, right in zip(lowerings[:-1], lowerings[1:]):
+    for left, right in itertools.pairwise(lowerings):
         hamiltonian += 2 * np.pi * COUPLING * (left.dag() * right + left * right.dag())
     collapse = [(1 / T1) ** 0.5 * lowering for lowering in lowerings]
     drive = lowerings[0] + lowerings[0].dag()

--- a/benchmarks/engine_sweep.py
+++ b/benchmarks/engine_sweep.py
@@ -134,7 +134,7 @@ def memory_metrics(device: str) -> dict:
 
             stats = jax.local_devices()[0].memory_stats() or {}
             metrics["gpu_peak_bytes"] = stats.get("peak_bytes_in_use")
-        except Exception:
+        except Exception:  # noqa: BLE001
             metrics["gpu_peak_bytes"] = None
         try:
             metrics["nvidia_smi"] = subprocess.check_output(
@@ -315,7 +315,7 @@ def run_validate(args: argparse.Namespace) -> None:
                 "dim": dim,
                 "max_deviation": deviation,
             }
-        except Exception as error:  # pragma: no cover - diagnostic path
+        except Exception as error:  # noqa: BLE001
             record = {
                 "mode": "validate",
                 "configuration": label,

--- a/poetry.lock
+++ b/poetry.lock
@@ -724,7 +724,7 @@ files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "(platform_system == \"Windows\" or sys_platform == \"win32\") and (extra == \"emulator\" or extra == \"backend\")", dev = "sys_platform == \"win32\"", docs = "platform_system == \"Windows\" or sys_platform == \"win32\"", tests = "platform_system == \"Windows\" or sys_platform == \"win32\""}
+markers = {main = "(platform_system == \"Windows\" or sys_platform == \"win32\") and (extra == \"backend\" or extra == \"emulator\")", dev = "sys_platform == \"win32\"", docs = "platform_system == \"Windows\" or sys_platform == \"win32\"", tests = "platform_system == \"Windows\" or sys_platform == \"win32\""}
 
 [[package]]
 name = "colorlog"
@@ -3160,7 +3160,7 @@ files = [
     {file = "packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e"},
     {file = "packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661"},
 ]
-markers = {main = "extra == \"emulator\" or extra == \"backend\""}
+markers = {main = "extra == \"backend\" or extra == \"emulator\""}
 
 [[package]]
 name = "pandas"
@@ -4437,7 +4437,7 @@ files = [
     {file = "qutip-5.2.3-cp314-cp314-win_amd64.whl", hash = "sha256:324218baa374a82f32d2c23871835019880d4eb9313bda2caf082adec8e3be6e"},
     {file = "qutip-5.2.3.tar.gz", hash = "sha256:a095df67f0afafa5db8ee67c342580de3fbfa0259320c9572ff820f51029baae"},
 ]
-markers = {main = "extra == \"emulator\""}
+markers = {main = "python_version == \"3.10\" and extra == \"emulator\"", docs = "python_version == \"3.10\""}
 
 [package.dependencies]
 numpy = ">=1.22"
@@ -4877,30 +4877,30 @@ oldlibyaml = ["ruamel.yaml.clib ; platform_python_implementation == \"CPython\""
 
 [[package]]
 name = "ruff"
-version = "0.9.10"
+version = "0.16.0"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
 groups = ["analysis"]
 files = [
-    {file = "ruff-0.9.10-py3-none-linux_armv6l.whl", hash = "sha256:eb4d25532cfd9fe461acc83498361ec2e2252795b4f40b17e80692814329e42d"},
-    {file = "ruff-0.9.10-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:188a6638dab1aa9bb6228a7302387b2c9954e455fb25d6b4470cb0641d16759d"},
-    {file = "ruff-0.9.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5284dcac6b9dbc2fcb71fdfc26a217b2ca4ede6ccd57476f52a587451ebe450d"},
-    {file = "ruff-0.9.10-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:47678f39fa2a3da62724851107f438c8229a3470f533894b5568a39b40029c0c"},
-    {file = "ruff-0.9.10-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:99713a6e2766b7a17147b309e8c915b32b07a25c9efd12ada79f217c9c778b3e"},
-    {file = "ruff-0.9.10-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:524ee184d92f7c7304aa568e2db20f50c32d1d0caa235d8ddf10497566ea1a12"},
-    {file = "ruff-0.9.10-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:df92aeac30af821f9acf819fc01b4afc3dfb829d2782884f8739fb52a8119a16"},
-    {file = "ruff-0.9.10-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de42e4edc296f520bb84954eb992a07a0ec5a02fecb834498415908469854a52"},
-    {file = "ruff-0.9.10-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d257f95b65806104b6b1ffca0ea53f4ef98454036df65b1eda3693534813ecd1"},
-    {file = "ruff-0.9.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b60dec7201c0b10d6d11be00e8f2dbb6f40ef1828ee75ed739923799513db24c"},
-    {file = "ruff-0.9.10-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d838b60007da7a39c046fcdd317293d10b845001f38bcb55ba766c3875b01e43"},
-    {file = "ruff-0.9.10-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ccaf903108b899beb8e09a63ffae5869057ab649c1e9231c05ae354ebc62066c"},
-    {file = "ruff-0.9.10-py3-none-musllinux_1_2_i686.whl", hash = "sha256:f9567d135265d46e59d62dc60c0bfad10e9a6822e231f5b24032dba5a55be6b5"},
-    {file = "ruff-0.9.10-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5f202f0d93738c28a89f8ed9eaba01b7be339e5d8d642c994347eaa81c6d75b8"},
-    {file = "ruff-0.9.10-py3-none-win32.whl", hash = "sha256:bfb834e87c916521ce46b1788fbb8484966e5113c02df216680102e9eb960029"},
-    {file = "ruff-0.9.10-py3-none-win_amd64.whl", hash = "sha256:f2160eeef3031bf4b17df74e307d4c5fb689a6f3a26a2de3f7ef4044e3c484f1"},
-    {file = "ruff-0.9.10-py3-none-win_arm64.whl", hash = "sha256:5fd804c0327a5e5ea26615550e706942f348b197d5475ff34c19733aee4b2e69"},
-    {file = "ruff-0.9.10.tar.gz", hash = "sha256:9bacb735d7bada9cfb0f2c227d3658fc443d90a727b47f206fb33f52f3c0eac7"},
+    {file = "ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e"},
+    {file = "ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522"},
+    {file = "ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81"},
+    {file = "ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9"},
+    {file = "ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a"},
+    {file = "ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717"},
+    {file = "ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17"},
+    {file = "ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4"},
+    {file = "ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b"},
+    {file = "ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0"},
+    {file = "ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213"},
+    {file = "ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af"},
+    {file = "ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09"},
+    {file = "ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed"},
+    {file = "ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb"},
+    {file = "ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472"},
+    {file = "ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d"},
+    {file = "ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982"},
 ]
 
 [[package]]
@@ -4985,12 +4985,12 @@ version = "83.0.0"
 description = "Most extensible Python build backend with support for C/C++ extension modules"
 optional = false
 python-versions = ">=3.10"
-groups = ["dev", "docs", "tests"]
+groups = ["docs", "tests"]
+markers = "python_version == \"3.10\""
 files = [
     {file = "setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3"},
     {file = "setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef"},
 ]
-markers = {docs = "python_version == \"3.10\"", tests = "python_version == \"3.10\""}
 
 [package.extras]
 check = ["pytest-checkdocs (>=2.14)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\"", "ruff (>=0.13.0) ; sys_platform != \"cygwin\""]
@@ -5585,7 +5585,7 @@ files = [
     {file = "tqdm-4.68.3-py3-none-any.whl", hash = "sha256:39832cc2def2789a6f29df83f172db7416cea70052c0907a57801c5f2fdccb03"},
     {file = "tqdm-4.68.3.tar.gz", hash = "sha256:00dfa48452b6b6cfae3dd9885636c23d3422d1ec97c66d96818cbd5e0821d482"},
 ]
-markers = {main = "extra == \"emulator\" or extra == \"backend\""}
+markers = {main = "extra == \"backend\" or extra == \"emulator\""}
 
 [package.dependencies]
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
@@ -6212,4 +6212,4 @@ qrng = ["pyserial"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.14"
-content-hash = "c2ce1cad8d25e6c861a11035798d99442418fbd4ea799184c5b4cd6ded54bf19"
+content-hash = "fc4d7bc735b61769b02aa8149fe186af13b53436ed4cbe7fc6e70a36fafad058"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,9 +107,6 @@ line-length = 88
 [tool.ruff.lint]
 extend-select = ["I","UP", "D103","D200","D206","D300","D301"] # I -> pycln, D->pydocstyle, UP->pyupgrade
 
-[tool.ruff.lint.isort]
-known-first-party = ["qibolab"]
-
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F403"]
 "!src/**/*" = ["D103", "D200", "D206", "D300", "D301"] # skip for non src/ files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,6 @@ line-length = 88
 
 [tool.ruff.lint]
 extend-select = ["I","UP", "D103","D200","D206","D300","D301"] # I -> pycln, D->pydocstyle, UP->pyupgrade
-ignore = ["BLE001"]  # TODO: warning about except Exception, fix properly
 
 [tool.ruff.lint.isort]
 known-first-party = ["qibolab"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ lint-warnings = """
   ruff check --exit-zero \
   --select F,E,W,C90,N,UP,BLE,FBT,B,A,C4,T10,EM,EXE,ISC,ICN,LOG,G,INP,PIE,T20,PT,Q,RSE,\
            RET,SLF,SLOT,SIM,TC,INT,ARG,PTH,ERA,NPY,PERF,RUF
-"""
+""" # these are some extra strict checks, but just for reporting purposes
 types = "true"
 docs = "make -C doc html"
 docs-clean = "make -C doc clean"
@@ -100,15 +100,18 @@ addopts = [
   "--ignore=tests/qblox", # TODO: move tests to qibolab-qblox
 ]
 
+[tool.ruff]
+target-version = "py310"
+line-length = 88
+
 [tool.ruff.lint]
-ignore = ["BLE001"] # TODO: warning about except Exception, fix properly
+extend-select = ["I","UP", "D103","D200","D206","D300","D301"] # I -> pycln, D->pydocstyle, UP->pyupgrade
+ignore = ["BLE001"]  # TODO: warning about except Exception, fix properly
+
+[tool.ruff.lint.isort]
+known-first-party = ["qibolab"]
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F403"]
-"src/qibolab/instruments/*.py" = ["F403"]
-"src/qibolab/backend.py" = ["F403"]
-"src/qibolab/_core/instruments/qm/program/loops.py" = ["TRY002"]
-
-[tool.pycln]
-all = true
-exclude = "__init__.py"
+"!src/**/*" = ["D103", "D200", "D206", "D300", "D301"] # skip for non src/ files
+"src/qibolab/_core/instruments/qm/program/loops.py" = ["TRY002"] # Create your own exception

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ requests = "^2.32.0"
 optional = true
 
 [tool.poetry.group.analysis.dependencies]
-ruff = "^0.9.1"
+ruff = "^0.16.0"
 
 [tool.poetry.extras]
 backend = ["qibo"]
@@ -100,8 +100,14 @@ addopts = [
   "--ignore=tests/qblox", # TODO: move tests to qibolab-qblox
 ]
 
+[tool.ruff.lint]
+ignore = ["BLE001"] # TODO: warning about except Exception, fix properly
+
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F403"]
+"src/qibolab/instruments/*.py" = ["F403"]
+"src/qibolab/backend.py" = ["F403"]
+"src/qibolab/_core/instruments/qm/program/loops.py" = ["TRY002"]
 
 [tool.pycln]
 all = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,5 @@ line-length = 88
 extend-select = ["I","UP", "D103","D200","D206","D300","D301"] # I -> pycln, D->pydocstyle, UP->pyupgrade
 
 [tool.ruff.lint.per-file-ignores]
-"__init__.py" = ["F403"]
 "!src/**/*" = ["D103", "D200", "D206", "D300", "D301"] # skip for non src/ files
 "src/qibolab/_core/instruments/qm/program/loops.py" = ["TRY002"] # Create your own exception

--- a/src/qibolab/_core/components/channels.py
+++ b/src/qibolab/_core/components/channels.py
@@ -21,7 +21,7 @@ share a component, because channels will refer to the same name for the componen
 from ..identifier import ChannelId
 from ..serialize import Model
 
-__all__ = ["Channel", "DcChannel", "IqChannel", "AcquisitionChannel"]
+__all__ = ["AcquisitionChannel", "Channel", "DcChannel", "IqChannel"]
 
 
 class Channel(Model):

--- a/src/qibolab/_core/components/configs.py
+++ b/src/qibolab/_core/components/configs.py
@@ -9,7 +9,7 @@ configuration defined by these classes.
 
 from functools import reduce
 from pathlib import Path
-from typing import Annotated, Literal, Union
+from typing import Annotated, Literal
 
 import numpy as np
 from pydantic import Field
@@ -18,15 +18,15 @@ from ..serialize import Model, NdArray, eq
 from .filters import Filter
 
 __all__ = [
-    "DcConfig",
-    "IqConfig",
     "AcquisitionConfig",
-    "IqMixerConfig",
-    "OscillatorConfig",
+    "ChannelConfig",
     "Config",
     "Configs",
-    "ChannelConfig",
+    "DcConfig",
+    "IqConfig",
+    "IqMixerConfig",
     "LogConfig",
+    "OscillatorConfig",
 ]
 
 
@@ -139,6 +139,11 @@ class LogConfig(Config):
     path: Path
 
 
-ChannelConfig = Union[
-    DcConfig, IqMixerConfig, OscillatorConfig, IqConfig, AcquisitionConfig, LogConfig
-]
+ChannelConfig = (
+    DcConfig
+    | IqMixerConfig
+    | OscillatorConfig
+    | IqConfig
+    | AcquisitionConfig
+    | LogConfig
+)

--- a/src/qibolab/_core/components/filters.py
+++ b/src/qibolab/_core/components/filters.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Literal, Union
+from typing import Annotated, Literal
 
 import numpy as np
 from pydantic import Field
@@ -56,6 +56,6 @@ class FiniteImpulseResponseFilter(Model):
 
 
 Filter = Annotated[
-    Union[ExponentialFilter, FiniteImpulseResponseFilter],
+    ExponentialFilter | FiniteImpulseResponseFilter,
     Field(discriminator="kind"),
 ]

--- a/src/qibolab/_core/identifier.py
+++ b/src/qibolab/_core/identifier.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Any, Union
+from typing import Annotated, Any
 
 import numpy as np
 import numpy.typing as npt
@@ -6,7 +6,7 @@ from pydantic import BeforeValidator, Field, PlainSerializer
 
 __all__ = ["ChannelId", "Result"]
 
-QubitId = Annotated[Union[int, str], Field(union_mode="left_to_right")]
+QubitId = Annotated[int | str, Field(union_mode="left_to_right")]
 """Qubit name."""
 
 ChannelId = str

--- a/src/qibolab/_core/instruments/dummy.py
+++ b/src/qibolab/_core/instruments/dummy.py
@@ -22,7 +22,7 @@ log = logging.getLogger(__name__)
 SAMPLING_RATE = 1
 
 
-__all__ = ["DummyLocalOscillator", "DummyInstrument"]
+__all__ = ["DummyInstrument", "DummyLocalOscillator"]
 
 
 class DummyDevice:

--- a/src/qibolab/_core/instruments/emulator/engine/abstract.py
+++ b/src/qibolab/_core/instruments/emulator/engine/abstract.py
@@ -10,10 +10,10 @@ from numpy.typing import NDArray
 from qibolab._core.serialize import Model
 
 __all__ = [
-    "SimulationEngine",
     "Operator",
-    "TimeDependentOperator",
     "OperatorEvolution",
+    "SimulationEngine",
+    "TimeDependentOperator",
 ]
 
 HAMILTONIAN_FILENAME = "System_Hamiltonian"
@@ -82,7 +82,7 @@ class SimulationEngine(Model, ABC):
         hamiltonian: Operator,
         initial_state: Operator,
         time: list[float],
-        collapse_operators: list[Operator] = None,
+        collapse_operators: list[Operator] | None = None,
         **kwargs,
     ) -> tuple[EvolutionResult, dict]:
         """Evolve the system."""

--- a/src/qibolab/_core/instruments/emulator/engine/dynamiqs.py
+++ b/src/qibolab/_core/instruments/emulator/engine/dynamiqs.py
@@ -152,7 +152,7 @@ class DynamiqsEngine(SimulationEngine):
         initial_state: Operator,
         time: Iterable[float],
         time_hamiltonian: OperatorEvolution = None,
-        collapse_operators: list[Operator] = None,
+        collapse_operators: list[Operator] | None = None,
         **kwargs,
     ) -> DynamiqsEvolutionResult:
         """Evolve the system."""

--- a/src/qibolab/_core/instruments/keysight/qcs.py
+++ b/src/qibolab/_core/instruments/keysight/qcs.py
@@ -45,7 +45,7 @@ class KeysightQCS(Controller):
     sampling_rate: ClassVar[float] = (
         qcs.SAMPLE_RATES[qcs.InstrumentEnum.M5300AWG] * nano
     )
-    offset_channels: list[ChannelId] = []
+    offset_channels: list[ChannelId] = []  # noqa: RUF012
     """Subset of channels that require DC offset"""
 
     def connect(self):

--- a/src/qibolab/_core/instruments/keysight/sweep.py
+++ b/src/qibolab/_core/instruments/keysight/sweep.py
@@ -80,7 +80,7 @@ def process_sweepers(
             elif sweeper.parameter in SUPPORTED_PULSE_SWEEPERS:
                 # Duration can only be swept in hardware for delays
                 if sweeper.parameter is Parameter.duration and any(
-                    [pulse.kind != "delay" for pulse in sweeper.pulses]
+                    pulse.kind != "delay" for pulse in sweeper.pulses
                 ):
                     hardware_sweeping = False
 

--- a/src/qibolab/_core/instruments/qblox/cluster.py
+++ b/src/qibolab/_core/instruments/qblox/cluster.py
@@ -46,6 +46,9 @@ from .validate import (
     validate_sequence,
 )
 
+logger = logging.getLogger(__name__)
+
+
 __all__ = ["Cluster"]
 
 SAMPLING_RATE = 1
@@ -293,7 +296,7 @@ class Cluster(Controller):
 
                 # finally execute the experiment, and fetch results
                 duration = _compute_duration(ps, sweepers_, options_, configs)
-                logging.info(f"Qblox expected execution time: {duration:.3f} s")
+                logger.info(f"Qblox expected execution time: {duration:.3f} s")
                 data = self._execute(
                     sequencers, sequences_, duration, options_.acquisition_type
                 )

--- a/src/qibolab/_core/instruments/qblox/mock/cluster.py
+++ b/src/qibolab/_core/instruments/qblox/mock/cluster.py
@@ -20,7 +20,7 @@ class MockSequencer:
         if name in ["idx", "register", "ancestors", "seq_idx"]:
             return super().__getattribute__(name)
 
-        log: dict["str", Any] = {"name": name}
+        log: dict[str, Any] = {"name": name}
         self.register["calls"].append(log)
 
         def wrapped(*args, **kwargs):
@@ -63,7 +63,7 @@ class MockModule:
         ]:
             return super().__getattribute__(name)
 
-        log: dict["str", Any] = {"name": name}
+        log: dict[str, Any] = {"name": name}
         self.register["calls"].append(log)
 
         def wrapped(*args, **kwargs):

--- a/src/qibolab/_core/instruments/qblox/q1asm/ast_.py
+++ b/src/qibolab/_core/instruments/qblox/q1asm/ast_.py
@@ -3,7 +3,7 @@ import re
 import shutil
 import textwrap
 from collections.abc import Iterable, Sequence
-from typing import Annotated, Any, Union
+from typing import Annotated, Any
 
 from pydantic import (
     AfterValidator,
@@ -37,7 +37,7 @@ class Register(Model):
         elif isinstance(data, dict):
             num = data["number"]
         else:
-            raise ValueError(f"Register not recognized '{data}'")
+            raise ValueError(f"Register not recognized '{data}'")  # noqa: TRY004
 
         assert 0 <= num < 64
         return {"number": num}
@@ -76,8 +76,8 @@ MultiBaseInt = Annotated[
     BeforeValidator(lambda n: int(n, 0) if isinstance(n, str) else n),
     BeforeValidator(lambda n: _value_bounds(n) if isinstance(n, int) else n),
 ]
-Immediate = Union[MultiBaseInt, Reference]
-Value = Union[Register, Immediate]
+Immediate = MultiBaseInt | Reference
+Value = Register | Immediate
 
 CAMEL_TO_SNAKE = re.compile("(?<=[a-z0-9])(?=[A-Z])(?!^)(?=[A-Z][a-z])")
 
@@ -157,7 +157,7 @@ class Nop(Instr):
     """
 
 
-Control = Union[Illegal, Stop, Nop]
+Control = Illegal | Stop | Nop
 """Control instructions."""
 
 
@@ -205,7 +205,7 @@ class Loop(Instr):
     address: Value
 
 
-Jump = Union[Jmp, Jge, Jlt, Loop]
+Jump = Jmp | Jge | Jlt | Loop
 """Jump instructions."""
 
 
@@ -344,7 +344,7 @@ class Asr(Instr):
     destination: Register
 
 
-Arithmetic = Union[Move, Not, Add, Sub, And, Or, Xor, Asl, Asr]
+Arithmetic = Move | Not | Add | Sub | And | Or | Xor | Asl | Asr
 """Arithmetic instructions."""
 
 
@@ -458,14 +458,14 @@ class SetAwgOffs(Instr):
         return v
 
 
-ParamOps = Union[SetMrk, SetFreq, ResetPh, SetPh, SetPhDelta, SetAwgGain, SetAwgOffs]
+ParamOps = SetMrk | SetFreq | ResetPh | SetPh | SetPhDelta | SetAwgGain | SetAwgOffs
 """Parameter operations.
 
 The parameters are latched and only updated when the ``upd_param``, ``play``, ``acquire``,
 ``acquire_weighed`` or ``acquire_ttl`` instructions are executed.
 """
 
-Q1Instr = Union[Control, Jump, Arithmetic, ParamOps]
+Q1Instr = Control | Jump | Arithmetic | ParamOps
 """Q1 Instructions.
 
 These instructions are used to compose and manipulate the arguments of
@@ -602,7 +602,7 @@ class AcquireTtl(Instr):
     duration: Immediate
 
 
-Io = Union[UpdParam, Play, Acquire, AcquireWeighed, AcquireTtl]
+Io = UpdParam | Play | Acquire | AcquireWeighed | AcquireTtl
 """Real-time IO operation instructions.
 
 The execution of any of these instructions will cause the latched
@@ -631,7 +631,7 @@ class LatchRst(Instr):
     duration: Value
 
 
-Trigger = Union[SetLatchEn, LatchRst]
+Trigger = SetLatchEn | LatchRst
 """Real-time trigger count control instructions."""
 
 
@@ -669,10 +669,10 @@ class WaitSync(Instr):
     duration: Value
 
 
-WaitOps = Union[Wait, WaitTrigger, WaitSync]
+WaitOps = Wait | WaitTrigger | WaitSync
 """Real-time wait operation instructions."""
 
-RealTimeInstr = Union[Conditional, Io, Trigger, WaitOps]
+RealTimeInstr = Conditional | Io | Trigger | WaitOps
 """Real-time instructions.
 
 These instructions have a duration argument, which corresponds to the
@@ -689,7 +689,7 @@ Therefore, the real-time pipeline will never wait for the Q1 processor.
 In case of a conflict, the sequencer will halt and raise an error flag.
 """
 
-Instruction = Union[Q1Instr, RealTimeInstr]
+Instruction = Q1Instr | RealTimeInstr
 
 
 INSTRUCTIONS = {
@@ -770,8 +770,8 @@ class Line(Model):
         )
 
 
-Element = Union[Line, Comment]
-Lineable = Union[Line, Instruction]
+Element = Line | Comment
+Lineable = Line | Instruction
 Block = Sequence[Lineable]
 BlockList = list[Lineable]
 BlockIter = Iterable[Lineable]

--- a/src/qibolab/_core/instruments/qibosoq/board.py
+++ b/src/qibolab/_core/instruments/qibosoq/board.py
@@ -219,7 +219,7 @@ class RFSoC(Controller):
             buffer_overflow = r"buffer length must be \d+ samples or less"
             if re.search(buffer_overflow, str(e)) is not None:
                 log.warning("Buffer full! Use shorter pulses.")
-            raise e
+            raise
 
 
 def _validate_input_command(
@@ -313,9 +313,11 @@ def _firmware_loops(
                 pulses_in_path = []
                 for p_ch, pulse in sequence:
                     # Type check so that ADC and DACs are not compared
-                    if type(channels[p_ch]) is type(channels[ch]):
-                        if channels[p_ch].path == path:
-                            pulses_in_path.append(pulse)
+                    if (
+                        type(channels[p_ch]) is type(channels[ch])
+                        and channels[p_ch].path == path
+                    ):
+                        pulses_in_path.append(pulse)
 
                 if len(pulses_in_path) > 1:
                     return n

--- a/src/qibolab/_core/instruments/qibosoq/convert.py
+++ b/src/qibolab/_core/instruments/qibosoq/convert.py
@@ -68,11 +68,10 @@ def replace_pulse_shape(
 
 def get_lo_frequency(ch: Channel, configs: dict[str, Config]) -> float:
     """Return LO frequency from channel, if applicable."""
-    if isinstance(ch, IqChannel):
-        if ch.lo is not None:
-            conf = configs[ch.lo]
-            if isinstance(conf, OscillatorConfig):
-                return conf.frequency
+    if isinstance(ch, IqChannel) and ch.lo is not None:
+        conf = configs[ch.lo]
+        if isinstance(conf, OscillatorConfig):
+            return conf.frequency
     return 0
 
 
@@ -265,7 +264,7 @@ def _(
 
     adc = 0  # Assign adc 0 to ensure frequency matching
     if isinstance(pulse, Acquisition):
-        freq = (getattr(configs[ch_id], "frequency") - lo_frequency) / mega
+        freq = (configs[ch_id].frequency - lo_frequency) / mega
         return rfsoc_pulses.Measurement(
             type="readout",
             frequency=freq,
@@ -280,7 +279,7 @@ def _(
         assert probe_id is not None
         adc = int(ch.path)
         ptype = "readout"
-        freq = (getattr(configs[probe_id], "frequency") - lo_frequency) / mega
+        freq = (configs[probe_id].frequency - lo_frequency) / mega
         amp = pulse.probe.amplitude
         rel_ph = pulse.probe.relative_phase + ch_vz_phase
         envelope = pulse.probe.envelope
@@ -353,9 +352,9 @@ def _(
             for ch_id in sweeper.channels:
                 parameters.append(rfsoc.Parameter.BIAS)
                 qubit_idx = 0
-                for ch in channels:
-                    if isinstance(channels[ch], DcChannel):
-                        if channels[ch] == channels[ch_id]:
+                for channel in channels.values():
+                    if isinstance(channel, DcChannel):
+                        if channel == channels[ch_id]:
                             indexes.append(qubit_idx)
                         else:
                             qubit_idx += 1
@@ -371,7 +370,7 @@ def _(
             assert sweeper.channels is not None
             for ch_id in sweeper.channels:
                 parameters.append(rfsoc.Parameter.FREQUENCY)
-                pulse = [p for ch, p, _ in ordered_sequence if ch == ch_id][0]
+                pulse = next(p for ch, p, _ in ordered_sequence if ch == ch_id)
                 # TODO what happens if more than one pulse are on the same channel?
                 indexes.append(get_index(pulse_sequence, pulse))
                 starts.append(start)
@@ -407,9 +406,11 @@ def _(
                 parameters.append(rfsoc.Parameter.DELAY)
                 # counting the index of the pulse (without delay pulses)
                 for idx, p in enumerate(pulse_sequence):
-                    if p.id in delay_equivalence:
-                        if pulse.id in delay_equivalence[p.id]:
-                            indexes.append(idx)
+                    if (
+                        p.id in delay_equivalence
+                        and pulse.id in delay_equivalence[p.id]
+                    ):
+                        indexes.append(idx)
 
                 starts.append(start)
                 stops.append(stop)

--- a/src/qibolab/_core/instruments/qm/components/configs.py
+++ b/src/qibolab/_core/instruments/qm/components/configs.py
@@ -1,4 +1,4 @@
-from typing import Any, Literal, Union
+from typing import Any, Literal
 
 import numpy as np
 from pydantic import Field
@@ -11,11 +11,11 @@ from qibolab._core.components import (
 from qibolab._core.components.filters import ExponentialFilter
 
 __all__ = [
+    "MwFemOscillatorConfig",
+    "OctaveOscillatorConfig",
     "OpxOutputConfig",
     "QmAcquisitionConfig",
     "QmConfigs",
-    "OctaveOscillatorConfig",
-    "MwFemOscillatorConfig",
 ]
 
 OctaveOutputModes = Literal[
@@ -131,9 +131,9 @@ class MwFemOscillatorConfig(OscillatorConfig):
     sampling_rate: float = DEFAULT_SAMPLING_RATE
 
 
-QmConfigs = Union[
-    OpxOutputConfig,
-    OctaveOscillatorConfig,
-    QmAcquisitionConfig,
-    MwFemOscillatorConfig,
-]
+QmConfigs = (
+    OpxOutputConfig
+    | OctaveOscillatorConfig
+    | QmAcquisitionConfig
+    | MwFemOscillatorConfig
+)

--- a/src/qibolab/_core/instruments/qm/config/config.py
+++ b/src/qibolab/_core/instruments/qm/config/config.py
@@ -240,9 +240,9 @@ class Configuration:
         acquisition = f"{op}_{element}"
         if acquisition not in self.pulses:
             new_probe = readout.probe.model_copy(
-                update=dict(
-                    duration=readout.acquisition.duration,
-                    envelope=Custom(
+                update={
+                    "duration": readout.acquisition.duration,
+                    "envelope": Custom(
                         i_=np.pad(
                             readout.probe.envelope.i(int(readout.probe.duration)),
                             (
@@ -268,7 +268,7 @@ class Configuration:
                             constant_values=0,
                         ),
                     ),
-                )
+                }
             )
             self.pulses[acquisition] = self.register_waveforms(
                 new_probe,

--- a/src/qibolab/_core/instruments/qm/config/devices.py
+++ b/src/qibolab/_core/instruments/qm/config/devices.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Literal, Union
+from typing import Literal
 
 from qibolab._core.components import OscillatorConfig
 
@@ -11,15 +11,15 @@ from ..components import (
 from ..components.configs import OctaveOutputModes
 
 __all__ = [
-    "ModuleTypes",
-    "MwFemOutput",
-    "MwFemInput",
-    "OctaveOutput",
-    "OctaveInput",
     "Controller",
-    "Octave",
     "ControllerId",
     "Controllers",
+    "ModuleTypes",
+    "MwFemInput",
+    "MwFemOutput",
+    "Octave",
+    "OctaveInput",
+    "OctaveOutput",
 ]
 
 
@@ -86,7 +86,7 @@ class OctaveOutput:
 
     @classmethod
     def from_config(cls, config: OscillatorConfig | OctaveOscillatorConfig):
-        kwargs = dict(LO_frequency=config.frequency, gain=config.power)
+        kwargs = {"LO_frequency": config.frequency, "gain": config.power}
         if isinstance(config, OctaveOscillatorConfig):
             kwargs["output_mode"] = config.output_mode
         return cls(**kwargs)
@@ -154,7 +154,7 @@ class Octave:
             self.connectivity = (con, int(fem))
 
 
-ControllerId = Union[str, tuple[str, int]]
+ControllerId = str | tuple[str, int]
 
 
 def process_controller_id(id: ControllerId):
@@ -175,7 +175,7 @@ def process_controller_id(id: ControllerId):
     return id, None
 
 
-class Controllers(dict[str, Union[Controller, Opx1000]]):
+class Controllers(dict[str, Controller | Opx1000]):
     """Dictionary of controllers compatible with OPX+ and OPX1000."""
 
     def __contains__(self, key: ControllerId) -> bool:

--- a/src/qibolab/_core/instruments/qm/config/elements.py
+++ b/src/qibolab/_core/instruments/qm/config/elements.py
@@ -1,21 +1,20 @@
 from dataclasses import dataclass, field
-from typing import Union
 
 from typing_extensions import TypedDict
 
 from qibolab._core.components import Channel
 
 __all__ = [
-    "DcElement",
-    "RfOctaveElement",
-    "AcquireOctaveElement",
-    "MwFemElement",
     "AcquireMwFemElement",
+    "AcquireOctaveElement",
+    "DcElement",
     "Element",
+    "MwFemElement",
+    "RfOctaveElement",
 ]
 
 
-InOutType = Union[tuple[str, int], tuple[str, int, int]]
+InOutType = tuple[str, int] | tuple[str, int, int]
 OctavePort = TypedDict("OpxPlusPort", {"port": tuple[str, int]})
 
 
@@ -23,7 +22,7 @@ class Port(TypedDict):
     port: InOutType
 
 
-ConnectivityType = Union[str, tuple[str, int]]
+ConnectivityType = str | tuple[str, int]
 
 
 @dataclass(frozen=True)
@@ -187,10 +186,10 @@ class AcquireMwFemElement:
         )
 
 
-Element = Union[
-    DcElement,
-    RfOctaveElement,
-    AcquireOctaveElement,
-    MwFemElement,
-    AcquireMwFemElement,
-]
+Element = (
+    DcElement
+    | RfOctaveElement
+    | AcquireOctaveElement
+    | MwFemElement
+    | AcquireMwFemElement
+)

--- a/src/qibolab/_core/instruments/qm/config/elements.py
+++ b/src/qibolab/_core/instruments/qm/config/elements.py
@@ -15,7 +15,10 @@ __all__ = [
 
 
 InOutType = tuple[str, int] | tuple[str, int, int]
-OctavePort = TypedDict("OpxPlusPort", {"port": tuple[str, int]})
+
+
+class OctavePort(TypedDict):
+    port: tuple[str, int]
 
 
 class Port(TypedDict):
@@ -73,7 +76,8 @@ class DcElement:
         return cls(_to_port(channel))
 
 
-DigitalInputs = TypedDict("digitalInputs", {"output_switch": OutputSwitch})
+class DigitalInputs(TypedDict):
+    output_switch: OutputSwitch
 
 
 @dataclass

--- a/src/qibolab/_core/instruments/qm/config/pulses.py
+++ b/src/qibolab/_core/instruments/qm/config/pulses.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass, field
-from typing import Union
 
 import numpy as np
 
@@ -7,12 +6,12 @@ from qibolab._core.pulses import Pulse, Rectangular
 from qibolab._core.pulses.modulation import rotate, wrap_phase
 
 __all__ = [
-    "operation",
-    "Waveform",
-    "waveforms_from_pulse",
-    "integration_weights",
-    "QmPulse",
     "QmAcquisition",
+    "QmPulse",
+    "Waveform",
+    "integration_weights",
+    "operation",
+    "waveforms_from_pulse",
 ]
 
 BATCH = 4
@@ -78,7 +77,7 @@ class ArbitraryWaveform:
         }
 
 
-Waveform = Union[ConstantWaveform, ArbitraryWaveform]
+Waveform = ConstantWaveform | ArbitraryWaveform
 
 
 def waveforms_from_pulse(
@@ -96,7 +95,7 @@ def waveforms_from_pulse(
 
 @dataclass(frozen=True)
 class Waveforms:
-    I: str  # noqa: E741
+    I: str
     Q: str
 
     @classmethod

--- a/src/qibolab/_core/instruments/qm/controller.py
+++ b/src/qibolab/_core/instruments/qm/controller.py
@@ -36,7 +36,7 @@ from .program.sweepers import find_lo_frequencies, sweeper_amplitude
 CALIBRATION_DB = "calibration_db.json"
 """Name of the file where the mixer calibration is stored."""
 
-__all__ = ["QmController", "Octave"]
+__all__ = ["Octave", "QmController"]
 
 MAX_VOLTAGE = 0.5
 """Maximum output of Quantum Machines OPX+ in Volts."""
@@ -304,7 +304,7 @@ class QmController(Controller):
     Default is ``False``.
     """
 
-    def model_post_init(self, __context):
+    def model_post_init(self, __context, /):
         if self.simulation_duration is not None:
             raise NotImplementedError(
                 "Simulation is no longer supported by the QM driver."
@@ -472,9 +472,7 @@ class QmController(Controller):
             acquisitions (dict): Map from measurement instructions to acquisition objects.
         """
         for id, pulse in sequence:
-            if isinstance(pulse, Pulse):
-                self.register_pulse(id, configs[id], pulse)
-            elif isinstance(pulse, Readout):
+            if isinstance(pulse, (Pulse, Readout)):
                 self.register_pulse(id, configs[id], pulse)
 
     def register_duration_sweeper_pulses(

--- a/src/qibolab/_core/instruments/qm/program/loops.py
+++ b/src/qibolab/_core/instruments/qm/program/loops.py
@@ -26,11 +26,11 @@ def from_array(var: Variable, array: npt.NDArray | list):
         return var, array[0], var <= array[0], var + 1
     # Check QUA vs python variables
     if not isinstance(var, Variable):
-        raise Exception("The first argument must be a QUA variable.")
+        raise TypeError("The first argument must be a QUA variable.")
     if (not isinstance(array[0], (np.generic, int, float))) or (
         isinstance(array[0], bool)
     ):
-        raise Exception("The array must be an array of python variables.")
+        raise TypeError("The array must be an array of python variables.")
     # Check array increment
     if np.isclose(np.diff(array).std() / np.abs(array).mean(), 0):
         increment = "lin"
@@ -97,7 +97,7 @@ def from_array(var: Variable, array: npt.NDArray | list):
                 "When using logarithmic increments with QUA integers, the resulting values will slightly differ from the ones in numpy.logspace() because of rounding errors. \n Please use the get_equivalent_log_array() function to get the exact values taken by the QUA variable and note that the number of points may also change."
             )
             if step > 1:
-                if int(round(start) * float(step)) == int(round(start)):
+                if int(round(start) * float(step)) == round(start):
                     raise ValueError(
                         "Two successive values in the scan are equal after being cast to integers which will make the QUA for_ loop fail. \nEither increase the logarithmic step or use for_each_(): https://docs.quantum-machines.co/1.1.6/qm-qua-sdk/docs/Guides/features/?h=for_ea#for_each."
                     )

--- a/src/qibolab/_core/parameters.py
+++ b/src/qibolab/_core/parameters.py
@@ -5,7 +5,8 @@ JSON <parameters_json>` example.
 """
 
 from collections.abc import Callable, Iterable
-from typing import Annotated, Any, Union
+from types import UnionType
+from typing import Annotated, Any, ClassVar, Union
 
 from pydantic import (
     BeforeValidator,
@@ -126,9 +127,7 @@ ComponentId = str
 This is assumed to always be in its serialized form.
 """
 
-# TODO: replace _UnionType with UnionType, once py3.9 will be abandoned
-_UnionType = Any
-_ChannelConfigT = Union[_UnionType, type[Config]]
+_ChannelConfigT = UnionType | type[Config]
 _BUILTIN_CONFIGS: tuple[_ChannelConfigT, ...] = (ChannelConfig,)
 
 
@@ -145,7 +144,7 @@ class ConfigKinds:
         loading operations.
     """
 
-    _registered: list[_ChannelConfigT] = list(_BUILTIN_CONFIGS)
+    _registered: ClassVar[list[_ChannelConfigT]] = list(_BUILTIN_CONFIGS)
 
     @classmethod
     def extend(cls, kinds: Iterable[_ChannelConfigT]):
@@ -174,7 +173,7 @@ class ConfigKinds:
         """
         return TypeAdapter(
             Annotated[
-                Union[tuple(ConfigKinds._registered)], Field(discriminator="kind")
+                Union[tuple(ConfigKinds._registered)], Field(discriminator="kind")  # noqa: UP007
             ]
         )
 

--- a/src/qibolab/_core/platform/parameters.py
+++ b/src/qibolab/_core/platform/parameters.py
@@ -51,7 +51,7 @@ def _gate_sequence(qubit: Qubit, gate: str) -> Native:
 
 def _pair_to_qubit(pair: str, qubits: QubitMap) -> Qubit:
     """Get first qubit of a pair given in ``{q0}-{q1}`` format."""
-    q = tuple(pair.split("-"))[0]
+    q = next(iter(pair.split("-")))
     try:
         return qubits[q]
     except KeyError:

--- a/src/qibolab/_core/platform/platform.py
+++ b/src/qibolab/_core/platform/platform.py
@@ -155,7 +155,7 @@ class Platform:
             for name, instrument in self.instruments.items():
                 try:
                     instrument.connect()
-                except Exception as exception:
+                except Exception as exception:  # noqa: BLE001
                     raise RuntimeError(
                         f"Cannot establish connection to instrument {name}. Error captured: '{exception}'",
                     )

--- a/src/qibolab/_core/pulses/envelope.py
+++ b/src/qibolab/_core/pulses/envelope.py
@@ -1,7 +1,7 @@
 """Library of pulse envelopes."""
 
 from abc import ABC
-from typing import Annotated, Literal, Union
+from typing import Annotated, Literal
 
 import numpy as np
 import numpy.typing as npt
@@ -11,17 +11,17 @@ from scipy.signal.windows import gaussian
 from ..serialize import Model, NdArray, eq
 
 __all__ = [
-    "Waveform",
-    "IqWaveform",
     "BaseEnvelope",
+    "Custom",
+    "Drag",
     "Envelope",
-    "Rectangular",
     "Exponential",
     "Gaussian",
     "GaussianSquare",
-    "Drag",
+    "IqWaveform",
+    "Rectangular",
     "Snz",
-    "Custom",
+    "Waveform",
 ]
 
 
@@ -316,15 +316,7 @@ class Custom(BaseEnvelope):
 
 
 Envelope = Annotated[
-    Union[
-        Rectangular,
-        Exponential,
-        Gaussian,
-        GaussianSquare,
-        Drag,
-        Snz,
-        Custom,
-    ],
+    Rectangular | Exponential | Gaussian | GaussianSquare | Drag | Snz | Custom,
     Field(discriminator="kind"),
 ]
 """Available pulse shapes."""

--- a/src/qibolab/_core/pulses/modulation.py
+++ b/src/qibolab/_core/pulses/modulation.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from .envelope import IqWaveform
 
-__all__ = ["wrap_phase", "rotate", "modulate", "demodulate"]
+__all__ = ["demodulate", "modulate", "rotate", "wrap_phase"]
 
 
 def wrap_phase(phase: float):

--- a/src/qibolab/_core/pulses/plot.py
+++ b/src/qibolab/_core/pulses/plot.py
@@ -175,9 +175,9 @@ def sequence(ps: PulseSequence, freq: dict[str, float], filename=None):
                         np.array(envelope), freq[ch], rate=SAMPLING_RATE
                     )
                     ax.plot(time, modulated[1], c="lightgrey")
-                    ax.plot(time, modulated[0], c=f"C{str(n)}")
-                ax.plot(time, pulse.i(SAMPLING_RATE), c=f"C{str(n)}")
-                ax.plot(time, -pulse.i(SAMPLING_RATE), c=f"C{str(n)}")
+                    ax.plot(time, modulated[0], c=f"C{n!s}")
+                ax.plot(time, pulse.i(SAMPLING_RATE), c=f"C{n!s}")
+                ax.plot(time, -pulse.i(SAMPLING_RATE), c=f"C{n!s}")
                 # TODO: if they overlap use different shades
                 ax.axhline(0, c="dimgrey")
                 ax.set_ylabel(f"channel {ch}")

--- a/src/qibolab/_core/pulses/pulse.py
+++ b/src/qibolab/_core/pulses/pulse.py
@@ -1,6 +1,6 @@
 """Pulse class."""
 
-from typing import Annotated, Literal, Union, cast
+from typing import Annotated, Literal, cast
 from uuid import uuid4
 
 import numpy as np
@@ -198,6 +198,6 @@ class Align(_PulseLike):
 
 
 PulseLike = Annotated[
-    Union[Align, Pulse, Delay, VirtualZ, Acquisition, Readout],
+    Align | Pulse | Delay | VirtualZ | Acquisition | Readout,
     Field(discriminator="kind"),
 ]

--- a/src/qibolab/_core/sequence.py
+++ b/src/qibolab/_core/sequence.py
@@ -3,11 +3,12 @@
 from collections import UserList, defaultdict
 from collections.abc import Callable, Iterable
 from functools import cache
-from typing import Any, Union
+from typing import Any
 
 import numpy as np
 from pydantic import TypeAdapter
 from pydantic_core import core_schema
+from typing_extensions import Self
 
 from qibolab._core.pulses.pulse import PulseId, VirtualZ
 
@@ -17,7 +18,7 @@ from .pulses import Acquisition, Align, Delay, Pulse, PulseLike, Readout
 __all__ = ["PulseSequence"]
 
 _Element = tuple[ChannelId, PulseLike]
-InputOps = Union[Readout, Acquisition]
+InputOps = Readout | Acquisition
 
 _adapted_sequence = TypeAdapter(list[_Element])
 
@@ -108,7 +109,7 @@ class PulseSequence(UserList[_Element]):
         _synchronize(self, PulseSequence(other).channels)
         self.extend(other)
 
-    def __ilshift__(self, other: Iterable[_Element]) -> "PulseSequence":
+    def __ilshift__(self, other: Iterable[_Element]) -> Self:
         """Juxtapose two sequences.
 
         Alias to :meth:`concatenate`.
@@ -146,7 +147,7 @@ class PulseSequence(UserList[_Element]):
         _synchronize(self, PulseSequence(other).channels | self.channels)
         self.extend(other)
 
-    def __ior__(self, other: Iterable[_Element]) -> "PulseSequence":
+    def __ior__(self, other: Iterable[_Element]) -> Self:
         """Pipe two sequences. ``other'' starts after ``self`` ends."""
         other_channels = PulseSequence(other).channels
         self.align(self.channels | other_channels)

--- a/src/qibolab/_core/sweeper.py
+++ b/src/qibolab/_core/sweeper.py
@@ -12,7 +12,7 @@ from .identifier import ChannelId
 from .pulses import PulseId, PulseLike, VirtualZ
 from .serialize import Model, eq
 
-__all__ = ["Parameter", "ParallelSweepers", "Sweeper"]
+__all__ = ["ParallelSweepers", "Parameter", "Sweeper"]
 
 _PULSE = "pulse"
 _CHANNEL = "channel"

--- a/src/qibolab/backend.py
+++ b/src/qibolab/backend.py
@@ -1,5 +1,5 @@
 from ._core import backends
-from ._core.backends import *  # noqa: F403
+from ._core.backends import *
 
 __all__ = []
 __all__ += backends.__all__

--- a/src/qibolab/instruments/bluefors.py
+++ b/src/qibolab/instruments/bluefors.py
@@ -4,7 +4,7 @@ https://bluefors.com/
 """
 
 from qibolab._core.instruments import bluefors
-from qibolab._core.instruments.bluefors import *  # noqa: F403
+from qibolab._core.instruments.bluefors import *
 
 __all__ = []
 __all__ += bluefors.__all__

--- a/src/qibolab/instruments/dummy.py
+++ b/src/qibolab/instruments/dummy.py
@@ -4,9 +4,9 @@ Define instruments mainly used for testing purposes.
 """
 
 from qibolab._core import dummy as dummy_plat
-from qibolab._core.dummy import *  # noqa: F403
+from qibolab._core.dummy import *
 from qibolab._core.instruments import dummy
-from qibolab._core.instruments.dummy import *  # noqa: F403
+from qibolab._core.instruments.dummy import *
 
 __all__ = []
 __all__ += dummy.__all__

--- a/src/qibolab/instruments/emulator.py
+++ b/src/qibolab/instruments/emulator.py
@@ -1,7 +1,7 @@
 """Emulator engine."""
 
 from qibolab._core.instruments import emulator
-from qibolab._core.instruments.emulator import *  # noqa: F403
+from qibolab._core.instruments.emulator import *
 
 __all__ = []
 __all__ += emulator.__all__

--- a/src/qibolab/instruments/era.py
+++ b/src/qibolab/instruments/era.py
@@ -4,7 +4,7 @@ http://erainstruments.com/
 """
 
 from qibolab._core.instruments import erasynth
-from qibolab._core.instruments.erasynth import *  # noqa: F403
+from qibolab._core.instruments.erasynth import *
 
 __all__ = []
 __all__ += erasynth.__all__

--- a/src/qibolab/instruments/keysight_qcs.py
+++ b/src/qibolab/instruments/keysight_qcs.py
@@ -1,7 +1,7 @@
 """Driver for Keysight Quantum Control System (QCS)."""
 
 from qibolab._core.instruments import keysight
-from qibolab._core.instruments.keysight import *  # noqa: F403
+from qibolab._core.instruments.keysight import *
 
 __all__ = []
 __all__ += keysight.__all__

--- a/src/qibolab/instruments/qblox.py
+++ b/src/qibolab/instruments/qblox.py
@@ -5,7 +5,7 @@ https://docs.qblox.com/
 """
 
 from qibolab._core.instruments import qblox
-from qibolab._core.instruments.qblox import *  # noqa: F403
+from qibolab._core.instruments.qblox import *
 
 __all__ = []
 __all__ += qblox.__all__

--- a/src/qibolab/instruments/qibosoq.py
+++ b/src/qibolab/instruments/qibosoq.py
@@ -1,7 +1,7 @@
 """Qibosoq driver."""
 
 from qibolab._core.instruments import qibosoq
-from qibolab._core.instruments.qibosoq import *  # noqa: F403
+from qibolab._core.instruments.qibosoq import *
 
 __all__ = []
 __all__ += qibosoq.__all__

--- a/src/qibolab/instruments/qm.py
+++ b/src/qibolab/instruments/qm.py
@@ -4,7 +4,7 @@ https://quantum-machines.co/
 """
 
 from qibolab._core.instruments import qm
-from qibolab._core.instruments.qm import *  # noqa: F403
+from qibolab._core.instruments.qm import *
 
 __all__ = []
 __all__ += qm.__all__

--- a/src/qibolab/instruments/qrng.py
+++ b/src/qibolab/instruments/qrng.py
@@ -1,6 +1,6 @@
 """Quantum random number generator drivers."""
 
-from qibolab._core.instruments.qrng import *  # noqa: F403
+from qibolab._core.instruments.qrng import *
 from qibolab._core.instruments.qrng import qrng
 
 __all__ = []

--- a/src/qibolab/instruments/rohde_schwarz.py
+++ b/src/qibolab/instruments/rohde_schwarz.py
@@ -4,7 +4,7 @@ https://www.rohde-schwarz.com/
 """
 
 from qibolab._core.instruments import rohde_schwarz
-from qibolab._core.instruments.rohde_schwarz import *  # noqa: F403
+from qibolab._core.instruments.rohde_schwarz import *
 
 __all__ = []
 __all__ += rohde_schwarz.__all__

--- a/src/qibolab/platform.py
+++ b/src/qibolab/platform.py
@@ -12,8 +12,8 @@ from qibolab._core.platform.platform import Platform
 __all__ = [
     "PLATFORM",
     "PLATFORMS_PATH",
-    "Platform",
     "Hardware",
+    "Platform",
     "create_platform",
     "initialize_parameters",
     "load_hardware",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 import os
 import pathlib
 from collections.abc import Callable, Iterator
-from typing import Optional
 
 import numpy as np
 import numpy.typing as npt
@@ -54,7 +53,7 @@ def platform(request):
 
 
 Execution = Callable[
-    [AcquisitionType, AveragingMode, int, Optional[list[ParallelSweepers]]], npt.NDArray
+    [AcquisitionType, AveragingMode, int, list[ParallelSweepers] | None], npt.NDArray
 ]
 
 
@@ -71,11 +70,11 @@ def execute() -> Iterator[Execution]:
         sequence: PulseSequence | None = None,
         target: int | None = None,
     ) -> npt.NDArray:
-        options = dict(
-            nshots=nshots,
-            acquisition_type=acquisition_type,
-            averaging_mode=averaging_mode,
-        )
+        options = {
+            "nshots": nshots,
+            "acquisition_type": acquisition_type,
+            "averaging_mode": averaging_mode,
+        }
 
         qubit = next(iter(platform.qubits.values()))
         natives = platform.natives.single_qubit[0]

--- a/tests/pulses/test_envelope.py
+++ b/tests/pulses/test_envelope.py
@@ -160,13 +160,13 @@ def test_eq():
     shape2 = Rectangular()
     shape3 = Gaussian(rel_sigma=5)
     assert shape1 == shape2
-    assert not shape1 == shape3
+    assert shape1 != shape3
 
     shape1 = Gaussian(rel_sigma=4)
     shape2 = Gaussian(rel_sigma=4)
     shape3 = Gaussian(rel_sigma=5)
     assert shape1 == shape2
-    assert not shape1 == shape3
+    assert shape1 != shape3
 
     shape1 = GaussianSquare(risefall=4, sigma=0.01)
     shape2 = GaussianSquare(risefall=4, sigma=0.01)
@@ -174,9 +174,9 @@ def test_eq():
     shape4 = GaussianSquare(risefall=4, sigma=0.05)
     shape5 = GaussianSquare(risefall=5, sigma=0.05)
     assert shape1 == shape2
-    assert not shape1 == shape3
-    assert not shape1 == shape4
-    assert not shape1 == shape5
+    assert shape1 != shape3
+    assert shape1 != shape4
+    assert shape1 != shape5
 
     shape1 = Drag(rel_sigma=4, beta=0.01)
     shape2 = Drag(rel_sigma=4, beta=0.01)
@@ -184,9 +184,9 @@ def test_eq():
     shape4 = Drag(rel_sigma=4, beta=0.05)
     shape5 = Drag(rel_sigma=5, beta=0.05)
     assert shape1 == shape2
-    assert not shape1 == shape3
-    assert not shape1 == shape4
-    assert not shape1 == shape5
+    assert shape1 != shape3
+    assert shape1 != shape4
+    assert shape1 != shape5
 
     shape1 = Snz(t_idling=5)
     shape2 = Snz(t_idling=5)
@@ -194,9 +194,9 @@ def test_eq():
     shape4 = Snz(t_idling=2, b_amplitude=0.1)
     shape5 = Snz(t_idling=2, b_amplitude=0.1)
     assert shape1 == shape2
-    assert not shape1 == shape3
-    assert not shape1 == shape4
-    assert not shape1 == shape5
+    assert shape1 != shape3
+    assert shape1 != shape4
+    assert shape1 != shape5
 
 
 def test_hash_custom():

--- a/tests/test_result_shapes.py
+++ b/tests/test_result_shapes.py
@@ -24,7 +24,7 @@ def test_discrimination_singleshot(execute, sweep):
 def test_discrimination_cyclic(execute, sweep):
     result = execute(Acq.DISCRIMINATION, Av.CYCLIC, NSHOTS, sweep)
     if sweep == []:
-        assert result.shape == tuple()
+        assert result.shape == ()
     else:
         assert result.shape == (NSWEEP1, NSWEEP2)
 

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -199,7 +199,7 @@ def test_juxtapose():
     assert sequence1.channel_duration("ch1") == 40 + 60
     assert sequence1.channel_duration("ch2") == 40 + 60 + 80
     assert sequence1.channel_duration("ch3") == 40 + 60 + 100
-    delay = list(sequence1.channel("ch3"))[0]
+    delay = next(iter(sequence1.channel("ch3")))
     assert isinstance(delay, Delay)
     assert delay.duration == 100
 
@@ -225,7 +225,7 @@ def test_pipe():
     s1_ior = deepcopy(s1)
     s1_ior |= s2
     assert isinstance(list(s1_ior.channel("ch1"))[1], Align)
-    assert isinstance(list(s1_ior.channel("ch2"))[0], Align)
+    assert isinstance(next(iter(s1_ior.channel("ch2"))), Align)
     compiled = s1_ior.align_to_delays()
     assert not any(isinstance(p, Align) for _, p in compiled)
     assert compiled.channels == {"ch1", "ch2"}

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -79,7 +79,7 @@ def test_array_nested_comparison():
     )
 
     # if identical, just checking the id
-    assert n0 == n0
+    assert n0 == n0  # noqa: PLR0124
     # otherwise, it is going for the nested comparison, and failing
     with pytest.raises(ValueError):
         assert n0 != n1


### PR DESCRIPTION
See also https://github.com/qiboteam/qibocal/pull/1633

--- 

Ruff v0.16 was merged for pre-commit https://github.com/qiboteam/qibolab/pull/1531

However, it results in failed tests since it significantly extends the set of default rules: https://astral.sh/blog/ruff-v0.16.0

In this PR we fix these newly supported rules. 

--- 

This PR also consolidates the functionality of pyupgrade and pycln in ruff. 
- pycln removes unused imports, which is also done by ruff rule F401. It seems pycln is slightly more extensive in some casses https://github.com/astral-sh/ruff/issues/8149, but also much slower and the `__init__.py` files which do the import with `*` were skipped anyway and for `instruments/dummy` it was so slow that it exceeded the allotted time in the CI. This is the main motivation for consolidating the linting tools in the same PR as the v0.16 changes.
- pyupgrade is prominently mentioned to be replaceable by ruff in the ruff documention. Specifically the `UP` set of rules are those from pyupgrade. 