### PR TITLE
Extend Qblox compact cluster representation to TWPAs

### DIFF
--- a/src/qibolab/_core/instruments/qblox/platform.py
+++ b/src/qibolab/_core/instruments/qblox/platform.py
@@ -14,6 +14,8 @@ __all__ = ["Channels", "Twpa", "Twpas", "infer_los", "infer_mixers", "map_ports"
 
 Channels = dict[ChannelId, Channel]
 Twpas = dict[str, tuple[str, str | None]]
+SlotMap = dict[str | int, list[QubitId]]
+ClusterMap = dict[str, tuple[int, SlotMap]]
 
 
 class Twpa(Model):
@@ -35,43 +37,42 @@ def _chtype(mod: str, input: bool) -> tuple[str, type[Channel]]:
     raise ValueError
 
 
-def _port_channels(mod: str, port: int | str, slot: int) -> dict:
+def _port_path(port: int | str, slot: int) -> str:
+    port = f"o{port}" if isinstance(port, int) else port
+    return f"{slot}/{port}"
+
+
+def _port_channels(mod: str, port: int | str, slot: int) -> dict[str, Channel]:
     if isinstance(port, str) and port.startswith("io"):
         return {
             "probe": IqChannel(path=f"{slot}/o{port[2:]}"),
             "acquisition": AcquisitionChannel(path=f"{slot}/i{port[2:]}"),
         }
-    port = f"o{port}" if isinstance(port, int) else port
-    name, cls = _chtype(mod, port[0] == "i")
-    return {name: cls(path=f"{slot}/{port}")}
+    path = _port_path(port, slot)
+    name, cls = _chtype(mod, isinstance(port, str) and port[0] == "i")
+    return {name: cls(path=path)}
 
 
-def _port_path(port: int | str, slot: int) -> str:
-    if isinstance(port, str) and port.startswith("io"):
-        return f"{slot}/o{port[2:]}"
-    port = f"o{port}" if isinstance(port, int) else port
-    return f"{slot}/{port}"
-
-
-def _premap(cluster: dict) -> tuple[dict, Twpas]:
-    d = defaultdict(lambda: defaultdict(dict))
+def _premap(
+    cluster: ClusterMap,
+) -> tuple[dict[QubitId, dict[str, Channel]], Twpas]:
+    channels = defaultdict(lambda: defaultdict(dict))
     twpas: Twpas = {}
 
     for mod, props in cluster.items():
         slot = props[0]
-        for port, els in props[1].items():
-            els_list = els if isinstance(els, (list, tuple, set)) else [els]
-            for el in els_list:
+        for port, elements in props[1].items():
+            for el in elements:
                 if isinstance(el, Twpa):
                     twpas[el.name] = (_port_path(port, slot), el.mixer)
                 else:
-                    d[el] |= _port_channels(mod, port, slot)
+                    channels[el] |= _port_channels(mod, port, slot)
 
-    return d, twpas
+    return channels, twpas
 
 
 def map_ports(
-    cluster: dict, qubits: dict, couplers: dict | None = None
+    cluster: ClusterMap, qubits: dict, couplers: dict | None = None
 ) -> tuple[Channels, Twpas]:
     """Extract channels and TWPAs from compact representation.
 

--- a/src/qibolab/_core/instruments/qblox/platform.py
+++ b/src/qibolab/_core/instruments/qblox/platform.py
@@ -7,9 +7,20 @@ from qibolab._core.components.channels import (
     DcChannel,
     IqChannel,
 )
-from qibolab._core.identifier import QubitId
+from qibolab._core.identifier import ChannelId, QubitId
+from qibolab._core.serialize import Model
 
-__all__ = ["infer_los", "map_ports"]
+__all__ = ["Channels", "Twpa", "Twpas", "infer_los", "infer_mixers", "map_ports"]
+
+Channels = dict[ChannelId, Channel]
+Twpas = dict[str, tuple[str, str | None]]
+
+
+class Twpa(Model):
+    """TWPA pump configuration placeholder for port mapping."""
+
+    name: str
+    mixer: str | None = None
 
 
 def _chtype(mod: str, input: bool) -> tuple[str, type[Channel]]:
@@ -35,34 +46,49 @@ def _port_channels(mod: str, port: int | str, slot: int) -> dict:
     return {name: cls(path=f"{slot}/{port}")}
 
 
-def _premap(cluster: dict):
+def _port_path(port: int | str, slot: int) -> str:
+    if isinstance(port, str) and port.startswith("io"):
+        return f"{slot}/o{port[2:]}"
+    port = f"o{port}" if isinstance(port, int) else port
+    return f"{slot}/{port}"
+
+
+def _premap(cluster: dict) -> tuple[dict, Twpas]:
     d = defaultdict(lambda: defaultdict(dict))
+    twpas: Twpas = {}
 
     for mod, props in cluster.items():
         slot = props[0]
         for port, els in props[1].items():
-            for el in els:
-                d[el] |= _port_channels(mod, port, slot)
+            els_list = els if isinstance(els, (list, tuple, set)) else [els]
+            for el in els_list:
+                if isinstance(el, Twpa):
+                    twpas[el.name] = (_port_path(port, slot), el.mixer)
+                else:
+                    d[el] |= _port_channels(mod, port, slot)
 
-    return d
+    return d, twpas
 
 
-def map_ports(cluster: dict, qubits: dict, couplers: dict | None = None) -> dict:
-    """Extract channels from compact representation.
+def map_ports(
+    cluster: dict, qubits: dict, couplers: dict | None = None
+) -> tuple[Channels, Twpas]:
+    """Extract channels and TWPAs from compact representation.
 
     Conventions:
     - each item is a module
     - the first element of each value is the module's slot ID
-    - the second element is a map from ports to qubits
+    - the second element is a map from ports to qubits or :class:`Twpa` instances
         - ports
             - they are `i{n}` or `o{n}` for the inputs and outputs respectively
             - `io{n}` is also allowed, to signal that both are connected (cater for the specific
               case of the QRM_RF where there are only one port of each type)
             - if it's just an integer, it is intended to be an output (equivalent to `o{n}`)
         - values
-            - list of element names
-            - they are `q{name}` or `c{name}` for qubits and couplers respectively
+            - list of element names or :class:`Twpa` instances
+            - element names are `q{name}` or `c{name}` for qubits and couplers respectively
             - multiple elements are allowed, for multiplexed ports
+            - :class:`Twpa` elements are collected into the returned :data:`Twpas` dictionary
 
     .. note::
 
@@ -76,9 +102,9 @@ def map_ports(cluster: dict, qubits: dict, couplers: dict | None = None) -> dict
     if couplers is None:
         couplers = {}
 
-    premap = _premap(cluster)
+    premap, twpas = _premap(cluster)
 
-    channels = {}
+    channels: Channels = {}
     for name, el in (qubits | couplers).items():
         for chname, ch in premap[name].items():
             channels[getattr(el, chname)] = ch
@@ -88,7 +114,7 @@ def map_ports(cluster: dict, qubits: dict, couplers: dict | None = None) -> dict
             )
         except KeyError:
             pass
-    return channels
+    return channels, twpas
 
 
 _PORT = re.compile(r"i?o?(.*)")
@@ -122,7 +148,8 @@ def _infer_outputs(cluster: dict, suffix: str) -> dict[tuple[QubitId, bool], str
         for mod, specs in cluster.items()
         if "_rf" in mod
         for port, qs in specs[1].items()
-        for q in qs
+        for q in (qs if isinstance(qs, (list, tuple, set)) else [qs])
+        if not isinstance(q, Twpa)
     }
 
 

--- a/tests/qblox/test_twpa_cw.py
+++ b/tests/qblox/test_twpa_cw.py
@@ -303,3 +303,92 @@ def test_cluster_twpa_channels_by_module():
     assert c._los["twpa2"] == "twpa2"
     assert "twpa" not in c._mixers
     assert c._mixers["twpa2"] == "mixer2"
+
+
+# ---------------------------------------------------------------------------
+# `map_ports` and `Twpa` helpers
+# ---------------------------------------------------------------------------
+
+
+def test_map_ports_with_twpa():
+    from qibolab._core.instruments.qblox.platform import Twpa, map_ports
+    from qibolab._core.qubits import Qubit
+
+    cluster = {
+        "qcm_rf0": (
+            8,
+            {
+                "o1": [Twpa(name="twpa")],
+                "o2": ["q0"],
+            },
+        ),
+        "qcm_rf1": (
+            7,
+            {
+                1: [Twpa(name="twpa2", mixer="mixer2")],
+                2: ["q1"],
+            },
+        ),
+        "qrm_rf0": (
+            6,
+            {
+                "io1": ["q0", "q1"],
+            },
+        ),
+    }
+
+    qubits = {
+        "q0": Qubit(drive="0/drive", probe="0/probe", acquisition="0/acquisition"),
+        "q1": Qubit(drive="1/drive", probe="1/probe", acquisition="1/acquisition"),
+    }
+
+    channels, twpas = map_ports(cluster, qubits)
+
+    # Channels checks
+    assert "0/drive" in channels
+    assert channels["0/drive"].path == "8/o2"
+    assert "1/drive" in channels
+    assert channels["1/drive"].path == "7/o2"
+    assert "0/probe" in channels
+    assert channels["0/probe"].path == "6/o1"
+    assert "0/acquisition" in channels
+    assert channels["0/acquisition"].path == "6/i1"
+    assert channels["0/acquisition"].probe == "0/probe"
+
+    # Twpas checks
+    assert twpas == {
+        "twpa": ("8/o1", None),
+        "twpa2": ("7/o1", "mixer2"),
+    }
+
+
+def test_infer_los_and_mixers_with_twpa():
+    from qibolab._core.instruments.qblox.platform import Twpa, infer_los, infer_mixers
+
+    cluster = {
+        "qcm_rf0": (
+            8,
+            {
+                "o1": [Twpa(name="twpa")],
+                "o2": ["q0"],
+            },
+        ),
+        "qrm_rf0": (
+            6,
+            {
+                "io1": ["q0"],
+            },
+        ),
+    }
+
+    los = infer_los(cluster)
+    mixers = infer_mixers(cluster)
+
+    assert los == {
+        ("q0", False): "qcm_rf0/o2/lo",
+        ("q0", True): "qrm_rf0/o1/lo",
+    }
+    assert mixers == {
+        ("q0", False): "qcm_rf0/o2/mixer",
+        ("q0", True): "qrm_rf0/o1/mixer",
+    }


### PR DESCRIPTION
Closes #1564

- [ ] extend syntax to TWPAs
- [ ] wrap also `infer_los()` and `infer_mixers()` in a single function
  - package them in an internal structure
- [ ] use the wrapper to define an alternative `Cluster()` constructor
  - if LOs, mixers, and TWPAs are all internal, the compact representation plus a transmission lines mapping (connecting them to the related TWPAs) should contain enough information to generate the entire platform for https://github.com/qiboteam/qibolab_platforms_qrc/tree/main/qw5q_platinum