### PR TITLE
Remove qibo raise

### DIFF
--- a/src/qibolab/_core/backends.py
+++ b/src/qibolab/_core/backends.py
@@ -1,7 +1,6 @@
 import numpy as np
 from qibo import __version__ as qibo_version
 from qibo.backends import NumpyBackend
-from qibo.config import raise_error
 from qibo.models import Circuit
 from qibo.result import MeasurementOutcomes
 
@@ -84,10 +83,10 @@ class QibolabBackend(NumpyBackend):
         return natives
 
     def apply_gate(self, gate, state, nqubits):  # pragma: no cover
-        raise_error(NotImplementedError, "Qibolab cannot apply gates directly.")
+        raise NotImplementedError("Qibolab cannot apply gates directly.")
 
     def apply_gate_density_matrix(self, gate, state, nqubits):  # pragma: no cover
-        raise_error(NotImplementedError, "Qibolab cannot apply gates directly.")
+        raise NotImplementedError("Qibolab cannot apply gates directly.")
 
     def assign_measurements(self, measurement_map, readout):
         """Assigning measurement outcomes to
@@ -128,9 +127,8 @@ class QibolabBackend(NumpyBackend):
                 nshots=nshots,
             )
         if initial_state is not None:
-            raise_error(
-                ValueError,
-                "Hardware backend only supports circuits as initial states.",
+            raise ValueError(
+                "Hardware backend only supports circuits as initial states."
             )
 
         sequence, measurement_map = self.compiler.compile(circuit, self.platform)
@@ -167,9 +165,8 @@ class QibolabBackend(NumpyBackend):
                 nshots=nshots,
             )
         if initial_states is not None:
-            raise_error(
-                ValueError,
-                "Hardware backend only supports circuits as initial states.",
+            raise ValueError(
+                "Hardware backend only supports circuits as initial states."
             )
 
         # TODO: Maybe these loops can be parallelized

--- a/src/qibolab/_core/instruments/emulator/hamiltonians.py
+++ b/src/qibolab/_core/instruments/emulator/hamiltonians.py
@@ -4,7 +4,6 @@ from typing import Literal
 import numpy as np
 from numpy.typing import NDArray
 from pydantic import Field
-from qibo.config import raise_error
 from scipy.constants import giga
 
 from ...components import Config
@@ -255,7 +254,7 @@ class ModulatedVirtualZ(Model):
 
     def __call__(self, t: float, sample: int, phase: float) -> float:
         """Delay waveform."""
-        raise_error(ValueError, "VirtualZ doesn't have waveform.")
+        raise ValueError("VirtualZ doesn't have waveform.")
 
 
 Modulated = ModulatedDrive | ModulatedDelay | ModulatedVirtualZ


### PR DESCRIPTION
This is causing the emulator to still depend on `qibo`, despite the dependency has been made optional quite long ago.

While it is not well-documented (as everything in Qibolab...) the optional dependency on `qibo` is intended just to support the `QibolabBackend`, which necessarily depends on the `qibo` parent classes (though, to certain extent, inheritance could be replace by conventions - but it's a different discussion).

In any case, since this `raise_error()` is often introducing a dependency even when it can be avoided, I decided to remove its usage even from the `backends.py` module.