### PR TITLE
Fix batch_shots producing a zero-shot batch

### DIFF
--- a/src/qibolab/_core/instruments/qblox/utils.py
+++ b/src/qibolab/_core/instruments/qblox/utils.py
@@ -53,7 +53,7 @@ def batch_shots(
     acq_memory_shot = per_shot_memory(sequence, sweepers, options)
     max_shots = int(ACQUISITION_MEMORY // acq_memory_shot)
     nfull, remainder = np.divmod(options.nshots, max_shots)
-    return [max_shots] * int(nfull) + ([int(remainder)] if remainder else [])
+    return [max_shots] * int(nfull) + ([int(remainder)] if remainder == 0 else [])
 
 
 def concat_shots(

--- a/src/qibolab/_core/instruments/qblox/utils.py
+++ b/src/qibolab/_core/instruments/qblox/utils.py
@@ -53,7 +53,7 @@ def batch_shots(
     acq_memory_shot = per_shot_memory(sequence, sweepers, options)
     max_shots = int(ACQUISITION_MEMORY // acq_memory_shot)
     nfull, remainder = np.divmod(options.nshots, max_shots)
-    return [max_shots] * int(nfull) + [int(remainder)]
+    return [max_shots] * int(nfull) + ([int(remainder)] if remainder else [])
 
 
 def concat_shots(


### PR DESCRIPTION
When nshots is evenly divisible by max_shots, np.divmod returns a remainder of 0, which was appended as an empty batch. This caused an unnecessary execution loop iteration with 0 shots.

The remainder entry is now only appended when it is non-zero.

Found this issue using qwen3.8
