### PR TITLE
Support arbitrary power for TWPA

### DIFF
--- a/src/qibolab/_core/instruments/qblox/cluster.py
+++ b/src/qibolab/_core/instruments/qblox/cluster.py
@@ -220,6 +220,7 @@ class Cluster(Controller):
                     self.sampling_rate,
                     merged_vzs=not phase_sweeper_present,
                     twpas=self.twpas,
+                    configs=configs,
                 )
 
                 for channelid, seq in sequences_.items():

--- a/src/qibolab/_core/instruments/qblox/config/port.py
+++ b/src/qibolab/_core/instruments/qblox/config/port.py
@@ -18,6 +18,7 @@ from qibolab._core.components.filters import (
 from qibolab._core.serialize import Model
 
 from ..identifiers import SlotId
+from ..twpa import twpa_attenuation_and_offset
 
 __all__ = []
 
@@ -227,7 +228,8 @@ class PortConfig(BaseModel):
         self.lo_freq = int(lo.frequency)
 
     def att_(self, lo: OscillatorConfig) -> None:
-        self.att = -int(lo.power)
+        att, _ = twpa_attenuation_and_offset(lo.power)
+        self.att = att
 
     def mixer(self, mixer: IqMixerConfig) -> None:
         self.offset_path0 = mixer.offset_i

--- a/src/qibolab/_core/instruments/qblox/config/sequencer.py
+++ b/src/qibolab/_core/instruments/qblox/config/sequencer.py
@@ -19,6 +19,7 @@ from qibolab._core.serialize import Model
 
 from ..q1asm.ast_ import Acquire, Line
 from ..sequence import Q1Sequence
+from ..twpa import twpa_attenuation_and_offset
 from .port import PortAddress
 
 __all__ = []
@@ -87,12 +88,19 @@ class SequencerConfig(Model):
         # pump TWPAs
         is_cw = sequence is not None and sequence.is_cw
 
+        offset = 0.0
+        if is_cw:
+            if isinstance(config, OscillatorConfig):
+                _, offset = twpa_attenuation_and_offset(config.power)
+            else:
+                offset = 1.0
+
         # conditional configurations
         cfg = cls(
             # connect to physical address
             address=address.local_address,
             # TODO: mixer calibration not yet propagated
-            offset_awg_path0=1.0 if is_cw else 0.0,
+            offset_awg_path0=offset,
             offset_awg_path1=0.0,
             gain_awg_path0=1.0 if is_cw else None,
             gain_awg_path1=1.0 if is_cw else None,

--- a/src/qibolab/_core/instruments/qblox/sequence/sequence.py
+++ b/src/qibolab/_core/instruments/qblox/sequence/sequence.py
@@ -4,6 +4,7 @@ from typing import Annotated
 import numpy as np
 from pydantic import PlainSerializer, PlainValidator
 
+from qibolab._core.components import Configs, OscillatorConfig
 from qibolab._core.execution_parameters import ExecutionParameters
 from qibolab._core.identifier import ChannelId
 from qibolab._core.pulses import Align, Pulse, PulseLike, Readout
@@ -18,6 +19,7 @@ from qibolab._core.sweeper import (
 
 from ..q1asm import Program, parse
 from ..q1asm.ast_ import Line, Stop
+from ..twpa import twpa_attenuation_and_offset
 from .acquisition import Acquisitions, MeasureId, Weight, Weights, acquisitions
 from .program import program, twpa_program
 from .waveforms import Waveform, WaveformIndex, waveforms
@@ -123,9 +125,22 @@ class Q1Sequence(Model):
         sampling_rate: float,
         channel: ChannelId,
         duration: float,
+        offset: float = 1.0,
     ) -> "Q1Sequence":
         duration_samples = int(duration * sampling_rate)
         _, sweepers_ = _apply_sampling_rate([], sweepers, sampling_rate)
+        if offset != 1.0:
+            sweepers_ = [
+                [
+                    (s * offset)
+                    if s.parameter is Parameter.offset
+                    and s.channels is not None
+                    and channel in s.channels
+                    else s
+                    for s in parsweep
+                ]
+                for parsweep in sweepers_
+            ]
         return cls(
             waveforms={},
             weights={},
@@ -192,6 +207,16 @@ def _effective_channels(ch: ChannelId, seq: Iterable[PulseLike]) -> set[ChannelI
     )
 
 
+def _twpa_offset(channel: ChannelId, configs: Configs | None) -> float:
+    if configs is None or channel not in configs:
+        return 1.0
+    cfg = configs[channel]
+    if not isinstance(cfg, OscillatorConfig):
+        return 1.0
+    _, offset = twpa_attenuation_and_offset(cfg.power)
+    return offset
+
+
 def compile(
     sequence: PulseSequence,
     sweepers: list[ParallelSweepers],
@@ -199,6 +224,7 @@ def compile(
     sampling_rate: float,
     merged_vzs: bool,
     twpas: Collection[ChannelId] = (),
+    configs: Configs | None = None,
 ) -> dict[ChannelId, Q1Sequence]:
     duration = sequence.duration
     sweeper_channels = {ch: [] for ch in swept_channels(sweepers)}
@@ -224,6 +250,7 @@ def compile(
                 sampling_rate,
                 ch,
                 duration,
+                offset=_twpa_offset(ch, configs),
             )
         )
         for ch in twpas

--- a/src/qibolab/_core/instruments/qblox/twpa.py
+++ b/src/qibolab/_core/instruments/qblox/twpa.py
@@ -1,0 +1,21 @@
+"""TWPA utility functions for Qblox instruments."""
+
+
+def twpa_attenuation_and_offset(power: float) -> tuple[int, float]:
+    """Calculate hardware port attenuation (in dB) and fine-tuning offset factor.
+
+    Follows standard Qibolab convention where target attenuation = -power (power <= 0).
+    The port attenuation is the largest even integer <= target attenuation,
+    ensuring offset <= 1.0.
+
+    Args:
+        power: Power in dBm (conventionally <= 0).
+
+    Returns:
+        tuple[int, float]: (attenuation_in_dB, fine_tuning_offset)
+    """
+    target_att = -power if power <= 0 else power
+    att = int(target_att // 2) * 2
+    delta = target_att - att
+    offset = float(10.0 ** (-delta / 20.0))
+    return att, offset

--- a/src/qibolab/_core/sweeper.py
+++ b/src/qibolab/_core/sweeper.py
@@ -177,7 +177,13 @@ class Sweeper(Model):
         """
         return self.model_copy(
             update=(
-                {"range": (self.range[0] * value, self.range[1] * value, self.range[2])}
+                {
+                    "range": (
+                        self.range[0] * value,
+                        self.range[1] * value,
+                        self.range[2] * value,
+                    )
+                }
                 if self.range is not None
                 else {}
             )

--- a/tests/qblox/test_twpa_cw.py
+++ b/tests/qblox/test_twpa_cw.py
@@ -6,7 +6,7 @@ import pytest
 from qibolab._core.components import IqChannel, OscillatorConfig
 from qibolab._core.execution_parameters import AcquisitionType, ExecutionParameters
 from qibolab._core.instruments.qblox.cluster import Cluster
-from qibolab._core.instruments.qblox.config.port import PortAddress
+from qibolab._core.instruments.qblox.config.port import PortAddress, PortConfig
 from qibolab._core.instruments.qblox.config.sequencer import SequencerConfig
 from qibolab._core.instruments.qblox.q1asm.ast_ import (
     Loop,
@@ -18,6 +18,7 @@ from qibolab._core.instruments.qblox.q1asm.ast_ import (
     WaitSync,
 )
 from qibolab._core.instruments.qblox.sequence import Q1Sequence, compile
+from qibolab._core.instruments.qblox.twpa import twpa_attenuation_and_offset
 from qibolab._core.sequence import PulseSequence
 from qibolab._core.sweeper import Parameter, Sweeper
 
@@ -303,3 +304,157 @@ def test_cluster_twpa_channels_by_module():
     assert c._los["twpa2"] == "twpa2"
     assert "twpa" not in c._mixers
     assert c._mixers["twpa2"] == "mixer2"
+
+
+# ---------------------------------------------------------------------------
+# TWPA Attenuation and Offset Fine-tuning
+# ---------------------------------------------------------------------------
+
+
+def test_twpa_attenuation_and_offset():
+    # Power = 0 dBm (0 dB att) -> (0, 1.0)
+    assert twpa_attenuation_and_offset(0.0) == (0, 1.0)
+
+    # Even power (e.g. -10 dBm -> 10 dB att) -> (10, 1.0)
+    assert twpa_attenuation_and_offset(-10.0) == (10, 1.0)
+    assert twpa_attenuation_and_offset(-4.0) == (4, 1.0)
+
+    # Odd / arbitrary power (e.g. -5 dBm -> 5 dB target att):
+    # Port attenuation is 4 dB, offset fine-tunes 1 dB
+    att, offset = twpa_attenuation_and_offset(-5.0)
+    assert att == 4
+    assert np.isclose(offset, 10.0 ** (-1.0 / 20.0))
+
+    # Fractional power (e.g. -11.5 dBm -> 11.5 dB target att):
+    # Port attenuation is 10 dB, offset fine-tunes 1.5 dB
+    att, offset = twpa_attenuation_and_offset(-11.5)
+    assert att == 10
+    assert np.isclose(offset, 10.0 ** (-1.5 / 20.0))
+
+    # Backwards-compatibility with positive power values
+    assert twpa_attenuation_and_offset(10.0) == (10, 1.0)
+    att, offset = twpa_attenuation_and_offset(5.0)
+    assert att == 4
+    assert np.isclose(offset, 10.0 ** (-1.0 / 20.0))
+
+
+def test_port_config_twpa_attenuation():
+    ch = IqChannel(path="8/o1")
+    p1 = PortConfig.build(
+        channel=ch,
+        config=OscillatorConfig(frequency=6.5e9, power=-10.0),
+        in_=False,
+        out=True,
+        lo=OscillatorConfig(frequency=6.5e9, power=-10.0),
+        mixer=None,
+    )
+    assert p1.att == 10
+
+    p2 = PortConfig.build(
+        channel=ch,
+        config=OscillatorConfig(frequency=6.5e9, power=-5.0),
+        in_=False,
+        out=True,
+        lo=OscillatorConfig(frequency=6.5e9, power=-5.0),
+        mixer=None,
+    )
+    assert p2.att == 4
+
+    p3 = PortConfig.build(
+        channel=ch,
+        config=OscillatorConfig(frequency=6.5e9, power=-11.5),
+        in_=False,
+        out=True,
+        lo=OscillatorConfig(frequency=6.5e9, power=-11.5),
+        mixer=None,
+    )
+    assert p3.att == 10
+
+
+def test_sequencer_config_build_twpa_arbitrary_power_cw():
+    c = Cluster(
+        address="addr",
+        name="my_cluster",
+        twpas={"twpa": ("8/o1", None)},
+    )
+    address = PortAddress.from_path("8/o1")
+    configs = {
+        "twpa": OscillatorConfig(frequency=6.5e9, power=-5.0),
+    }
+
+    seq = Q1Sequence.cw()
+    cfg = SequencerConfig.build(
+        address=address,
+        channel_id="twpa",
+        channels=c.all_channels,
+        configs=configs,
+        acquisition=AcquisitionType.INTEGRATION,
+        rf=True,
+        sequence=seq,
+    )
+
+    assert cfg.sync_en is False
+    assert cfg.cont_mode_en_awg_path0 is True
+    assert cfg.cont_mode_en_awg_path1 is True
+    expected_offset = 10.0 ** (-1.0 / 20.0)
+    assert np.isclose(cfg.offset_awg_path0, expected_offset)
+
+
+def test_q1sequence_from_twpa_offset_swept_scaled():
+    options = ExecutionParameters(nshots=50, relaxation_time=100_000)
+    sweeper = Sweeper(
+        parameter=Parameter.offset,
+        values=np.array([0.1, 0.2, 0.3]),
+        channels=["twpa_ch"],
+    )
+    offset_scale = 10.0 ** (-1.0 / 20.0)
+    seq = Q1Sequence.from_twpa(
+        options=options,
+        sweepers=[[sweeper]],
+        sampling_rate=1.0,
+        channel="twpa_ch",
+        duration=500.0,
+        offset=offset_scale,
+    )
+
+    from qibolab._core.instruments.qblox.q1asm.ast_ import Move
+    from qibolab._core.instruments.qblox.sequence.asm import convert
+
+    instructions = [line.instruction for line in seq.program.elements]
+    expected_start = int(convert(0.1 * offset_scale, Parameter.offset))
+    moves = [ins for ins in instructions if isinstance(ins, Move)]
+    assert any(ins.source == expected_start for ins in moves)
+
+
+def test_compile_twpa_offset_swept_with_configs():
+    ps = PulseSequence()
+    options = ExecutionParameters(nshots=10, relaxation_time=1000)
+    sweeper = Sweeper(
+        parameter=Parameter.offset,
+        values=np.array([0.1, 0.2]),
+        channels=["twpa"],
+    )
+    configs = {
+        "twpa": OscillatorConfig(frequency=6.5e9, power=-5.0),
+    }
+    seqs = compile(
+        sequence=ps,
+        sweepers=[[sweeper]],
+        options=options,
+        sampling_rate=1.0,
+        merged_vzs=True,
+        twpas={"twpa": ("8/o1", None)},
+        configs=configs,
+    )
+    assert "twpa" in seqs
+    seq = seqs["twpa"]
+    assert seq.is_cw is False
+
+    from qibolab._core.instruments.qblox.q1asm.ast_ import Move
+    from qibolab._core.instruments.qblox.sequence.asm import convert
+
+    offset_scale = 10.0 ** (-1.0 / 20.0)
+    expected_start = int(convert(0.1 * offset_scale, Parameter.offset))
+    instructions = [line.instruction for line in seq.program.elements]
+    moves = [ins for ins in instructions if isinstance(ins, Move)]
+    assert any(ins.source == expected_start for ins in moves)


### PR DESCRIPTION
- Compute port attenuation and fine-tuning offset factor in twpa_attenuation_and_offset.
- Apply hardware port attenuation using largest valid even step <= target attenuation.
- Scale offset_awg_path0 from default 1.0 in SequencerConfig for CW mode.
- Scale swept offset values in Q1Sequence.from_twpa and compile for swept mode.
- Fix Sweeper.__mul__ to also scale step size in range.
- Add unit tests for fine-tuning offset and attenuation calculations.