### PR TITLE
qubits and couplers ids as input for create dummy hardware and platform

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -59,6 +59,7 @@ Contents
     main-documentation/drivers
     main-documentation/compiler
     main-documentation/circuits
+    main-documentation/emulator
 
 .. toctree::
     :maxdepth: 2

--- a/src/qibolab/_core/dummy/__init__.py
+++ b/src/qibolab/_core/dummy/__init__.py
@@ -1,3 +1,3 @@
-from .platform import create_dummy
+from .platform import create_dummy_platform
 
-__all__ = ["create_dummy"]
+__all__ = ["create_dummy_platform"]

--- a/src/qibolab/_core/dummy/platform.py
+++ b/src/qibolab/_core/dummy/platform.py
@@ -8,13 +8,21 @@ from qibolab._core.qubits import Qubit
 FOLDER = pathlib.Path(__file__).parent
 
 
-def create_dummy_hardware() -> Hardware:
+def create_dummy_hardware(
+    qubits_set: list | None = None, couplers_set: list | None = None
+) -> Hardware:
     """Create dummy hardware configuration based on the dummy instrument."""
     qubits = {}
     channels = {}
     # attach the channels
     pump_name = "twpa_pump"
-    for q in range(5):
+
+    if qubits_set is None:
+        qubits_set = list(range(5))
+    if couplers_set is None:
+        couplers_set = list(range(5))
+
+    for q in qubits_set:
         drive12 = f"{q}/drive12"
         qubits[q] = qubit = Qubit.default(q, drive_extra={(1, 2): drive12})
         channels |= {
@@ -28,7 +36,7 @@ def create_dummy_hardware() -> Hardware:
         }
 
     couplers = {}
-    for c in (0, 1, 3, 4):
+    for c in couplers_set:
         couplers[c] = coupler = Qubit(flux=f"coupler_{c}/flux")
         channels |= {coupler.flux: DcChannel()}
 
@@ -41,7 +49,9 @@ def create_dummy_hardware() -> Hardware:
     return Hardware(instruments=instruments, qubits=qubits, couplers=couplers)
 
 
-def create_dummy() -> Platform:
+def create_dummy_platform(
+    qubits_set: list | None = None, couplers_set: list | None = None
+) -> Platform:
     """Create a dummy platform using the dummy instrument."""
-    hardware = create_dummy_hardware()
+    hardware = create_dummy_hardware(qubits_set=qubits_set, couplers_set=couplers_set)
     return Platform.load(path=FOLDER, **vars(hardware))

