### PR TITLE
expose `create_dummy()` to public API.

### DIFF
--- a/src/qibolab/platform.py
+++ b/src/qibolab/platform.py
@@ -1,3 +1,4 @@
+from qibolab._core.dummy.platform import create_dummy
 from qibolab._core.platform.components import Hardware
 from qibolab._core.platform.load import (
     PLATFORM,
@@ -14,6 +15,7 @@ __all__ = [
     "PLATFORMS_PATH",
     "Hardware",
     "Platform",
+    "create_dummy",
     "create_platform",
     "initialize_parameters",
     "load_hardware",


### PR DESCRIPTION
In this PR we are exposing in the public API `create_dummy` function; 
this choice was made for [Qibocal #1624](https://github.com/qiboteam/qibocal/pull/1624).

Checklist:
- [x] Reviewers confirm new code works as expected.
- [x] Tests are passing.
- [x] Coverage does not decrease.
- [x] Documentation is updated.
