### PR TITLE
Exclude ExponentialFilter from OPX1000 feedforward convolution

### DIFF
--- a/src/qibolab/_core/instruments/qm/components/configs.py
+++ b/src/qibolab/_core/instruments/qm/components/configs.py
@@ -94,7 +94,7 @@ class OpxOutputConfig(DcConfig):
         ``feedforward`` convolution, to avoid double-applying the same
         correction through both stages.
         """
-        fir_filters = [f for f in self.filters if not isinstance(f, ExponentialFilter)]
+        fir_filters = [f for f in self.filters if isinstance(f, FiniteImpulseResponseFilter)]
         feedforward = (
             reduce(np.convolve, [f.feedforward for f in fir_filters])
             if len(fir_filters) > 0

--- a/src/qibolab/_core/instruments/qm/components/configs.py
+++ b/src/qibolab/_core/instruments/qm/components/configs.py
@@ -9,7 +9,10 @@ from qibolab._core.components import (
     DcConfig,
     OscillatorConfig,
 )
-from qibolab._core.components.filters import ExponentialFilter
+from qibolab._core.components.filters import (
+    ExponentialFilter, 
+    FiniteImpulseResponseFilter,
+)
 
 __all__ = [
     "MwFemOscillatorConfig",

--- a/src/qibolab/_core/instruments/qm/components/configs.py
+++ b/src/qibolab/_core/instruments/qm/components/configs.py
@@ -10,7 +10,7 @@ from qibolab._core.components import (
     OscillatorConfig,
 )
 from qibolab._core.components.filters import (
-    ExponentialFilter, 
+    ExponentialFilter,
     FiniteImpulseResponseFilter,
 )
 

--- a/src/qibolab/_core/instruments/qm/components/configs.py
+++ b/src/qibolab/_core/instruments/qm/components/configs.py
@@ -1,3 +1,4 @@
+from functools import reduce
 from typing import Any, Literal
 
 import numpy as np
@@ -60,30 +61,55 @@ class OpxOutputConfig(DcConfig):
 
     def filter(self, cluster: str) -> dict[str, list[float | tuple[float, float]]]:
         if cluster == "opx1":
-            feedback_filters = [
-                -i.feedback[1] for i in self.filters if isinstance(i, ExponentialFilter)
-            ]
-            iir = {
-                "feedback": normalize_feedback(feedback_filters, self.feedback_max)
-                if len(feedback_filters) > 0
-                else []
-            }
-        elif cluster in {"opx1000", "LF", "MW"}:
-            iir = {
-                "exponential": [
-                    (filt.amplitude, filt.tau)
-                    for filt in self.filters
-                    if isinstance(filt, ExponentialFilter)
-                ]
-            }
-        else:
-            raise NotImplementedError(f"Cluster type {cluster} not yet supported")
+            return self._opx1_filter()
+        if cluster in {"opx1000", "LF", "MW"}:
+            return self._opx1000_filter()
+        raise NotImplementedError(f"Cluster type {cluster} not yet supported")
 
+    def _opx1_filter(self) -> dict[str, list[float | tuple[float, float]]]:
+        """Digital filters for the (legacy) OPX+.
+
+        This generation has no dedicated hardware stage for the
+        exponential correction, so it is folded into the generic FIR
+        ``feedforward`` (and its pole into ``feedback``) together with
+        any other configured filter.
+        """
+        feedback_filters = [
+            -i.feedback[1] for i in self.filters if isinstance(i, ExponentialFilter)
+        ]
         return {
             "feedforward": normalize_feedforward(self.feedforward, self.feedforward_max)
             if len(self.feedforward) > 0
+            else [],
+            "feedback": normalize_feedback(feedback_filters, self.feedback_max)
+            if len(feedback_filters) > 0
+            else [],
+        }
+
+    def _opx1000_filter(self) -> dict[str, list[float | tuple[float, float]]]:
+        """Digital filters for OPX1000 (LF/MW FEM) clusters.
+
+        Unlike the OPX+, these expose a native ``exponential`` IIR
+        stage. ``ExponentialFilter``s are thus excluded from the FIR
+        ``feedforward`` convolution, to avoid double-applying the same
+        correction through both stages.
+        """
+        fir_filters = [f for f in self.filters if not isinstance(f, ExponentialFilter)]
+        feedforward = (
+            reduce(np.convolve, [f.feedforward for f in fir_filters])
+            if len(fir_filters) > 0
             else []
-        } | iir
+        )
+        return {
+            "feedforward": normalize_feedforward(feedforward, self.feedforward_max)
+            if len(feedforward) > 0
+            else [],
+            "exponential": [
+                (filt.amplitude, filt.tau)
+                for filt in self.filters
+                if isinstance(filt, ExponentialFilter)
+            ],
+        }
 
 
 class OctaveOscillatorConfig(OscillatorConfig):

--- a/src/qibolab/_core/instruments/qm/components/configs.py
+++ b/src/qibolab/_core/instruments/qm/components/configs.py
@@ -94,7 +94,9 @@ class OpxOutputConfig(DcConfig):
         ``feedforward`` convolution, to avoid double-applying the same
         correction through both stages.
         """