--- a/src/qibolab/_core/dummy/platform.py
+++ b/src/qibolab/_core/dummy/platform.py
@@ -20,7 +20,7 @@ def create_dummy_hardware(
     if qubits_set is None:
         qubits_set = list(range(5))
     if couplers_set is None:
-        couplers_set = list(range(5))
+        couplers_set = [0, 1, 3, 4]
 
     for q in qubits_set:
         drive12 = f"{q}/drive12"

--- a/src/qibolab/_core/platform/load.py
+++ b/src/qibolab/_core/platform/load.py
@@ -117,9 +117,9 @@ def create_platform(name: str) -> Platform:
         The plaform class.
     """
     if name == "dummy":
-        from qibolab._core.dummy import create_dummy
+        from qibolab._core.dummy import create_dummy_platform
 
-        return create_dummy()
+        return create_dummy_platform()
     path = _search(name, _platforms_paths())
 
     hardware = _load_platform(path)

--- a/src/qibolab/_core/platform/platform.py
+++ b/src/qibolab/_core/platform/platform.py
@@ -227,9 +227,9 @@ class Platform:
 
                 import numpy as np
                 from qibolab import Parameter, PulseSequence, Sweeper
-                from qibolab.instruments.dummy import create_dummy
+                from qibolab.platform import create_dummy_platform
 
-                platform = create_dummy()
+                platform = create_dummy_platform()
                 qubit = platform.qubits[0]
                 natives = platform.natives.single_qubit[0]
                 sequence = natives.MZ.create_sequence()

--- a/src/qibolab/_core/sweeper.py
+++ b/src/qibolab/_core/sweeper.py
@@ -61,7 +61,7 @@ class Sweeper(Model):
 
             import numpy as np
             from qibolab import Parameter, PulseSequence, Sweeper
-            from qibolab.instruments.dummy import create_dummy_platform
+            from qibolab.platform import create_dummy_platform
 
             platform = create_dummy_platform()
             qubit = platform.qubits[0]

--- a/src/qibolab/_core/sweeper.py
+++ b/src/qibolab/_core/sweeper.py
@@ -61,9 +61,9 @@ class Sweeper(Model):
 
             import numpy as np
             from qibolab import Parameter, PulseSequence, Sweeper
-            from qibolab.instruments.dummy import create_dummy
+            from qibolab.instruments.dummy import create_dummy_platform
 
-            platform = create_dummy()
+            platform = create_dummy_platform()
             qubit = platform.qubits[0]
             natives = platform.natives.single_qubit[0]
             sequence = natives.MZ.create_sequence()

--- a/src/qibolab/platform.py
+++ b/src/qibolab/platform.py
@@ -1,4 +1,4 @@
-from qibolab._core.dummy.platform import create_dummy
+from qibolab._core.dummy.platform import create_dummy_platform
 from qibolab._core.platform.components import Hardware
 from qibolab._core.platform.load import (
     PLATFORM,
@@ -15,7 +15,7 @@ __all__ = [
     "PLATFORMS_PATH",
     "Hardware",
     "Platform",
-    "create_dummy",
+    "create_dummy_platform",
     "create_platform",
     "initialize_parameters",
     "load_hardware",

--- a/src/qibolab/platform.py
+++ b/src/qibolab/platform.py
@@ -10,11 +10,14 @@ from qibolab._core.platform.load import (
 from qibolab._core.platform.parameters import initialize_parameters, reset_parameters
 from qibolab._core.platform.platform import Platform
 
+create_dummy = create_dummy_platform  # deprecated alias, remove in next release
+
 __all__ = [
     "PLATFORM",
     "PLATFORMS_PATH",
     "Hardware",
     "Platform",
+    "create_dummy",
     "create_dummy_platform",
     "create_platform",
     "initialize_parameters",

--- a/tests/platform/test_platform.py
+++ b/tests/platform/test_platform.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 
 from qibolab._core.components import AcquisitionConfig, IqConfig, OscillatorConfig
-from qibolab._core.dummy import create_dummy
+from qibolab._core.dummy import create_dummy_platform
 from qibolab._core.dummy.platform import FOLDER as DUMMY_FOLDER
 from qibolab._core.native import SingleQubitNatives, TwoQubitNatives
 from qibolab._core.parameters import NativeGates, Parameters, update_configs
@@ -133,7 +133,7 @@ def test_dump_parameters_with_updates(platform: Platform, tmp_path: Path):
 def test_kernels(tmp_path: Path):
     """Test dumping and loading of `Kernels`."""
 
-    platform = create_dummy()
+    platform = create_dummy_platform()
     for name, config in platform.parameters.configs.items():
         if isinstance(config, AcquisitionConfig):
             platform.parameters.configs[name] = replace(
@@ -157,7 +157,7 @@ def test_kernels(tmp_path: Path):
 def test_dump_platform(tmp_path):
     """Test platform dump and loading parameters and kernels."""
 
-    platform = create_dummy()
+    platform = create_dummy_platform()
 
     platform.dump(tmp_path)
 


### PR DESCRIPTION
also renaming `create_dummy()` as `create_dummy_platform()`
This small PR is needed for [Qibocal #1624](https://github.com/qiboteam/qibocal/pull/1624).

Checklist:
- [ ] Reviewers confirm new code works as expected.
- [ ] Tests are passing.
- [ ] Coverage does not decrease.
- [ ] Documentation is updated.
