### PR TITLE
remove recommonmark

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -4,12 +4,6 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
-# -- Path setup --------------------------------------------------------------
-
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-#
 from pathlib import Path
 
 from sphinx.ext import apidoc

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -12,7 +12,6 @@
 #
 from pathlib import Path
 
-from recommonmark.transform import AutoStructify
 from sphinx.ext import apidoc
 
 import qibolab
@@ -44,7 +43,6 @@ extensions = [
     "sphinx.ext.coverage",
     "sphinx.ext.napoleon",
     "sphinx.ext.intersphinx",
-    "recommonmark",
     "sphinx_copybutton",
     "sphinx.ext.todo",
     "sphinx.ext.viewcode",
@@ -114,8 +112,6 @@ intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 autodoc_member_order = "bysource"
 
 
-# Adapted this from
-# https://github.com/readthedocs/recommonmark/blob/ddd56e7717e9745f11300059e4268e204138a6b1/docs/conf.py
 # app setup hook
 
 
@@ -128,8 +124,6 @@ def run_apidoc(_):
 
 
 def setup(app):
-    app.add_config_value("recommonmark_config", {"enable_eval_rst": True}, True)
-    app.add_transform(AutoStructify)
     app.add_css_file("css/style.css")
 
     app.connect("builder-inited", run_apidoc)

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -24,8 +24,6 @@ author = "The Qibo team"
 
 release = qibolab.__version__
 
-github_username = "qiboteam"
-github_repository = "qibolab"
 
 # -- General configuration ---------------------------------------------------
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -27,8 +27,6 @@ release = qibolab.__version__
 
 # -- General configuration ---------------------------------------------------
 
-# https://stackoverflow.com/questions/56336234/build-fail-sphinx-error-contents-rst-not-found
-# master_doc = "index"
 
 autodoc_mock_imports = ["icarusq_rfsoc_driver", "keysight", "qm", "qibosoq"]
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -10,7 +10,6 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-import os
 from pathlib import Path
 
 from recommonmark.transform import AutoStructify
@@ -109,11 +108,6 @@ html_static_path = ["_static"]
 
 intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 
-
-# -- Doctest ------------------------------------------------------------------
-#
-
-doctest_path = [os.path.abspath("../examples")]
 
 # -- Autodoc ------------------------------------------------------------------
 #

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -48,8 +48,6 @@ extensions = [
 ]
 bibtex_bibfiles = ["refs.bib"]
 
-# Add any paths that contain templates here, relative to this directory.
-templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/poetry.lock
+++ b/poetry.lock
@@ -707,21 +707,6 @@ files = [
 test = ["pytest"]
 
 [[package]]
-name = "commonmark"
-version = "0.9.2"
-description = "Python parser for the CommonMark Markdown spec"
-optional = false
-python-versions = "*"
-groups = ["docs"]
-files = [
-    {file = "commonmark-0.9.2-py2.py3-none-any.whl", hash = "sha256:cc7dfaea4557c79e32ce1ad36727185ea8cfe9c7e797cf79297c5cdffe6c7f5a"},
-    {file = "commonmark-0.9.2.tar.gz", hash = "sha256:194d693e0c1ac49e83c26455bdeeb2483235e6280313c58b11d0b71c19f58ed1"},
-]
-
-[package.extras]
-test = ["flake8 (==3.9.2)", "hypothesis (==4.24.4)"]
-
-[[package]]
 name = "contourpy"
 version = "1.3.3"
 description = "Python library for calculating contours of 2D quadrilateral grids"
@@ -4015,23 +4000,6 @@ semidefinite = ["cvxopt", "cvxpy (>=1.3)"]
 tests = ["pytest (>=7.2)", "pytest-rerunfailures"]
 
 [[package]]
-name = "recommonmark"
-version = "0.7.1"
-description = "A docutils-compatibility bridge to CommonMark, enabling you to write CommonMark inside of Docutils & Sphinx projects."
-optional = false
-python-versions = "*"
-groups = ["docs"]
-files = [
-    {file = "recommonmark-0.7.1-py2.py3-none-any.whl", hash = "sha256:1b1db69af0231efce3fa21b94ff627ea33dee7079a01dd0a7f8482c3da148b3f"},
-    {file = "recommonmark-0.7.1.tar.gz", hash = "sha256:bdb4db649f2222dcd8d2d844f0006b958d627f732415d399791ee436a3686d67"},
-]
-
-[package.dependencies]
-commonmark = ">=0.8.1"
-docutils = ">=0.11"
-sphinx = ">=1.3.1"
-
-[[package]]
 name = "referencing"
 version = "0.37.0"
 description = "JSON Referencing + Python"
@@ -5399,4 +5367,4 @@ qrng = ["pyserial"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.14"
-content-hash = "af19048aae4437edc1ffa53c2c4fe1e96bed86168020cd36ea4c35c6566d1d18"
+content-hash = "b489971a8916f601cc6f993e14cd342cf8f45ed292afb24703f1b67b49289ad9"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2132,22 +2132,6 @@ lingua = ["lingua"]
 testing = ["pytest"]
 
 [[package]]
-name = "markdown"
-version = "3.10.2"
-description = "Python implementation of John Gruber's Markdown."
-optional = false
-python-versions = ">=3.10"
-groups = ["docs"]
-files = [
-    {file = "markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36"},
-    {file = "markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950"},
-]
-
-[package.extras]
-docs = ["mdx_gh_links (>=0.2)", "mkdocs (>=1.6)", "mkdocs-gen-files", "mkdocs-literate-nav", "mkdocs-nature (>=0.6)", "mkdocs-section-index", "mkdocstrings[python] (>=0.28.3)"]
-testing = ["coverage", "pyyaml"]
-
-[[package]]
 name = "markupsafe"
 version = "3.0.3"
 description = "Safely add untrusted strings to HTML/XML markup."
@@ -4438,21 +4422,6 @@ code-style = ["pre-commit (==2.12.1)"]
 rtd = ["ipython", "myst-nb", "sphinx", "sphinx-book-theme", "sphinx-examples"]
 
 [[package]]
-name = "sphinx-markdown-tables"
-version = "0.0.17"
-description = "A Sphinx extension for rendering tables written in markdown"
-optional = false
-python-versions = "*"
-groups = ["docs"]
-files = [
-    {file = "sphinx-markdown-tables-0.0.17.tar.gz", hash = "sha256:6bc6d3d400eaccfeebd288446bc08dd83083367c58b85d40fe6c12d77ef592f1"},
-    {file = "sphinx_markdown_tables-0.0.17-py3-none-any.whl", hash = "sha256:2bd0c30779653e4dd120300cbd9ca412c480738cc2241f6dea477a883f299e04"},
-]
-
-[package.dependencies]
-markdown = ">=3.4"
-
-[[package]]
 name = "sphinxcontrib-applehelp"
 version = "2.0.0"
 description = "sphinxcontrib-applehelp is a Sphinx extension which outputs Apple help books"
@@ -5367,4 +5336,4 @@ qrng = ["pyserial"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.14"
-content-hash = "b489971a8916f601cc6f993e14cd342cf8f45ed292afb24703f1b67b49289ad9"
+content-hash = "4fb0b4531fa14d059a01acc51e4b0bc9fabeda600264a8f6f9013fe5e231816d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ optional = true
 [tool.poetry.group.docs.dependencies]
 sphinx = "^8.2"
 furo = "^2025.7.19"
-recommonmark = "^0.7.1"
 sphinxcontrib-bibtex = "^2.5.0"
 sphinx-markdown-tables = "^0.0.17"
 nbsphinx = "^0.9.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ optional = true
 sphinx = "^8.2"
 furo = "^2025.7.19"
 sphinxcontrib-bibtex = "^2.5.0"
-sphinx-markdown-tables = "^0.0.17"
 nbsphinx = "^0.9.1"
 ipython = "^8.12.0"
 sphinx-copybutton = "^0.5.1"


### PR DESCRIPTION
There are no longer .md in the docs, so we don't need recommonmark (it's also not maintained so we needed to get rid of it anyway).