-        fir_filters = [f for f in self.filters if isinstance(f, FiniteImpulseResponseFilter)]
+        fir_filters = [
+            f for f in self.filters if isinstance(f, FiniteImpulseResponseFilter)
+        ]
         feedforward = (
             reduce(np.convolve, [f.feedforward for f in fir_filters])
             if len(fir_filters) > 0

--- a/tests/instruments/qm/test_configs.py
+++ b/tests/instruments/qm/test_configs.py
@@ -1,0 +1,84 @@
+"""Tests ``components/configs.py``."""
+
+import pytest
+
+pytest.importorskip("qm")
+
+from qibolab._core.components.filters import (
+    ExponentialFilter,
+    FiniteImpulseResponseFilter,
+)
+from qibolab._core.instruments.qm.components.configs import OpxOutputConfig
+
+FIR_COEFFICIENTS = [0.97, 0.36, -0.18, -0.10]
+EXPONENTIAL = ExponentialFilter(amplitude=-0.0089, tau=100.0)
+
+
+@pytest.mark.parametrize("cluster", ["opx1000", "LF", "MW"])
+def test_opx1000_feedforward_excludes_exponential(cluster):
+    """The FIR ``feedforward`` should only contain genuine FIR taps.
+
+    ``ExponentialFilter``s are applied through the dedicated
+    ``exponential`` IIR stage on these clusters, and must not also be
+    folded into ``feedforward`` (which would double-apply them).
+
+    Cf. https://github.com/qiboteam/qibolab/issues/1547
+    """
+    config = OpxOutputConfig(
+        offset=0.0,
+        filters=[
+            FiniteImpulseResponseFilter(coefficients=FIR_COEFFICIENTS),
+            EXPONENTIAL,
+        ],
+    )
+
+    filt = config.filter(cluster)
+
+    assert filt["feedforward"] == FIR_COEFFICIENTS
+    assert filt["exponential"] == [(EXPONENTIAL.amplitude, EXPONENTIAL.tau)]
+
+
+def test_opx1000_feedforward_empty_with_only_exponential():
+    """No FIR filter configured means no FIR stage at all, not an
+    approximation of the exponential correction."""
+    config = OpxOutputConfig(offset=0.0, filters=[EXPONENTIAL])
+
+    filt = config.filter("LF")
+
+    assert filt["feedforward"] == []
+    assert filt["exponential"] == [(EXPONENTIAL.amplitude, EXPONENTIAL.tau)]
+
+
+def test_opx1000_feedforward_no_filters():
+    config = OpxOutputConfig(offset=0.0, filters=[])
+
+    filt = config.filter("LF")
+
+    assert filt == {"feedforward": [], "exponential": []}
+
+
+def test_opx1_still_folds_exponential_into_feedforward():
+    """On the legacy OPX+ there is no dedicated ``exponential`` stage, so
+    folding the exponential's own FIR/IIR approximation into
+    ``feedforward``/``feedback`` remains the correct (and only) way to
+    apply it; this branch must be unaffected by the OPX1000 fix."""
+    config = OpxOutputConfig(
+        offset=0.0,
+        filters=[
+            FiniteImpulseResponseFilter(coefficients=FIR_COEFFICIENTS),
+            EXPONENTIAL,
+        ],
+    )
+
+    filt = config.filter("opx1")
+
+    assert filt["feedforward"] != FIR_COEFFICIENTS
+    assert len(filt["feedforward"]) == len(FIR_COEFFICIENTS) + 1
+    assert filt["feedback"] == [-EXPONENTIAL.feedback[1]]
+
+
+def test_filter_unsupported_cluster_raises():
+    config = OpxOutputConfig(offset=0.0)
+
+    with pytest.raises(NotImplementedError):
+        config.filter("unknown")


### PR DESCRIPTION
## Summary

- `OpxOutputConfig.filter()` computed the shared `"feedforward"` key by convolving *every* filter's `.feedforward` regardless of cluster, even though the `"exponential"` key (opx1000/LF/MW) already correctly restricts to `ExponentialFilter` members. Any `ExponentialFilter` therefore got double-applied on `opx1000`/`LF`/`MW`: once as an FIR approximation baked into `feedforward`, once via the native `exponential` IIR stage.
- Split `filter()` into `_opx1_filter()` and `_opx1000_filter()` with no shared feedforward computation (per @alecandido's suggestion in the issue thread, rather than a one-line patch inside the old `if`/`elif`):
  - `_opx1_filter()` keeps the original behavior unchanged — OPX+ has no native exponential stage, so folding `ExponentialFilter.feedforward` into the FIR convolution remains the only way to express it.
  - `_opx1000_filter()` excludes `ExponentialFilter` members from the FIR convolution, so `feedforward` only ever contains genuine FIR taps, matching what QuAM's own `generate_config()` produces.

Fixes #1547

## Testing note

**I do not have access to OPX1000/LF/MW hardware, so this is not validated against real output (oscilloscope/Chevron).** I've added `tests/instruments/qm/test_configs.py`, which is a pure unit test of `OpxOutputConfig.filter()` (no `qm` connection needed beyond `pytest.importorskip("qm")`, matching the existing `test_unrolling.py` convention). It checks:
- `opx1000`/`LF`/`MW`: `feedforward` contains only the FIR taps, unaffected by a coexisting `ExponentialFilter`; `exponential` still carries the amplitude/tau pair.
- Only an `ExponentialFilter` configured (no FIR filter): `feedforward` is empty rather than an approximation.
- `opx1` (legacy): unchanged — `ExponentialFilter` still folded into `feedforward`/`feedback`.
- Unsupported cluster still raises `NotImplementedError`.

I confirmed these tests fail against the pre-fix code (reproducing the 5-tap vs. 4-tap discrepancy from the issue) and pass against the fix. If someone with OPX1000/LF/MW bench access can confirm against a real trace, that would close the loop nicely.

## Test plan

- [x] `pytest tests/instruments/qm/test_configs.py` passes
- [x] `ruff check` / `ruff format --check` pass
- [ ] Hardware confirmation (oscilloscope or Chevron comparison) — not possible on my end, flagging for review

<!-- gk-ai-analysis-start:42c20fa9a211faa883215c3fbf9ec836c99359d8 -->
<!-- gk-ai-analysis-data:eyJzdW1tYXJ5IjoiU3BsaXQgT3B4T3V0cHV0Q29uZmlnLmZpbHRlcigpIGludG8gY2x1c3Rlci1zcGVjaWZpYyBtZXRob2RzIHRvIHByZXZlbnQgZG91YmxlLWFwcGx5aW5nIEV4cG9uZW50aWFsRmlsdGVycyBvbiBPUFgxMDAwL0xGL01XIGhhcmR3YXJlLiIsImtleUluc2lnaHRzIjpbeyJ0aXRsZSI6IlNlcGFyYXRpb24gb2YgT1BYMSBhbmQgT1BYMTAwMCBmaWx0ZXIgbG9naWMiLCJkZXNjcmlwdGlvbiI6IlRoZSBgZmlsdGVyKClgIG1ldGhvZCBub3cgZGVsZWdhdGVzIHRvIGBfb3B4MV9maWx0ZXIoKWAgb3IgYF9vcHgxMDAwX2ZpbHRlcigpYCBiYXNlZCBvbiB0aGUgY2x1c3RlciB0eXBlLCBpbnN0ZWFkIG9mIHRyeWluZyB0byBzaGFyZSB0aGUgYGZlZWRmb3J3YXJkYCBwcm9wZXJ0eSBjYWxjdWxhdGlvbi4iLCJzZXZlcml0eSI6Im1lZGl1bSIsImZpbGVQYXRoIjoic3JjL3FpYm9sYWIvX2NvcmUvaW5zdHJ1bWVudHMvcW0vY29tcG9uZW50cy9jb25maWdzLnB5IiwibGluZVN0YXJ0Ijo2Nn0seyJ0aXRsZSI6IkV4Y2x1ZGUgRXhwb25lbnRpYWxGaWx0ZXJzIGZyb20gT1BYMTAwMCBGSVIiLCJkZXNjcmlwdGlvbiI6IkZvciBPUFgxMDAwL0xGL01XIGNsdXN0ZXJzLCB0aGUgZmVlZGZvcndhcmQgc2VxdWVuY2UgaXMgY2FsY3VsYXRlZCBtYW51YWxseSBieSBjb252b2x2aW5nIG9ubHkgYEZpbml0ZUltcHVsc2VSZXNwb25zZUZpbHRlcmAgaW5zdGFuY2VzLiBUaGlzIHN0b3BzIGBFeHBvbmVudGlhbEZpbHRlcmAgZnJvbSBiZWluZyBhcHBsaWVkIHZpYSBGSVIgaW4gYWRkaXRpb24gdG8gdGhlIG5hdGl2ZSBgZXhwb25lbnRpYWxgIElJUiBzdGFnZS4iLCJzZXZlcml0eSI6Im1lZGl1bSIsImZpbGVQYXRoIjoic3JjL3FpYm9sYWIvX2NvcmUvaW5zdHJ1bWVudHMvcW0vY29tcG9uZW50cy9jb25maWdzLnB5IiwibGluZVN0YXJ0IjoxMDJ9XSwiaXNzdWVzIjpbXSwic3VnZ2VzdGlvbnMiOltdLCJzZWN1cml0eSI6W119 -->
<!-- gk-ai-analysis-end:42c20fa9a211faa883215c3fbf9ec836c99359d8 -->

<!-- gitkraken-review-badge-begin -->
---
<a href="https://gitkraken.dev/review/github/qiboteam/qibolab/pull/1548?source=pr_review_chip">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://gitkraken.dev/images/figures/gitkraken-review-badge-dark.svg">
    <img src="https://gitkraken.dev/images/figures/gitkraken-review-badge-light.svg" alt="Open with GitKraken">
  </picture>
</a>
<!-- gitkraken-review-badge-end -->